### PR TITLE
Fixed callback and custom event bugs.

### DIFF
--- a/src/js/EventHandler.js
+++ b/src/js/EventHandler.js
@@ -27,7 +27,6 @@ define([
    *
    * EventHandler
    *  - TODO: new instance per a editor
-   *  - TODO: rename EventHandler
    */
   var EventHandler = function () {
     /**
@@ -48,8 +47,13 @@ define([
       helpDialog: new HelpDialog(this)
     };
 
-    // TODO refactor modules and eventHandler
-    //  - remove this method and use custom event from $holder instead
+    /**
+     * invoke module's method
+     *
+     * @param {String} moduleAndMethod - ex) 'editor.redo'
+     * @param {...*} arguments - arguments of method
+     * @return {*}
+     */
     this.invoke = function () {
       var moduleAndMethod = list.head(list.from(arguments));
       var args = list.tail(list.from(arguments));

--- a/src/js/EventHandler.js
+++ b/src/js/EventHandler.js
@@ -85,7 +85,7 @@ define([
       return function () {
         var callback = callbacks[func.namespaceToCamel(eventNamespace, 'on')];
         if (callback) {
-          callback(arguments);
+          callback.apply($holder[0], arguments);
         }
         return $holder.trigger('summernote.' + eventNamespace, arguments);
       };
@@ -108,7 +108,7 @@ define([
 
       // If onImageUpload options setted
       if (callbacks.onImageUpload) {
-        bindCustomEvent($holder, callbacks, 'image.upload')([files]);
+        bindCustomEvent($holder, callbacks, 'image.upload')(files);
       // else insert Image as dataURL
       } else {
         $.each(files, function (idx, file) {
@@ -455,12 +455,11 @@ define([
       $editable.on('paste', bindCustomEvent($holder, callbacks, 'paste'));
       
       // [workaround] for old IE - IE8 don't have input events
-      if (agent.isMSIE) {
-        var sDomEvents = 'DOMCharacterDataModified DOMSubtreeModified DOMNodeInserted';
-        $editable.on(sDomEvents, bindCustomEvent($holder, callbacks, 'change'));
-      } else {
-        $editable.on('input', bindCustomEvent($holder, callbacks, 'change'));
-      }
+      //  - TODO check IE version
+      var changeEventName = agent.isMSIE ? 'DOMCharacterDataModified DOMSubtreeModified DOMNodeInserted' : 'input';
+      $editable.on(changeEventName, function () {
+        bindCustomEvent($holder, callbacks, 'change')($editable.html(), $editable);
+      });
 
       // callbacks for advanced features (camel)
       if (!options.airMode) {

--- a/src/js/module/Codeview.js
+++ b/src/js/module/Codeview.js
@@ -99,7 +99,8 @@ define([
      * @param {Object} layoutInfo
      */
     this.deactivate = function (layoutInfo) {
-      var $editor = layoutInfo.editor(),
+      var $holder = layoutInfo.holder(),
+          $editor = layoutInfo.editor(),
           $toolbar = layoutInfo.toolbar(),
           $editable = layoutInfo.editable(),
           $codable = layoutInfo.codable();
@@ -113,9 +114,18 @@ define([
         cmEditor.toTextArea();
       }
 
-      $editable.html(dom.value($codable, options.prettifyHtml) || dom.emptyPara);
+      var value = dom.value($codable, options.prettifyHtml) || dom.emptyPara;
+      var isChange = $editable.html() !== value;
+
+      $editable.html(value);
       $editable.height(options.height ? $codable.height() : 'auto');
       $editor.removeClass('codeview');
+
+      if (isChange) {
+        handler.bindCustomEvent(
+          $holder, $editable.data('callbacks'), 'change'
+        )($editable.html(), $editable);
+      }
 
       $editable.focus();
 

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -112,17 +112,17 @@ define([
     };
 
     var triggerOnBeforeChange = function ($editable) {
-      // TODO find holder
+      var $holder = dom.makeLayoutInfo($editable).holder();
       handler.bindCustomEvent(
-        $(), $editable.data('callbacks'), 'before.command'
-      ).call($editable.html(), $editable);
+        $holder, $editable.data('callbacks'), 'before.command'
+      )($editable.html(), $editable);
     };
 
     var triggerOnChange = function ($editable) {
-      // TODO find holder
+      var $holder = dom.makeLayoutInfo($editable).holder();
       handler.bindCustomEvent(
-        $(), $editable.data('callbacks'), 'change'
-      ).call($editable.html(), $editable);
+        $holder, $editable.data('callbacks'), 'change'
+      )($editable.html(), $editable);
     };
 
     /**


### PR DESCRIPTION
#### What's this PR do?
- Fixed unwrap onImageUpload callback's first arguments.
- bind holder element as callback handler's `this` context(for external API in handler)

#### What are the relevant tickets?
#1041, #1021, #977, #758

#### How should this be manually tested?
add callback or custom events and watch log.
```javascript
// summernote
$('.summernote').summernote({
  height: 300,                  // set editable area's height
  onInit: function () {
    console.log('init', arguments, $('.summernote')[0] === this);
  },
  onFocus: function () {
    console.log('focus', arguments, $('.summernote')[0] === this);
  },
  onBlur: function () {
    console.log('blur', arguments, $('.summernote')[0] === this);
  },
  onKeydown: function () {
    console.log('keydown', arguments, $('.summernote')[0] === this);
  },
  onKeyup: function () {
    console.log('keyup', arguments, $('.summernote')[0] === this);
  },
  onEnter: function () {
    console.log('enter', arguments, $('.summernote')[0] === this);
  },
  onMousedown: function () {
    console.log('onMousedown', arguments, $('.summernote')[0] === this);
  },
  onMouseup: function () {
    console.log('onMouseup', arguments, $('.summernote')[0] === this);
  },
  onScroll: function () {
    console.log('onscroll', arguments, $('.summernote')[0] === this);
  },
  onPaste: function () {
    console.log('paste', arguments, $('.summernote')[0] === this);
  },
  onBeforeCommand: function () {
    console.log('onBeforeCommand', arguments, $('.summernote')[0] === this);
  },
  onChange: function () {
    console.log('onChange', arguments, $('.summernote')[0] === this);
  },
  onImageUpload: function () {
    console.log('onImageUpload', arguments, $('.summernote')[0] === this);
  },
  onImageUploadError: function () {
    console.log('onImageUploadError', arguments, $('.summernote')[0] === this);
  }
}).on('summernote.init', function () {
  console.log('summernote.init', arguments, $('.summernote')[0] === this);
}).on('summernote.focus', function () {
  console.log('summernote.focus', arguments, $('.summernote')[0] === this);
}).on('summernote.blur', function () {
  console.log('summernote.blur', arguments, $('.summernote')[0] === this);
}).on('summernote.keydown', function () {
  console.log('summernote.keydown', arguments, $('.summernote')[0] === this);
}).on('summernote.keyup', function () {
  console.log('summernote.keyup', arguments, $('.summernote')[0] === this);
}).on('summernote.enter', function () {
  console.log('summernote.enter', arguments, $('.summernote')[0] === this);
}).on('summernote.mousedown', function () {
  console.log('summernote.mousedown', arguments, $('.summernote')[0] === this);
}).on('summernote.mouseup', function () {
  console.log('summernote.mouseup', arguments, $('.summernote')[0] === this);
}).on('summernote.scroll', function () {
  console.log('summernote.scroll', arguments, $('.summernote')[0] === this);
}).on('summernote.paste', function () {
  console.log('summernote.paste', arguments, $('.summernote')[0] === this);
}).on('summernote.before.command', function () {
  console.log('summernote.before.command', arguments, $('.summernote')[0] === this);
}).on('summernote.change', function () {
  console.log('summernote.change', arguments, $('.summernote')[0] === this);
}).on('summernote.image.upload', function () {
  console.log('summernote.image.upload', arguments, $('.summernote')[0] === this);
}).on('summernote.image.upload.error', function () {
  console.log('summernote.image.error', arguments, $('.summernote')[0] === this);
});
```