### PR TITLE
Update color button - clearing color/background-color property

### DIFF
--- a/summernote.js
+++ b/summernote.js
@@ -1364,10 +1364,12 @@
         '<li>' +
         '<div class="btn-group">' +
         '<div class="note-palette-title">BackColor</div>' +
+        '<div class="note-color-reset" data-event="backColor" data-value="inherit" title="Transparent">Set transparent</div>' +
         '<div class="note-color-palette" data-target-event="backColor"></div>' +
         '</div>' +
         '<div class="btn-group">' +
         '<div class="note-palette-title">FontColor</div>' +
+        '<div class="note-color-reset" data-event="foreColor" data-value="inherit" title="Reset">Reset to default</div>' +
         '<div class="note-color-palette" data-target-event="foreColor"></div>' +
         '</div>' +
         '</li>' +
@@ -1654,6 +1656,9 @@
 
       //031. create Codeable
       var welCodeable = $('<textarea class="note-codeable"></textarea>').prependTo(welEditor);
+
+      //032. set styleWithCSS for backColor / foreColor clearing with 'inherit'.
+      document.execCommand('styleWithCSS', true, null);
       
       //04. create Toolbar
       var sToolbar = '';

--- a/summernote.less
+++ b/summernote.less
@@ -100,6 +100,21 @@
 
           .note-palette-title {
             font-size: 12px;
+            margin: 2px 7px;
+            text-align: center;
+            border-bottom: 1px solid #eee;
+          }
+
+          .note-color-reset {
+            font-size: 12px;
+            margin: 5px;
+            padding: 0 3px;
+            cursor: pointer;
+            .rounded(5px);
+          }
+
+          .note-color-reset:hover {
+            background: #eee;
           }
         }
       }


### PR DESCRIPTION
I updated color dialog with below features:
- Add `Transparent` for clearing background color.
- Add `Reset to default` for clearing foreground(text) color.
- Shape up color dialog.

This patch will solve https://github.com/HackerWins/summernote/issues/76

After applying this patch, color dialog will look like below image.
![screen shot 2013-10-18 at 2 36 38 pm](https://f.cloud.github.com/assets/579366/1358488/aafa1fa6-37c3-11e3-8f08-0f4ce8c6c81f.png)
