### PR TITLE
Fixes weird jquery bug

### DIFF
--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -402,7 +402,8 @@ define([
           langInfo = $.summernote.lang[options.lang];
 
       //already created
-      if ($holder.next().hasClass('note-editor')) { return; }
+      var next = $holder.next();
+      if (!next && next.hasClass('note-editor')) { return; }
 
       //01. create Editor
       var $editor = $('<div class="note-editor"></div>');


### PR DESCRIPTION
When next returns null, the hasClass further throws Untyped exception.

The fix checks for next first then follows the same logic.

Had a hard time reproducing this bug, seems to be coupled with box-layout and jquery.
