### PR TITLE
Fixed #1066, inline style for collapsed range.

### DIFF
--- a/src/js/EventHandler.js
+++ b/src/js/EventHandler.js
@@ -191,15 +191,13 @@ define([
       }, 0);
     };
 
-    var hScroll = function (event) {
+    var hScrollOrBlur = function (event) {
       var layoutInfo = dom.makeLayoutInfo(event.currentTarget || event.target);
       //hide popover and handle when scrolled
       modules.popover.hide(layoutInfo.popover());
       modules.handle.hide(layoutInfo.handle());
     };
 
-    var hBlur = hScroll;
-    
     var hToolbarAndPopoverMousedown = function (event) {
       // prevent default event when insertTable (FF, Webkit)
       var $btn = $(event.target).closest('[data-event]');
@@ -353,8 +351,9 @@ define([
       }
       layoutInfo.editable().on('mousedown', hMousedown);
       layoutInfo.editable().on('keyup mouseup', hToolbarAndPopoverUpdate);
-      layoutInfo.editable().on('scroll', hScroll);
-      layoutInfo.editable().on('blur', hBlur);
+      layoutInfo.editable().on('scroll blur', hScrollOrBlur);
+
+      // handler for clipboard
       modules.clipboard.attach(layoutInfo, options);
 
       // handler for handle and popover

--- a/src/js/EventHandler.js
+++ b/src/js/EventHandler.js
@@ -174,6 +174,12 @@ define([
       }
     };
 
+    var hKeyupAndMouseup = function (event) {
+      var layoutInfo = dom.makeLayoutInfo(event.currentTarget || event.target);
+      modules.editor.removeBogus(layoutInfo.editable());
+      hToolbarAndPopoverUpdate(event);
+    }
+
     var hToolbarAndPopoverUpdate = function (event) {
       // delay for range after mouseup
       setTimeout(function () {
@@ -350,7 +356,7 @@ define([
         this.bindKeyMap(layoutInfo, options.keyMap[agent.isMac ? 'mac' : 'pc']);
       }
       layoutInfo.editable().on('mousedown', hMousedown);
-      layoutInfo.editable().on('keyup mouseup', hToolbarAndPopoverUpdate);
+      layoutInfo.editable().on('keyup mouseup', hKeyupAndMouseup);
       layoutInfo.editable().on('scroll blur', hScrollAndBlur);
 
       // handler for clipboard

--- a/src/js/EventHandler.js
+++ b/src/js/EventHandler.js
@@ -422,13 +422,7 @@ define([
       // Textarea: auto filling the code before form submit.
       if (dom.isTextarea(list.head(layoutInfo.holder()))) {
         layoutInfo.holder().closest('form').submit(function () {
-          var contents = layoutInfo.holder().code();
-          layoutInfo.holder().val(contents);
-
-          // callback on submit
-          if (options.onsubmit) {
-            options.onsubmit(contents);
-          }
+          layoutInfo.holder().val(layoutInfo.holder().code());
         });
       }
     };
@@ -467,7 +461,6 @@ define([
         bindCustomEvent($holder, callbacks, 'change')($editable.html(), $editable);
       });
 
-      // callbacks for advanced features (camel)
       if (!options.airMode) {
         layoutInfo.toolbar().click(bindCustomEvent($holder, callbacks, 'toolbar.click'));
         layoutInfo.popover().click(bindCustomEvent($holder, callbacks, 'popover.click'));

--- a/src/js/EventHandler.js
+++ b/src/js/EventHandler.js
@@ -191,7 +191,7 @@ define([
       }, 0);
     };
 
-    var hScrollOrBlur = function (event) {
+    var hScrollAndBlur = function (event) {
       var layoutInfo = dom.makeLayoutInfo(event.currentTarget || event.target);
       //hide popover and handle when scrolled
       modules.popover.hide(layoutInfo.popover());
@@ -351,7 +351,7 @@ define([
       }
       layoutInfo.editable().on('mousedown', hMousedown);
       layoutInfo.editable().on('keyup mouseup', hToolbarAndPopoverUpdate);
-      layoutInfo.editable().on('scroll blur', hScrollOrBlur);
+      layoutInfo.editable().on('scroll blur', hScrollAndBlur);
 
       // handler for clipboard
       modules.clipboard.attach(layoutInfo, options);

--- a/src/js/EventHandler.js
+++ b/src/js/EventHandler.js
@@ -178,7 +178,7 @@ define([
       var layoutInfo = dom.makeLayoutInfo(event.currentTarget || event.target);
       modules.editor.removeBogus(layoutInfo.editable());
       hToolbarAndPopoverUpdate(event);
-    }
+    };
 
     var hToolbarAndPopoverUpdate = function (event) {
       // delay for range after mouseup

--- a/src/js/core/agent.js
+++ b/src/js/core/agent.js
@@ -83,6 +83,8 @@ define(['jquery'], function ($) {
     return originalWidth !== width;
   };
 
+  var userAgent = navigator.userAgent;
+
   /**
    * @class core.agent
    *
@@ -95,9 +97,12 @@ define(['jquery'], function ($) {
     /** @property {Boolean} [isMac=false] true if this agent is Mac  */
     isMac: navigator.appVersion.indexOf('Mac') > -1,
     /** @property {Boolean} [isMSIE=false] true if this agent is a Internet Explorer  */
-    isMSIE: navigator.userAgent.indexOf('MSIE') > -1 || navigator.userAgent.indexOf('Trident') > -1,
+    isMSIE: /MSIE|Trident/i.test(userAgent),
     /** @property {Boolean} [isFF=false] true if this agent is a Firefox  */
-    isFF: navigator.userAgent.indexOf('Firefox') > -1,
+    isFF: /firefox/i.test(userAgent),
+    isWebkit: /webkit/i.test(userAgent),
+    /** @property {Boolean} [isSafari=false] true if this agent is a Safari  */
+    isSafari: /safari/i.test(userAgent),
     /** @property {String} jqueryVersion current jQuery version string  */
     jqueryVersion: parseFloat($.fn.jquery),
     isSupportAmd: isSupportAmd,

--- a/src/js/core/dom.js
+++ b/src/js/core/dom.js
@@ -270,8 +270,11 @@ define([
 
       if (len === 0) {
         return true;
-      } else if (!dom.isText(node) && len === 1 && node.innerHTML === blankHTML) {
+      } else if (!isText(node) && len === 1 && node.innerHTML === blankHTML) {
         // ex) <p><br></p>, <span><br></span>
+        return true;
+      } else if (list.all(node.childNodes, isText) && node.innerHTML === '') {
+        // ex) <p></p>, <span></span>
         return true;
       }
 

--- a/src/js/core/key.js
+++ b/src/js/core/key.js
@@ -58,6 +58,15 @@ define([
         return list.contains([8, 9, 13, 32], keyCode);
       },
       /**
+       * @method isMove
+       *
+       * @param {Number} keyCode
+       * @return {Boolean}
+       */
+      isMove: function (keyCode) {
+        return list.contains([37, 38, 39, 40], keyCode);
+      },
+      /**
        * @property {Object} nameFromCode
        * @property {String} nameFromCode.8 "BACKSPACE"
        */

--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -620,7 +620,7 @@ define([
         if (!arguments.length) { // from Browser Selection
           if (agent.isW3CRangeSupport) {
             var selection = document.getSelection();
-            if (selection.rangeCount === 0) {
+            if (!selection || selection.rangeCount === 0) {
               return null;
             } else if (dom.isBody(selection.anchorNode)) {
               // Firefox: returns entire body as range on initialization. We won't never need it.

--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -692,6 +692,26 @@ define([
       },
 
       /**
+       * create WrappedRange from node after position
+       *
+       * @param {Node} node
+       * @return {WrappedRange}
+       */
+      createFromNodeBefore: function (node) {
+        return this.createFromNode(node).collapse(true);
+      },
+
+      /**
+       * create WrappedRange from node after position
+       *
+       * @param {Node} node
+       * @return {WrappedRange}
+       */
+      createFromNodeAfter: function (node) {
+        return this.createFromNode(node).collapse();
+      },
+
+      /**
        * @method 
        * 
        * create WrappedRange from bookmark

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -394,7 +394,7 @@ define([
           width: Math.min($editable.width(), $image.width())
         });
         range.create().insertNode($image[0]);
-        range.createFromNode($image[0]).collapse().select();
+        range.createFromNodeAfter($image[0]).select();
         afterCommand($editable);
       }).fail(function () {
         var $holder = dom.makeLayoutInfo($editable).holder();
@@ -413,7 +413,7 @@ define([
     this.insertNode = function ($editable, node) {
       beforeCommand($editable);
       range.create().insertNode(node);
-      range.createFromNode(node).collapse().select();
+      range.createFromNodeAfter(node).select();
       afterCommand($editable);
     };
 
@@ -437,7 +437,7 @@ define([
     this.pasteHTML = function ($editable, markup) {
       beforeCommand($editable);
       var contents = range.create().pasteHTML(markup);
-      range.createFromNode(list.last(contents)).collapse().select();
+      range.createFromNodeAfter(list.last(contents)).select();
       afterCommand($editable);
     };
 
@@ -565,9 +565,9 @@ define([
         }
       });
 
-      var startRange = range.createFromNode(list.head(anchors)).collapse(true);
+      var startRange = range.createFromNodeBefore(list.head(anchors));
       var startPoint = startRange.getStartPoint();
-      var endRange = range.createFromNode(list.last(anchors)).collapse();
+      var endRange = range.createFromNodeAfter(list.last(anchors));
       var endPoint = endRange.getEndPoint();
 
       range.create(


### PR DESCRIPTION
#### What's this PR do?

- Added bogus node for temporary style and cursor position. #1066
- Added more properties for detecting agent.
- Extract `createFromNodeBefore` and `createFromNodeAfter` method
- Remove statement calling onsubmit, because attachCustomEvent handle this
- Little code cleaning for #1070
- Rename hScrollOrBlur to hScrollAndBlur

#### How should this be manually tested?

- Test #1066 again.

#### What are the relevant tickets?
#1066, #1070