### PR TITLE
Changed the name of font-awesome for correct package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "jquery": ">= 1.9.0",
     "bootstrap": ">= 3.0.1",
-    "fontawesome": ">= 4.1.0"
+    "font-awesome": ">= 4.1.0"
   }
 }


### PR DESCRIPTION
I get small conflict with font-awesome:

bower uninstall fontawesome --save
bower conflict      summernote depends on fontawesome
[?] Continue anyway? (Y/n)

The oficial package is "font-awesome", not "fontawesome". For not keep both is better set the correct name.
