### PR TITLE
Fixes adding links with no text description

### DIFF
--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -544,17 +544,17 @@ define([
         linkUrl = options.onCreateLink(linkUrl);
       }
 
-      var anchors;
+      var anchors = [];
       if (isTextChanged) {
         // Create a new link when text changed.
         var anchor = rng.insertNode($('<A>' + linkText + '</A>')[0]);
-        anchors = [anchor];
+        anchors.push(anchor);
       } else {
-        anchors = style.styleNodes(rng, {
+        anchors.push(style.styleNodes(rng, {
           nodeName: 'A',
           expandClosestSibling: true,
           onlyPartialContains: true
-        });
+        }));
       }
 
       $.each(anchors, function (idx, anchor) {

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -550,11 +550,11 @@ define([
         var anchor = rng.insertNode($('<A>' + linkText + '</A>')[0]);
         anchors.push(anchor);
       } else {
-        anchors.push(style.styleNodes(rng, {
+        anchors = style.styleNodes(rng, {
           nodeName: 'A',
           expandClosestSibling: true,
           onlyPartialContains: true
-        }));
+        });
       }
 
       $.each(anchors, function (idx, anchor) {

--- a/src/js/module/LinkDialog.js
+++ b/src/js/module/LinkDialog.js
@@ -51,6 +51,7 @@ define([
           $linkText.val(linkInfo.text);
 
           $linkText.on('input', function () {
+            toggleBtn($linkBtn, $linkText.val() && $linkUrl.val());
             // if linktext was modified by keyup,
             // stop cloning text from linkUrl
             linkInfo.text = $linkText.val();
@@ -63,7 +64,7 @@ define([
           }
 
           $linkUrl.on('input', function () {
-            toggleBtn($linkBtn, $linkUrl.val());
+            toggleBtn($linkBtn, $linkText.val() && $linkUrl.val());
             // display same link on `Text to display` input
             // when create a new link
             if (!linkInfo.text) {


### PR DESCRIPTION
#### What does this PR do?

- Fixes something related to #1022, but only enables the "Create Link" button when all input fields have content.

#### Where should the reviewer start?

- src/js/module/LinkDialog.js
- src/js/module/Editor.js

#### How should this be manually tested?

1. Click the button to insert a new link
2. Provide content to only one of the input fields in the modal
3. "Create Link" button should not be clickable

#### Any background context you want to provide?

- The changes in Editor.js are related to the way it supposes to create a link. `anchors`, in that case, is an iterable array variable and this fix reassures it.

#### What are the relevant tickets?

#1022 