### PR TITLE
use actual icon names instead of aliases

### DIFF
--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -82,7 +82,7 @@ define('summernote/defaults', function () {
         link: {
           link: 'link',
           unlink: 'chain-broken',
-          edit: 'fa-pencil-square-o'
+          edit: 'pencil-square-o'
         },
         table: {
           table: 'table'

--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -81,8 +81,8 @@ define('summernote/defaults', function () {
         },
         link: {
           link: 'link',
-          unlink: 'unlink',
-          edit: 'edit'
+          unlink: 'chain-broken',
+          edit: 'fa-pencil-square-o'
         },
         table: {
           table: 'table'


### PR DESCRIPTION
the use of icon aliases can cause issues for those who use services like [fonticons](https://www.fonticons.com/) or [fontello](http://fontello.com) to generate icon fonts. using the actual icon names removes these issues.