### PR TITLE
Add fontNamesIgnoreCheck settings for lazy-loadable webfonts

### DIFF
--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -150,7 +150,9 @@ define([
       },
       fontname: function (lang, options) {
         var items = options.fontNames.reduce(function (memo, v) {
-          if (!agent.isFontInstalled(v)) { return memo; }
+          if (!agent.isFontInstalled(v) && options.fontNamesIgnoreCheck.indexOf(v) === -1) {
+            return memo;
+          }
           return memo + '<li><a data-event="fontName" href="#" data-value="' + v + '">' +
                           '<i class="fa fa-check"></i> ' + v +
                         '</a></li>';

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -84,6 +84,7 @@ define('summernote/settings', function () {
         'Helvetica Neue', 'Impact', 'Lucida Grande',
         'Tahoma', 'Times New Roman', 'Verdana'
       ],
+      fontNamesIgnoreCheck: [],
 
       // pallete colors(n x n)
       colors: [


### PR DESCRIPTION
See https://github.com/summernote/summernote/issues/651 about web font problem.
Web fonts could not be loaded before checking availabilities while building the toolbar, so they will fail test and not be added.

We can also fix this problem by adding lazy creating `fontNames` buttons, but I chose simpler way. If user wants to use web fonts, just put them also into `fontNamesIgnoreCheck` too.