### PR TITLE
Add default textAlign option to settings

### DIFF
--- a/src/js/core/dom.js
+++ b/src/js/core/dom.js
@@ -1,4 +1,7 @@
-define(['summernote/core/func', 'summernote/core/list', 'summernote/core/agent'], function (func, list, agent) {
+define([
+  'summernote/core/func', 'summernote/core/list', 'summernote/core/agent',
+  'summernote/settings'
+], function (func, list, agent, settings) {
   /**
    * Dom functions
    */
@@ -425,10 +428,13 @@ define(['summernote/core/func', 'summernote/core/list', 'summernote/core/agent']
     var html = function ($node) {
       return dom.isTextarea($node[0]) ? $node.val() : $node.html();
     };
+
+    var emptyPara = (settings.options.textAlign === 'left') ?
+      '<p><br/></p>' : '<p style="text-align:' + settings.options.textAlign + '"><br/></p>';
   
     return {
       blank: agent.isMSIE ? '&nbsp;' : '<br/>',
-      emptyPara: '<p><br/></p>',
+      emptyPara: emptyPara,
       isEditable: isEditable,
       isControlSizing: isControlSizing,
       buildLayoutInfo: buildLayoutInfo,

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -95,6 +95,9 @@ define('summernote/settings', function () {
         ['#630000', '#7B3900', '#846300', '#295218', '#083139', '#003163', '#21104A', '#4A1031']
       ],
 
+      // textalign
+      textAlign: 'left',
+
       // fontSize
       fontSizes: ['8', '9', '10', '11', '12', '14', '18', '24', '36'],
 


### PR DESCRIPTION
This patch contains default `text-align` option for `emptyPara`.
Ref : https://github.com/HackerWins/summernote/issues/533.
