### PR TITLE
Updated bower.json version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "summernote",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "main": ["./dist/summernote.min.js", "./dist/summernote.css"],
   "ignore": [
     "**/.*",


### PR DESCRIPTION
I'm having inconsistencies with several computers because of this, in the package.json you have defined the version as 0.5.2 and you changed the folder `summernote-dist` to `dist` but you didn't bump the bower.json version, so when I try to add the newest version of summernote to my bower.json file in my project I can't find it.
