### PR TITLE
added default font to editor container to fix issue #642

### DIFF
--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -749,7 +749,7 @@ define([
 
       //03. create Editable
       var isContentEditable = !$holder.is(':disabled');
-      var $editable = $('<div class="note-editable" style="font-family: \'' + 
+      var $editable = $('<div class="note-editable" style="font-family: \'' +
           options.defaultFontName + '\'" contentEditable="' + isContentEditable + '"></div>')
           .prependTo($editor);
       if (options.height) {

--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -749,8 +749,8 @@ define([
 
       //03. create Editable
       var isContentEditable = !$holder.is(':disabled');
-      var $editable = $('<div class="note-editable" style="font-family: \'' 
-          + options.defaultFontName + '\'" contentEditable="' + isContentEditable + '"></div>')
+      var $editable = $('<div class="note-editable" style="font-family: \'' + 
+          options.defaultFontName + '\'" contentEditable="' + isContentEditable + '"></div>')
           .prependTo($editor);
       if (options.height) {
         $editable.height(options.height);

--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -749,7 +749,7 @@ define([
 
       //03. create Editable
       var isContentEditable = !$holder.is(':disabled');
-      var $editable = $('<div class="note-editable" contentEditable="' + isContentEditable + '"></div>')
+      var $editable = $('<div class="note-editable" style="font-family: \'' + options.defaultFontName + '\'" contentEditable="' + isContentEditable + '"></div>')
           .prependTo($editor);
       if (options.height) {
         $editable.height(options.height);

--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -749,7 +749,8 @@ define([
 
       //03. create Editable
       var isContentEditable = !$holder.is(':disabled');
-      var $editable = $('<div class="note-editable" style="font-family: \'' + options.defaultFontName + '\'" contentEditable="' + isContentEditable + '"></div>')
+      var $editable = $('<div class="note-editable" style="font-family: \'' 
+          + options.defaultFontName + '\'" contentEditable="' + isContentEditable + '"></div>')
           .prependTo($editor);
       if (options.height) {
         $editable.height(options.height);


### PR DESCRIPTION
adding the default font to the container means that jqueryCSS collects the correct style details for the default font. My testing indicates that this solves the problem quite well.