### PR TITLE
[FIX] prevent absolute elements float into toolbar

### DIFF
--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -98,6 +98,7 @@
     padding: 10px;
     overflow: auto;
     outline: none;
+    position: relative;
   }
   .note-editable[contenteditable="false"] {
     background-color: #e5e5e5;


### PR DESCRIPTION
### What does this do?

I had some elements with `style="position: absolute; top: 0px"` and they were floating into the toolbar.


### tickets? 

fixes #893

### Screenshots?

##### BEFORE:

![screen shot 2015-02-07 at 2 41 51 pm](https://cloud.githubusercontent.com/assets/955736/6094254/036a2122-aed8-11e4-8390-4bb0d75164ec.png)
![screen shot 2015-02-07 at 2 42 28 pm](https://cloud.githubusercontent.com/assets/955736/6094255/036b34a4-aed8-11e4-9663-0aebc3ce6d60.png)


##### AFTER:

![screen shot 2015-02-07 at 2 59 54 pm](https://cloud.githubusercontent.com/assets/955736/6094324/06233960-aeda-11e4-87df-be61c660873e.png)