### PR TITLE
Add a composer.json file for PHP projects (w/composer)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "HackerWins/summernote",
+    "description": "Super Simple WYSIWYG Editor on Bootstrap(3.0 and 2.x).",
+    "type": "library",
+    "keywords": [
+        "wysiwyg"
+    ],
+    "homepage": "http://hackerwins.github.io/summernote/",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Alan",
+            "email": "susukang98@gmail.com",
+            "role": "lead"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/HackerWins/summernote/issues"
+    }
+}


### PR DESCRIPTION
Adding Composer support so this project can be registered on Packagist and be easily added to PHP projects.
