### PR TITLE
Allow webdev to show/hide option target of a link

### DIFF
--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -341,7 +341,7 @@ define([
                            '<label>' + lang.link.url + '</label>' +
                            '<input class="note-link-url form-control span12" type="text" />' +
                          '</div>' +
-                         '<div class="checkbox">' +
+                         '<div class="checkbox checkbox_target">' +
                            '<label>' + '<input type="checkbox" checked> ' +
                              lang.link.openInNewWindow +
                            '</label>' +


### PR DESCRIPTION
allow webdev to show/hide the checkbox option target of a link 
(add class 'checkbox_target')
