### PR TITLE
publish npm package #833

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,14 @@ before_script:
   - npm --version
   - npm install -g grunt-cli
 script: grunt test --verbose
+before_deploy:
+  - npm install
+  - grunt build
+  - grunt dist
+deploy:
+  provider: npm
+  email: susukang98@gmail.com
+  api_key:
+    secure: TYJfuTLZKbYvTskuMlmuKnQb5F35GFPN2AqSf0RtZYWGLozIaIkKcpTVbjzo859FWuxPjci53FGiJih3+0iVfIC39CDTrFZutubn8qduOfRAVTL1WzeQvdww8miJNwUY59HmoOa78OtbNCVg/N7zFSZzRXAcgje8IADQFIISwk8=
+  on:
+    tags: true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,12 @@
 {
-  "name": "Summernote",
+  "name": "summernote",
   "description": "Super Simple WYSIWYG Editor on Bootstrap",
   "version": "0.6.0",
+  "keywords": [
+    "editor",
+    "bootstrap",
+    "WYSIWYG"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/HackerWins/summernote.git"


### PR DESCRIPTION
publish npm package via travis-ci.

I already publish [summernote on npm registry](http://blog.npmjs.org/post/77758351673/no-more-npm-publish-f).

I mistaked something. [npm registry doesn't allow republish package.](http://blog.npmjs.org/post/77758351673/no-more-npm-publish-f) But I unpublished 0.6.0 and attemped to republish it. That's why the version is `0.6.0-ga`, not `0.6.0`. I know it's ugly, but I can't fix it. (We can fix it on next release)

We have to test auto-publish on travis-ci when we release next version.