### PR TITLE
Remove dialog templates from body on destroy, using `options.dialogsInBody`

### DIFF
--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -949,6 +949,9 @@ define([
       } else {
         $holder.html(layoutInfo.editable().html());
 
+        if (options.dialogsInBody) {
+          layoutInfo.dialog().remove();
+        }
         layoutInfo.editor().remove();
         $holder.show();
       }


### PR DESCRIPTION
#### What's this PR do?

- removes modal templates generated in `document.body`, when using `options.dialogsInBody` attribute as defined in #1175.

#### Where should the reviewer start?

- src/js/Renderer.js (added conditional function call to remove `.note-dialog` template div based on `options.dialogsInBody` definition in summernote's settings)

#### How should this be manually tested?

1. In an editor instance, try to execute a `destroy()` call to summernote;
2. Assert if the element with dialog templates was properly removed from `document.body`, as expected to that function behavior

#### Any background context you want to provide?

This is just a missed code snippet in #1175 PR. Sorry to create another one, folks.

#### What are the relevant tickets?

#1175