### PR TITLE
add missing 'name' key to summernote-ja-JP.js

### DIFF
--- a/lang/summernote-ja-JP.js
+++ b/lang/summernote-ja-JP.js
@@ -8,6 +8,7 @@
         strikethrough: '取り消し線',
         clear: 'クリア',
         height: '文字高',
+        name: 'フォント',
         size: '大きさ'
       },
       image: {


### PR DESCRIPTION
In lang 'ja-JP', tooptip of 'font family' button show `undefined`.
So add font.name key to summernote-ja-JP.js.

Thanks.
