### PR TITLE
Correction for styleWithSpan setting

### DIFF
--- a/src/js/EventHandler.js
+++ b/src/js/EventHandler.js
@@ -631,10 +631,10 @@ define([
       layoutInfo.editor.data('options', options);
 
       // ret styleWithCSS for backColor / foreColor clearing with 'inherit'.
-      if (options.styleWithSpan && !agent.isMSIE) {
+      if (!agent.isMSIE) {
         // protect FF Error: NS_ERROR_FAILURE: Failure
         setTimeout(function () {
-          document.execCommand('styleWithCSS', 0, true);
+          document.execCommand('styleWithCSS', 0, options.styleWithSpan);
         }, 0);
       }
 


### PR DESCRIPTION
This correction makes sure that if I don't want to style with a span, it will not.  Previously this function was purely passive, and only enforced styling with spans...  a browser defaulting to css styling would continue to do so regardless of this setting.

This feature was used in response to issue https://github.com/HackerWins/summernote/issues/244 and is re-raised on issue https://github.com/HackerWins/summernote/issues/728.
