### PR TITLE
 Add buttons toolbar sup, 'sub' , 'strik' part 2

### DIFF
--- a/src/js/module/Toolbar.js
+++ b/src/js/module/Toolbar.js
@@ -67,6 +67,15 @@ define([
       btnState('button[data-event="underline"]', function () {
         return oStyle['font-underline'] === 'underline';
       });
+      btnState('button[data-event="strikethrough"]', function () {
+        return oStyle['font-strikethrough'] === 'strikethrough';
+      });
+      btnState('button[data-event="superscript"]', function () {
+        return oStyle['font-superscript'] === 'superscript';
+      });
+      btnState('button[data-event="subscript"]', function () {
+        return oStyle['font-subscript'] === 'subscript';
+      });
       btnState('button[data-event="justifyLeft"]', function () {
         return oStyle['text-align'] === 'left' || oStyle['text-align'] === 'start';
       });


### PR DESCRIPTION
1) Add buttons toolbar 'superscript' and 'subscript'
2) Finalize button toolbar 'strikethrough'

ex: ['font', ['bold', 'italic', 'underline', 'strikethrough', 'superscript', 'subscript', 'clear']],
