### PR TITLE
Apply modal dialogs into document.body

### DIFF
--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -868,8 +868,10 @@ define([
       //06. handle(control selection, ...)
       $(tplHandles()).prependTo($editor);
 
+      var $dialogContainer = options.dialogsInBody ? document.body : $editor;
+
       //07. create Dialog
-      var $dialog = $(tplDialogs(langInfo, options)).prependTo($editor);
+      var $dialog = $(tplDialogs(langInfo, options)).prependTo($dialogContainer);
       $dialog.find('button.close, a.modal-close').click(function () {
         $(this).closest('.modal').modal('hide');
       });

--- a/src/js/core/dom.js
+++ b/src/js/core/dom.js
@@ -77,9 +77,14 @@ define([
 
         // frame mode
       } else {
-        makeFinder = function (sClassName) {
-          return function () { return $editor.find(sClassName); };
+        makeFinder = function (sClassName, sBaseElement) {
+          var $baseElement = sBaseElement ? $(sBaseElement) : $editor;
+          return function () { return $baseElement.find(sClassName); };
         };
+
+        var options = $editor.data('options');
+        var dialogHolder = (options && options.dialogsInBody) ? document.body : null;
+
         return {
           editor: function () { return $editor; },
           holder : function () { return $editor.data('holder'); },
@@ -90,7 +95,7 @@ define([
           statusbar: makeFinder('.note-statusbar'),
           popover: makeFinder('.note-popover'),
           handle: makeFinder('.note-handle'),
-          dialog: makeFinder('.note-dialog')
+          dialog: makeFinder('.note-dialog', dialogHolder)
         };
       }
     };


### PR DESCRIPTION
#### What's this PR do?

- Enable user to choose whether summernote should put modal dialogs templates directly on body
- This implementation is based mainly in a option to be provided into summernote's initial settings (options arguments) as `dialogsInBody: true`
- If summernote's settings have this attribute either suppressed or set to `false` or `null`, default configuration shall be applied (`$editor` used as container for dialogs)

#### Where should the reviewer start?

Core changes are based on:
- `src/js/Renderer.js` (definitions related to dialogs container disposition)
- `src/js/core/dom.js` (methods for dialog access and modal provision)

#### How should this be manually tested?

In an editor instance, try to open any modal dialog with:
- `dialogsInBody: true` in summernote settings
- with no `dialogsInBody: true` in summernote settings
- with `dialogsInBody: false` or `dialogsInBody: null`

#### Any background context you want to provide?

This PR is related and conceived as a solution to specific scenarios where some elements throughout the document in a web application are overlapping summernote's modal because of DOM hierarchy issues.

Since summernote puts modal dialog templates by default into its inner structure, it's not difficult to the `$editor` base element depth be overlapped, even when forcing it with `z-index` tricks.

These changes are focused on a versatile and adaptable way. If this related configuration shouldn't be provided, summernote would behave as it is.
