### PR TITLE
Fixes #306 IE9 form submit

### DIFF
--- a/src/js/summernote.js
+++ b/src/js/summernote.js
@@ -39,7 +39,7 @@ define([
         // Textarea: auto filling the code before form submit.
         if (dom.isTextarea($holder[0])) {
           $holder.closest('form').submit(function () {
-            $holder.html($holder.code());
+            $holder.val($holder.code());
           });
         }
       });


### PR DESCRIPTION
We should be setting the value for the textarea using `.val` instead of `.html` for cross-browser compatibility.
