### PR TITLE
prevent errors in FireFox

### DIFF
--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -619,11 +619,16 @@ define([
       create : function (sc, so, ec, eo) {
         if (!arguments.length) { // from Browser Selection
           if (agent.isW3CRangeSupport) {
-            var selection = document.getSelection();
-            if (selection.rangeCount === 0) {
-              return null;
-            } else if (dom.isBody(selection.anchorNode)) {
-              // Firefox: returns entire body as range on initialization. We won't never need it.
+            try {
+              var selection = document.getSelection();
+              if (selection.rangeCount === 0) {
+                return null;
+              } else if (dom.isBody(selection.anchorNode)) {
+                // Firefox: returns entire body as range on initialization. We won't never need it.
+                return null;
+              }
+            }
+            catch (e) {
               return null;
             }
   


### PR DESCRIPTION
When Summernote is in an iFrame FireFox throws an error related to selection.rangeCount, this suppresses said error.

fixes #1057 