### PR TITLE
Add warning to sanitize the HTML on the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ var sHTML = $('#summernote').code();
 $('#summernote').destroy();
 ```
 
+#### Warning - code injection
+
+The code view allows the user to enter script contents. Make sure to filter/[sanitize the HTML on the server](https://github.com/search?l=JavaScript&q=sanitize+html). Otherwise, an attacker can inject arbitrary JavaScript code into clients.
+
 ### Supported platforms
 
 Any modern browser: Safari, Chrome, Firefox, Opera, Internet Explorer 9+.


### PR DESCRIPTION
Since Summernote doesn't sanitize the HTML it receives, this represents a security risk if the developer neglects to sanitize the HTML on the server (which is bet is the case more often than not).

[Sanitization isn't easy](https://www.npmjs.com/package/sanitize-html), and Summernote might or might not want to do it. But it should warn about the risk.

Addresses #583.