### PR TITLE
Fixed detecting of CTRL key press

### DIFF
--- a/src/js/EventHandler.js
+++ b/src/js/EventHandler.js
@@ -517,7 +517,7 @@ define([
 
         // modifier
         if (event.metaKey) { aKey.push('CMD'); }
-        if (event.ctrlKey) { aKey.push('CTRL'); }
+        if (event.ctrlKey && !event.altKey) { aKey.push('CTRL'); }
         if (event.shiftKey) { aKey.push('SHIFT'); }
 
         // keycode


### PR DESCRIPTION
This pull request is continue of #285 pull request.

On Windows alt and ctrl keys sets flag event.ctrlKey as true. event.altKey need to be checked to allow user to write some national chars (for example polish ż; alt + z).

I red more about problem with ctrlKey where ALT key and CTRL key set it to true. This is problem with WebKit and Trident engine (https://bugs.webkit.org/show_bug.cgi?id=34002) which incorrectly reports special keys. Gecko engine reports special keys correctly.

In code you have following condition:

``` php
if (event.ctrlKey) { aKey.push('CTRL'); }
```

This condition will be true for CTRL key and sometimes for ALT key (not always, it probably depends on input language). To be sure that pressed is CTRL key you need to check ctrlKey and altKey as in pull request.
