### PR TITLE
use correct font-awesome bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,6 @@
   "dependencies": {
     "jquery": ">= 1.9.0",
     "bootstrap": ">= 3.0.1",
-    "fontawesome": ">= 4.1.0"
+    "font-awesome": ">=4.2.0"
   }
 }


### PR DESCRIPTION
Using the wrong version is causing any project that uses the correct version to have two versions of font awesome.

![image](https://cloud.githubusercontent.com/assets/941075/5368778/5aa2a43e-7ff1-11e4-9781-e8c507a472c1.png)
