### PR TITLE
Fix for issues like #516

### DIFF
--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -4063,7 +4063,7 @@
         var group = options.toolbar[idx];
         sToolbar += '<div class="note-' + group[0] + ' btn-group">';
         for (var i = 0, szGroup = group[1].length; i < szGroup; i++) {
-          if($.isFunction(tplButtonInfo[group[1][i]])) {
+          if ($.isFunction(tplButtonInfo[group[1][i]])) {
             sToolbar += tplButtonInfo[group[1][i]](langInfo, options);
           }
           


### PR DESCRIPTION
Fix a crash when a toolbar button does'nt exist. Now not appear, but no crash the js. Maybe some warn like "The button {blabla} not exists, not rendering" will be fine! But i don't want use the console.log/error that can crash in ie :/
