### PR TITLE
add hasFullElement parameter in range.getWordRange

### DIFF
--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -518,7 +518,7 @@ define([
        *
        * @return {WrappedRange}
        */
-      this.getWordRange = function () {
+      this.getWordRange = function (hasFullElement) {
         var endPoint = this.getEndPoint();
 
         if (!dom.isCharPoint(endPoint)) {
@@ -528,6 +528,12 @@ define([
         var startPoint = dom.prevPointUntil(endPoint, function (point) {
           return !dom.isCharPoint(point);
         });
+
+        if (hasFullElement) {
+          endPoint = dom.nextPointUntil(endPoint, function (point) {
+            return !dom.isCharPoint(point);
+          });
+        }
 
         return new WrappedRange(
           startPoint.node,

--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -516,6 +516,7 @@ define([
       /**
        * returns range for word before cursor
        *
+       * @param {Boolean} hasFullElement get range for full element  at current cursor
        * @return {WrappedRange}
        */
       this.getWordRange = function (hasFullElement) {


### PR DESCRIPTION
# What's this PR do?

* add hasFullElement parameter in range.getWordRange 

# Any background context you want to provide?

It is how to get full text use by getWordRange() at current cursor.