### PR TITLE
Fix ugly minus margins for form-group of dialog in form-horizontal

### DIFF
--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -297,6 +297,10 @@
   &>div {
     display: none; /* BS2's hide pacth. */
   }
+  .form-group { /* overwrite BS's form-horizontal minus margins */
+    margin-left: 0;
+    margin-right: 0;
+  }
   .note-modal-form {
     margin: 0; /* overwrite BS2's form margin bottom */
   }


### PR DESCRIPTION
@feryardiant made a patch for https://github.com/summernote/summernote/issues/788 in https://github.com/summernote/summernote/pull/500, but it was closed not merged.
So I wrote it again.
