### PR TITLE
Fix dropout link creation on Firefox

### DIFF
--- a/src/js/editing/Editor.js
+++ b/src/js/editing/Editor.js
@@ -352,7 +352,7 @@ define([
       var rng = range.create().expand(dom.isAnchor);
 
       // Fix for wrong selection on FireFox
-      if (!$editable.find(rng.sc) || $editable[0] === rng.sc) {
+      if ($.inArray($editable[0], $(rng.sc).parents()) < 0) {
         rng = range.createFromNode($editable.children()[0]);
       }
 


### PR DESCRIPTION
Symptom:
Firefox returns wrong selection - not related with current caret position.
https://github.com/HackerWins/summernote/blob/develop/src/js/editing/Editor.js#L350 tries to set focus to editable before getting a range, but it doesn't work properly on Firefox.

This fixes https://github.com/HackerWins/summernote/issues/606 but implemented by very ad-hoc approach.
