### PR TITLE
[bugfix] #1012, insertText added another line on empty paragraph.

### DIFF
--- a/src/js/core/dom.js
+++ b/src/js/core/dom.js
@@ -836,8 +836,13 @@ define([
         container = splitRoot.parentNode;
       }
 
-      // split with splitTree
+      // if splitRoot is exists, split with splitTree
       var pivot = splitRoot && splitTree(splitRoot, point, isInline);
+
+      // if container is point.node, find pivot with point.offset
+      if (!pivot && container === point.node) {
+        pivot = point.node.childNodes[point.offset];
+      }
 
       return {
         rightNode: pivot,

--- a/test/unit/dom.spec.js
+++ b/test/unit/dom.spec.js
@@ -240,5 +240,22 @@ define(['jquery', 'summernote/core/dom', 'summernote/core/func'], function ($, d
       equalsToUpperCase($cont.html(), '<p><span><b>b</b><u>u</u></span><span><s>s</s><i>i</i></span></p>',
                         'splitBy span tag with offset 2 (1 depth, element case)');
     });
+
+    test('dom.splitPoint', function () {
+      var $editable, $para, $br;
+      $editable = $('<div class="note-editable"><p><br></p></div>');
+
+      $para = $editable.clone().find('p');
+      $br = $para.find('br');
+      
+      deepEqual(dom.splitPoint({
+        node: $para[0],
+        offset: 0
+      }, true), {
+        rightNode: $br[0],
+        container: $para[0]
+      }, 'splitPoint empty paragraph with inline should returns rightNode:<br> container:<p>');
+
+    });
   };
 });


### PR DESCRIPTION
 - splitPoint empty paragraph with inline should returns `rightNode:<br> container:<p>`);
 - splitPoint: if container is point.node, find pivot with point.offset