### PR TITLE
Implement `rng.getWordRange`.

### DIFF
--- a/src/js/core/dom.js
+++ b/src/js/core/dom.js
@@ -684,6 +684,21 @@ define([
     };
 
     /**
+     * returns whether point has character or not.
+     *
+     * @param {Point} point
+     * @return {Boolean}
+     */
+    var isCharPoint = function (point) {
+      if (!isText(point.node)) {
+        return false;
+      }
+
+      var ch = point.node.nodeValue.charAt(point.offset - 1);
+      return ch && (ch !== ' ' && ch !== NBSP_CHAR);
+    };
+
+    /**
      * @method walkPoint
      *
      * @param {BoundaryPoint} startPoint
@@ -1030,6 +1045,7 @@ define([
       isVisiblePoint: isVisiblePoint,
       prevPointUntil: prevPointUntil,
       nextPointUntil: nextPointUntil,
+      isCharPoint: isCharPoint,
       walkPoint: walkPoint,
       ancestor: ancestor,
       singleChildAncestor: singleChildAncestor,

--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -534,7 +534,7 @@ define([
           startPoint.offset,
           endPoint.node,
           endPoint.offset
-        ).normalize();
+        );
       };
   
       /**

--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -512,6 +512,30 @@ define([
         var nativeRng = nativeRange();
         return agent.isW3CRangeSupport ? nativeRng.toString() : nativeRng.text;
       };
+
+      /**
+       * returns range for word before cursor
+       *
+       * @return {WrappedRange}
+       */
+      this.getWordRange = function () {
+        var endPoint = this.getEndPoint();
+
+        if (!dom.isCharPoint(endPoint)) {
+          return this;
+        }
+
+        var startPoint = dom.prevPointUntil(endPoint, function (point) {
+          return !dom.isCharPoint(point);
+        });
+
+        return new WrappedRange(
+          startPoint.node,
+          startPoint.offset,
+          endPoint.node,
+          endPoint.offset
+        ).normalize();
+      };
   
       /**
        * create offsetPath bookmark

--- a/test/unit/range.spec.js
+++ b/test/unit/range.spec.js
@@ -229,5 +229,54 @@ define([
       range.create($cont[0], 2).wrapBodyInlineWithPara();
       equalsToUpperCase($cont.html(), '<p><b>b</b><i>i</i></p>', 'rng.wrapBodyInlineWithPara with inline should wrap text with paragraph.');
     });
+
+    test('rng.getWordRange', function () {
+      var $cont, rng;
+
+      $cont = $('<div class="note-editable">super simple wysiwyg editor</div>');
+
+      // no word before cursor
+      rng = range.create(
+        $cont[0].firstChild, 0
+      ).getWordRange();
+
+      deepEqual([
+        rng.sc, rng.so, rng.ec, rng.eo
+      ], [
+        $cont[0].firstChild, 0, $cont[0].firstChild, 0
+      ], 'rng.getWordRange with no word before cursor should return itself');
+
+      // find word before cursor
+      rng = range.create(
+        $cont[0].firstChild, 5
+      ).getWordRange();
+
+      deepEqual([
+        rng.sc, rng.so, rng.ec, rng.eo
+      ], [
+        $cont[0].firstChild, 0, $cont[0].firstChild, 5
+      ], 'rng.getWordRange with word before cursor should return expanded range');
+
+      rng = range.create(
+        $cont[0].firstChild, 3
+      ).getWordRange();
+
+      deepEqual([
+        rng.sc, rng.so, rng.ec, rng.eo
+      ], [
+        $cont[0].firstChild, 0, $cont[0].firstChild, 3
+      ], 'rng.getWordRange with half word before cursor should expanded range');
+
+      rng = range.create(
+        $cont[0].firstChild, 12
+      ).getWordRange();
+
+      deepEqual([
+        rng.sc, rng.so, rng.ec, rng.eo
+      ], [
+        $cont[0].firstChild, 6, $cont[0].firstChild, 12
+      ], 'rng.getWordRange with half word before cursor should expanded range');
+
+    });
   };
 });


### PR DESCRIPTION
#### What's this PR do?

This PR implements `range.getWordRange`.
`range.getWordRange` will find word before cursor then returns it's range.

#### Any background context you want to provide?

With this PR you can find current word and replace to another markup.

```javascript
var rng = editor.createRange(); // current range.
wordRange = rng.getWordRange(); // find word before cursor then returns it's range
if (wordRange.toString() === 'bar:30,10,20') { // wordRange's contents
  contents = rng.pasteHTML(this.getChart(wordRange.toString())); // replace word with custom markup
  range.createFromNode(list.last(contents)).collapse().select(); // select after custom markup
}
```