### PR TITLE
update middleware function to append to existing middlewares

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,12 +75,12 @@ module.exports = function (grunt) {
         options: {
           port: 3000,
           livereload: true,
-          middleware: function (connect, options) {
-            return [
+          middleware: function (connect, options, middlewares) {
+            return middlewares.concat([
               require('connect-livereload')(), // livereload middleware
               connect.static(options.base),    // serve static files
               connect.directory(options.base)  // make empty directories browsable
-            ];
+            ]);
           },
           open: 'http://localhost:3000'
         }


### PR DESCRIPTION
`grunt server` was throwing an error:

```
TypeError: Object /Users/edeustace/dev/github/edeustace/summernote has no method 'charAt' at exports.normalize (path.js:336:27)
```

This fixes it.  
