### PR TITLE
Fix near ancestor to prevent go out of editor bounds.

### DIFF
--- a/src/js/core/dom.js
+++ b/src/js/core/dom.js
@@ -38,7 +38,7 @@ define(['core/func', 'core/list'], function (func, list) {
      * @param {function} pred - predicate function
      */
     var ancestor = function (node, pred) {
-      while (node) {
+      while (node && !$(node).hasClass('note-editor')) {
         if (pred(node)) { return node; }
         node = node.parentNode;
       }


### PR DESCRIPTION
If you place the editor inside a list element the currentStyle method return the key isOnList as true. This is because dom.ancestor method is looking for a list through dom tree even when parent elements are outside of the editor.  I do not know if it's the best solution but I hope it helps.
