### PR TITLE
Add banner while uglifying

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,9 @@ module.exports = function (grunt) {
 
     // uglify: minify javascript
     uglify: {
+      options: {
+        banner: '/*! Summernote v<%=pkg.version%> | (c) 2013-2015 Alan Hong and other contributors | MIT license */\n'
+      },
       all: {
         files: { 'dist/summernote.min.js': ['dist/summernote.js'] }
       }


### PR DESCRIPTION
#### What's this PR do?

- Add a banner contains author, license and version for uglified files.

#### Where should the reviewer start?

- start on the Gruntfile.js

#### How should this be manually tested?

- `grunt dist`
- Check `dist/summernote.min.js` has a banner.