### PR TITLE
Option for prettifying html while toggling codeview

### DIFF
--- a/src/js/EventHandler.js
+++ b/src/js/EventHandler.js
@@ -205,7 +205,7 @@ define([
 
         var isCodeview = $editor.hasClass('codeview');
         if (isCodeview) {
-          $codable.val(dom.html($editable, true));
+          $codable.val(dom.html($editable, options.prettifyHtml));
           $codable.height($editable.height());
           toolbar.deactivate($toolbar);
           popover.hide($popover);
@@ -237,7 +237,7 @@ define([
             cmEditor.toTextArea();
           }
 
-          $editable.html(dom.value($codable) || dom.emptyPara);
+          $editable.html(dom.value($codable, options.prettifyHtml) || dom.emptyPara);
           $editable.height(options.height ? $codable.height() : 'auto');
 
           toolbar.activate($toolbar);

--- a/src/js/core/dom.js
+++ b/src/js/core/dom.js
@@ -784,10 +784,12 @@ define([
       return markup;
     };
 
-    var value = function ($textarea) {
+    var value = function ($textarea, stripLinebreaks) {
       var val = $textarea.val();
-      // strip line breaks
-      return val.replace(/[\n\r]/g, '');
+      if (stripLinebreaks) {
+        return val.replace(/[\n\r]/g, '');
+      }
+      return val;
     };
 
     return {

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -25,6 +25,7 @@ define('summernote/settings', function () {
       shortcuts: true,              // enable keyboard shortcuts
 
       placeholder: false,           // enable placeholder text
+      prettifyHtml: true,           // enable prettifying html while toggling codeview
 
       codemirror: {                 // codemirror options
         mode: 'text/html',


### PR DESCRIPTION
`dom.html` and `dom.value` were called when toggling codeview/wysiwyg.
However, it does not work well as expected. It makes lots of blank lines, breaks intended indents, so on.
But I leave `prettifyHtml` as true by default for backward compatibility.