### PR TITLE
Added default Size for inserted Images

### DIFF
--- a/summernote.js
+++ b/summernote.js
@@ -1062,7 +1062,6 @@
       $.each(files, function(idx, file) {
         var fileReader = new FileReader;
         fileReader.onload = function(event) {
-          console.log(editor.insertImage);
           editor.insertImage(welEditable, event.target.result); // sURL
         };
         fileReader.readAsDataURL(file);


### PR DESCRIPTION
Currently if you add a _big_ image the resize handle will be most time very hard to use.

This modification inserts an image manually rather than using the execCommands to have more control over the added node.

The Credits for the logic goes to: 
[http://stackoverflow.com/a/2213514](http://stackoverflow.com/a/2213514)
