### PR TITLE
Use options.iconPrefix for font and plugin related toolbar buttons instead of hard-coded 'fa fa-'

### DIFF
--- a/plugin/summernote-ext-hello.js
+++ b/plugin/summernote-ext-hello.js
@@ -26,29 +26,29 @@
      * @property {Function} buttons.helloImage   function to make button
      */
     buttons: { // buttons
-      hello: function () {
+      hello: function (lang, options) {
 
-        return tmpl.iconButton('fa fa-header', {
+        return tmpl.iconButton(options.iconPrefix + 'header', {
           event : 'hello',
           title: 'hello',
           hide: true
         });
       },
-      helloDropdown: function () {
+      helloDropdown: function (lang, options) {
 
 
         var list = '<li><a data-event="helloDropdown" href="#" data-value="summernote">summernote</a></li>';
         list += '<li><a data-event="helloDropdown" href="#" data-value="codemirror">Code Mirror</a></li>';
         var dropdown = '<ul class="dropdown-menu">' + list + '</ul>';
 
-        return tmpl.iconButton('fa fa-header', {
+        return tmpl.iconButton(options.iconPrefix + 'header', {
           title: 'hello',
           hide: true,
           dropdown : dropdown
         });
       },
-      helloImage : function () {
-        return tmpl.iconButton('fa fa-file-image-o', {
+      helloImage : function (lang, options) {
+        return tmpl.iconButton(options.iconPrefix + 'file-image-o', {
           event : 'helloImage',
           title: 'helloImage',
           hide: true

--- a/plugin/summernote-ext-video.js
+++ b/plugin/summernote-ext-video.js
@@ -204,8 +204,8 @@
      * @property {function(object): string} buttons.video
      */
     buttons: {
-      video: function (lang) {
-        return tmpl.iconButton('fa fa-youtube-play', {
+      video: function (lang, options) {
+        return tmpl.iconButton(options.iconPrefix + 'youtube-play', {
           event: 'showVideoDialog',
           title: lang.video.video,
           hide: true

--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -163,9 +163,9 @@ define([
             return memo;
           }
           realFontList.push(v);
-          return memo + '<li><a data-event="fontName" href="#" data-value="' + v + '" style="font-family:\'' + v + '\'">' +
-                          '<i class="' + options.iconPrefix + 'check"></i> ' + v +
-                        '</a></li>';
+          return memo + '<li><a data-event="fontName" href="#" data-value="' + v + '">' +
+                          '<i class="' + options.iconPrefix + 'check"></i> <span style="font-family:\'' + v + '\'">' + v +
+                        '</span></a></li>';
         }, '');
 
         var hasDefaultFont = agent.isFontInstalled(options.defaultFontName);

--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -183,7 +183,7 @@ define([
       fontsize: function (lang, options) {
         var items = options.fontSizes.reduce(function (memo, v) {
           return memo + '<li><a data-event="fontSize" href="#" data-value="' + v + '">' +
-                          '<i class="fa fa-check"></i> ' + v +
+                          '<i class="' + options.iconPrefix + 'check"></i> ' + v +
                         '</a></li>';
         }, '');
 
@@ -248,20 +248,20 @@ define([
           title: lang.font.underline
         });
       },
-      strikethrough: function (lang) {
-        return tplIconButton('fa fa-strikethrough', {
+      strikethrough: function (lang, options) {
+        return tplIconButton(options.iconPrefix + 'strikethrough', {
           event: 'strikethrough',
           title: lang.font.strikethrough
         });
       },
-      superscript: function (lang) {
-        return tplIconButton('fa fa-superscript', {
+      superscript: function (lang, options) {
+        return tplIconButton(options.iconPrefix + 'superscript', {
           event: 'superscript',
           title: lang.font.superscript
         });
       },
-      subscript: function (lang) {
-        return tplIconButton('fa fa-subscript', {
+      subscript: function (lang, options) {
+        return tplIconButton(options.iconPrefix + 'subscript', {
           event: 'subscript',
           title: lang.font.subscript
         });

--- a/src/js/summernote.js
+++ b/src/js/summernote.js
@@ -89,7 +89,7 @@ define([
    *        // "hello"  is button's namespace.      
    *        "hello" : function(lang, options) {
    *            // make icon button by template function          
-   *            return tmpl.iconButton('fa fa-header', {
+   *            return tmpl.iconButton(options.iconPrefix + 'header', {
    *                // callback function name when button clicked 
    *                event : 'hello',
    *                // set data-value property                 


### PR DESCRIPTION
#### What's this PR do?
Use options.iconPrefix for font and plugin related toolbar buttons instead of hard-coded 'fa fa-'
This applies to: Strikethough, Subscript, Superscript, Font size dropdown (checkmark for current size), Video (plugin), Hello (plugin)

#### What are the relevant tickets?
Fixes #1131 
