### PR TITLE
[FIX] prevent default for mousedown image to prevent ie and ff must set the new range

### DIFF
--- a/src/js/editing/Editor.js
+++ b/src/js/editing/Editor.js
@@ -102,13 +102,10 @@ define([
      * @method currentStyle
      *
      * current style
-     *
-     * @param {Node} target
-     * @return {Boolean} false if range is no
      */
-    this.currentStyle = function (target) {
+    this.currentStyle = function () {
       var rng = range.create();
-      return rng ? rng.isOnEditable() && style.current(rng, target) : false;
+      return rng ? rng.isOnEditable() && style.current(rng) : false;
     };
 
     var triggerOnBeforeChange = this.triggerOnBeforeChange = function ($editable) {
@@ -621,15 +618,23 @@ define([
     };
 
     /**
+     * @return {Node} image from the current range selection
+     */
+    function getImgTarget() {
+      var rng = range.create();
+      var target = rng.sc.childNodes.length && rng.sc.childNodes[rng.so] || rng.sc;
+      return target;
+    }
+
+    /**
      * float me
      *
      * @param {jQuery} $editable
      * @param {String} value
-     * @param {jQuery} $target
      */
-    this.floatMe = function ($editable, value, $target) {
+    this.floatMe = function ($editable, value) {
       beforeCommand($editable);
-      $target.css('float', value);
+      $(getImgTarget()).css('float', value);
       afterCommand($editable);
     };
 
@@ -638,17 +643,14 @@ define([
      *
      * @param {jQuery} $editable
      * @param {String} value css class
-     * @param {Node} $target
      */
-    this.imageShape = function ($editable, value, $target) {
+    this.imageShape = function ($editable, value) {
       beforeCommand($editable);
-
+      var $target = $(getImgTarget());
       $target.removeClass('img-rounded img-circle img-thumbnail');
-
       if (value) {
         $target.addClass(value);
       }
-
       afterCommand($editable);
     };
 
@@ -656,11 +658,10 @@ define([
      * resize overlay element
      * @param {jQuery} $editable
      * @param {String} value
-     * @param {jQuery} $target - target element
      */
-    this.resize = function ($editable, value, $target) {
+    this.resize = function ($editable, value) {
       beforeCommand($editable);
-
+      var $target = $(getImgTarget());
       $target.css({
         width: value * 100 + '%',
         height: ''
@@ -697,11 +698,10 @@ define([
      * remove media object
      *
      * @param {jQuery} $editable
-     * @param {String} value - dummy argument (for keep interface)
-     * @param {jQuery} $target - target element
      */
-    this.removeMedia = function ($editable, value, $target) {
+    this.removeMedia = function ($editable) {
       beforeCommand($editable);
+      var $target = $(getImgTarget());
       $target.detach();
 
       var callbacks = $editable.data('callbacks');

--- a/src/js/editing/Style.js
+++ b/src/js/editing/Style.js
@@ -104,10 +104,9 @@ define([
      * get current style on cursor
      *
      * @param {WrappedRange} rng
-     * @param {Node} target - target element on event
      * @return {Object} - object contains style properties.
      */
-    this.current = function (rng, target) {
+    this.current = function (rng) {
       var $cont = $(dom.isText(rng.sc) ? rng.sc.parentNode : rng.sc);
       var properties = ['font-family', 'font-size', 'text-align', 'list-style-type', 'line-height'];
       var styleInfo = jQueryCSS($cont, properties) || {};
@@ -138,6 +137,8 @@ define([
         var lineHeight = parseInt(styleInfo['line-height'], 10) / parseInt(styleInfo['font-size'], 10);
         styleInfo['line-height'] = lineHeight.toFixed(1);
       }
+
+      var target = rng.sc.childNodes.length && rng.sc.childNodes[rng.so] || rng.sc;
 
       styleInfo.image = dom.isImg(target) && target;
       styleInfo.anchor = rng.isOnAnchor() && dom.ancestor(rng.sc, dom.isAnchor);


### PR DESCRIPTION
[FIX] prevent default for mousedown image to prevent ie and ff default 'features' must set the range because the cursor is used for edition. Warning for picture because the browser can't target the image but the container.

Using range instead of $target, it is not necessary to memorize $target if the range is properly distributed
Modify the code to use the dom range.
