### PR TITLE
implements dropdown.note-check as selectbox

### DIFF
--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -173,7 +173,7 @@ define([
                      '</span>';
         return tplButton(label, {
           title: lang.font.name,
-          dropdown: '<ul class="dropdown-menu">' + items + '</ul>'
+          dropdown: '<ul class="dropdown-menu note-check">' + items + '</ul>'
         });
       },
       fontsize: function (lang, options) {
@@ -186,7 +186,7 @@ define([
         var label = '<span class="note-current-fontsize">11</span>';
         return tplButton(label, {
           title: lang.font.size,
-          dropdown: '<ul class="dropdown-menu">' + items + '</ul>'
+          dropdown: '<ul class="dropdown-menu note-check">' + items + '</ul>'
         });
       },
       color: function (lang, options) {
@@ -329,7 +329,7 @@ define([
 
         return tplIconButton(options.iconPrefix + 'text-height', {
           title: lang.font.height,
-          dropdown: '<ul class="dropdown-menu">' + items + '</ul>'
+          dropdown: '<ul class="dropdown-menu note-check">' + items + '</ul>'
         });
 
       },

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -258,15 +258,17 @@
       &::before { right: 9px; left: auto !important;  }
       &::after { right: 10px; left: auto !important;  }
     }
-
     /* dropdown-menu for selectbox */
-    li a i {
-      color: deepskyblue;
-      visibility: hidden;
+    &.note-check {
+      li a i {
+        color: deepskyblue;
+        visibility: hidden;
+      }
+      li a.checked i {
+        visibility: visible;
+      }
     }
-    li a.checked i {
-      visibility: visible;
-    }
+
   }
 
   .note-fontsize-10 {


### PR DESCRIPTION
#### What's this PR do?

- add .note-check class for selectbox 
- when you need dropdown like selectbox, you can add .note-check class to .dropdown-menu class. 

#### Where should the reviewer start?

- src/less/summernote.less ,  .dropdown-menu > .note-check  
- src/js/Renderer.js,  fontsize, height, fontname command 

#### What are the relevant tickets?

#1067 
