### PR TITLE
Fixed missing references for superscript and subscript tooltips.

### DIFF
--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -201,6 +201,8 @@ define('summernote/settings', function () {
           italic: 'Italic',
           underline: 'Underline',
           strikethrough: 'Strikethrough',
+          subscript: 'Subscript',
+          superscript: 'Superscript',
           clear: 'Remove Font Style',
           height: 'Line Height',
           name: 'Font Family',


### PR DESCRIPTION
Added the missing entries in the settings.js for en.
