### PR TITLE
Add `hasOwnProperty` check when iterating over array

### DIFF
--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -457,10 +457,12 @@ define([
       var body = [];
 
       for (var i in keys) {
-        body.push(
-          '<div class="' + keyClass + 'key">' + keys[i].kbd + '</div>' +
-          '<div class="' + keyClass + 'name">' + keys[i].text + '</div>'
-          );
+        if (keys.hasOwnProperty(i)) {
+          body.push(
+            '<div class="' + keyClass + 'key">' + keys[i].kbd + '</div>' +
+            '<div class="' + keyClass + 'name">' + keys[i].text + '</div>'
+            );
+        }
       }
 
       return '<div class="note-shortcut-row row"><div class="' + keyClass + 'title col-xs-offset-6">' + title + '</div></div>' +


### PR DESCRIPTION
Adding methods to the `Array` prototype makes the rendering fail. This patch fixes the error by adding a `hasOwnProperty` check while iterating over the `keys` array.