### PR TITLE
Fixed script error on creating bullet with multiple lines on firefox.

### DIFF
--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -201,8 +201,7 @@ define([
           if ((dom.isVisiblePoint(point) && !dom.isEdgePoint(point)) ||
               (dom.isVisiblePoint(point) && dom.isRightEdgePoint(point) && !isLeftToRight) ||
               (dom.isVisiblePoint(point) && dom.isLeftEdgePoint(point) && isLeftToRight) ||
-              (dom.isVisiblePoint(point) && dom.isBlock(point.node) && dom.isEmpty(point.node)) ||
-              (dom.isEditable(point.node) && dom.isEdgePoint(point))) {
+              (dom.isVisiblePoint(point) && dom.isBlock(point.node) && dom.isEmpty(point.node))) {
             return point;
           }
 
@@ -459,20 +458,26 @@ define([
           return new WrappedRange(sc.firstChild, 0, sc.firstChild, 0);
         }
 
+        /**
+         * [workaround] firefox often create range on not visible point. so normalize here.
+         *  - firefox: |<p>text</p>|
+         *  - chrome: <p>|text|</p>
+         */
+        var rng = this.normalize();
         if (dom.isParaInline(sc) || dom.isPara(sc)) {
-          return this.normalize();
+          return rng;
         }
 
         // find inline top ancestor
         var topAncestor;
-        if (dom.isInline(sc)) {
-          var ancestors = dom.listAncestor(sc, func.not(dom.isInline));
+        if (dom.isInline(rng.sc)) {
+          var ancestors = dom.listAncestor(rng.sc, func.not(dom.isInline));
           topAncestor = list.last(ancestors);
           if (!dom.isInline(topAncestor)) {
-            topAncestor = ancestors[ancestors.length - 2] || sc.childNodes[so];
+            topAncestor = ancestors[ancestors.length - 2] || rng.sc.childNodes[rng.so];
           }
         } else {
-          topAncestor = sc.childNodes[so > 0 ? so - 1 : 0];
+          topAncestor = rng.sc.childNodes[rng.so > 0 ? rng.so - 1 : 0];
         }
 
         // siblings not in paragraph

--- a/test/unit/range.spec.js
+++ b/test/unit/range.spec.js
@@ -134,7 +134,17 @@ define([
         rng.sc, rng.so, rng.ec, rng.eo
       ], [
         $p[1].firstChild, 0, $p[1].firstChild, 0
-      ], 'rng.normalize on `<p>text</p><p>|<b>b<b></p>` should returns `<p>text</p><p><b>|b</b></p>`');
+      ], 'rng.normalize on `<p>text</p><p>|text</p>` should returns `<p>text</p><p>|text</b></p>`');
+
+      $cont = $('<div class="note-editable"><p>text</p><p>text</p></div>');
+      $p = $cont.find('p');
+
+      rng = range.create($cont[0], 0,  $cont[0], 2).normalize();
+      deepEqual([
+        rng.sc, rng.so, rng.ec, rng.eo
+      ], [
+        $p[0].firstChild, 0, $p[1].firstChild, 4
+      ], 'rng.normalize on `|<p>text</p><p>text</p>|` should returns `<p>|text</p><p>text|</b></p>`');
     });
 
 


### PR DESCRIPTION
#### What's this PR do?
- Fixed script error on creating bullet with multiple lines on firefox.

#### How should this be manually tested?
- type multiple lines and select all paragraphs.
- click `ordered list` button

#### Any background context you want to provide?
- firefox often create range on not visible point.
```
firefox: |<p>text</p>|
chrome: <p>|text|</p>
```

#### What are the relevant tickets?
#627