### PR TITLE
Fixed IE change events syntax

### DIFF
--- a/src/js/EventHandler.js
+++ b/src/js/EventHandler.js
@@ -639,7 +639,7 @@ define([
         };
 
         if (agent.isMSIE) {
-          var sDomEvents = 'DOMCharacterDataModified, DOMSubtreeModified, DOMNodeInserted';
+          var sDomEvents = 'DOMCharacterDataModified DOMSubtreeModified DOMNodeInserted';
           oLayoutInfo.editable.on(sDomEvents, hChange);
         } else {
           oLayoutInfo.editable.on('input', hChange);


### PR DESCRIPTION
Removed commas from list of events. The correct syntax for adding a handler to multiple events in jQuery is without commas. Without this fix, IE10 (and possibly IE9) does not work with the onChange callback.
