### PR TITLE
Fix clearning file input on image dialog

### DIFF
--- a/src/js/module/Dialog.js
+++ b/src/js/module/Dialog.js
@@ -39,6 +39,7 @@ define('summernote/module/Dialog', function () {
               deferred.resolve(this.files);
               $imageDialog.modal('hide');
             })
+            .val('')
           );
 
           $imageBtn.click(function (event) {


### PR DESCRIPTION
On latest versions of Firefox and Chrome, calling `clone()` even clones value in file input elements.
But they support `val('')` either.
