### PR TITLE
Fixed video plugin for urls that don't match any of the video url patterns

### DIFF
--- a/plugin/summernote-ext-video.js
+++ b/plugin/summernote-ext-video.js
@@ -94,6 +94,7 @@
         .attr('width', '640').attr('height', '360');
     } else {
       // this is not a known video link. Now what, Cat? Now what?
+      return false;
     }
 
     return $video[0];
@@ -244,9 +245,14 @@
 
           // restore range
           editor.restoreRange($editable);
-
-          // insert video node
-          editor.insertNode($editable, createVideoNode(url));
+          
+          // build node
+          var $node = createVideoNode(url);
+          
+          if ($node) {
+            // insert video node
+            editor.insertNode($editable, $node);
+          }
         }).fail(function () {
           // when cancel button clicked
           editor.restoreRange($editable);


### PR DESCRIPTION
This is a regression bug that I noticed upgrading to the latest version.

If you go to https://github.com/summernote/summernote/blob/v0.5.1/src/js/editing/Editor.js#L198 you can see that the variable `video` used to be checked and causes a JavaScript error for the cases that don't match a pattern.

Previously when video was not a plugin, it wouldn't insert any node and would simply close the modal if the URL didn't match a pattern. This brings that back.