### PR TITLE
FIX z-index youtube video embedding and add options webdev

### DIFF
--- a/src/js/editing/Editor.js
+++ b/src/js/editing/Editor.js
@@ -154,12 +154,11 @@ define([
       var dmRegExp = /.+dailymotion.com\/(video|hub)\/([^_]+)[^#]*(#video=([^_&]+))?/;
       var dmMatch = sUrl.match(dmRegExp);
 
-      if ((typeof(videoWidthDefault) != 'undefined') && (typeof(videoHeightDefault) != 'undefined')){
-        var videoWidth = videoWidthDefault;
-        var videoHeight = videoHeightDefault;
-      } else {
-        var videoWidth = '640';
-        var videoHeight = '360';
+      var videoWidth = '640';
+      var videoHeight = '360';
+      if ((typeof(videoWidthDefault) !== 'undefined') && (typeof(videoHeightDefault) !== 'undefined')){
+        videoWidth = videoWidthDefault;
+        videoHeight = videoHeightDefault;
       }
 
       var $video;


### PR DESCRIPTION
1) Fix z-index youtube video embedding
2) allow webdev to define the default size of the video (youtube, vimeo, dailymotion) without changing "summernote.js"
3) allow webdev to define the style of links only for the "summernote" content (add class 'link_summernote' )
