### PR TITLE
Using a placeholder of the original holder

### DIFF
--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -765,7 +765,9 @@ define([
       if (options.direction) {
         $editable.attr('dir', options.direction);
       }
-      if (options.placeholder) {
+      if ($holder.attr('placeholder') !== undefined) {
+        $editable.attr('data-placeholder', $holder.attr('placeholder'));
+      } else if (options.placeholder) {
         $editable.attr('data-placeholder', options.placeholder);
       }
 

--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -765,10 +765,9 @@ define([
       if (options.direction) {
         $editable.attr('dir', options.direction);
       }
-      if ($holder.attr('placeholder') !== undefined) {
-        $editable.attr('data-placeholder', $holder.attr('placeholder'));
-      } else if (options.placeholder) {
-        $editable.attr('data-placeholder', options.placeholder);
+      var placeholder = $holder.attr('placeholder') || options.placeholder;
+      if (placeholder) {
+        $editable.attr('data-placeholder', placeholder);
       }
 
       $editable.html(dom.html($holder));


### PR DESCRIPTION
If a holder has its own `placeholder`, then use it for summernote placeholder.
For https://github.com/summernote/summernote/issues/543