### PR TITLE
Prevent popping tooltips on clicking toolbar buttons

### DIFF
--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -355,7 +355,8 @@ define([
         var tplShortcut = $btn.attr(agent.bMac ? 'data-mac-shortcut': 'data-shortcut');
         if (tplShortcut) { $btn.attr('title', function (i, v) { return v + ' (' + tplShortcut + ')'; }); }
       // bootstrap tooltip on btn-group bug: https://github.com/twitter/bootstrap/issues/5687
-      }).tooltip({container: 'body', placement: sPlacement || 'top'});
+      }).tooltip({container: 'body', trigger: 'hover', placement: sPlacement || 'top'})
+        .on('click', function () {$(this).tooltip('hide'); });
     };
 
     // pallete colors


### PR DESCRIPTION
This patch prevents popping tooltips on clicking toolbar buttons.
![screen shot 2013-12-31 at 5 38 59 pm](https://f.cloud.github.com/assets/579366/1826561/f99fcec2-7200-11e3-9860-dd74fdec52c0.png)
