### PR TITLE
implement disableResizeImage option

### DIFF
--- a/src/js/Renderer.js
+++ b/src/js/Renderer.js
@@ -471,7 +471,7 @@ define([
           value: 'none'
         });
 
-        var content = '<div class="btn-group">' + fullButton + halfButton + quarterButton + '</div>' +
+        var content = (options.disableResizeImage ? '' : '<div class="btn-group">' + fullButton + halfButton + quarterButton + '</div>') +
                       '<div class="btn-group">' + leftButton + rightButton + justifyButton + '</div><br>' +
                       '<div class="btn-group">' + roundedButton + circleButton + thumbnailButton + noneButton + '</div>' +
                       '<div class="btn-group">' + removeButton + '</div>';
@@ -509,15 +509,17 @@ define([
       return $notePopover;
     };
 
-    var tplHandles = function () {
+    var tplHandles = function (options) {
       return '<div class="note-handle">' +
                '<div class="note-control-selection">' +
                  '<div class="note-control-selection-bg"></div>' +
                  '<div class="note-control-holder note-control-nw"></div>' +
                  '<div class="note-control-holder note-control-ne"></div>' +
                  '<div class="note-control-holder note-control-sw"></div>' +
-                 '<div class="note-control-sizing note-control-se"></div>' +
-                 '<div class="note-control-selection-info"></div>' +
+                 '<div class="' +
+                 (options.disableResizeImage ? 'note-control-holder' : 'note-control-sizing') +
+                 ' note-control-se"></div>' +
+                 (options.disableResizeImage ? '' : '<div class="note-control-selection-info"></div>') +
                '</div>' +
              '</div>';
     };
@@ -858,7 +860,7 @@ define([
       createTooltip($popover, keyMap);
 
       //05. handle(control selection, ...)
-      $(tplHandles()).prependTo($editingArea);
+      $(tplHandles(options)).prependTo($editingArea);
 
       $editingArea.prependTo($editor);
 

--- a/src/js/defaults.js
+++ b/src/js/defaults.js
@@ -47,6 +47,7 @@ define('summernote/defaults', function () {
       disableLinkTarget: false,     // hide link Target Checkbox
       disableDragAndDrop: false,    // disable drag and drop event
       disableResizeEditor: false,   // disable resizing editor
+      disableResizeImage: false,    // disable resizing image
 
       shortcuts: true,              // enable keyboard shortcuts
 

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -448,6 +448,12 @@
       cursor: se-resize;
     }
 
+    .note-control-se.note-control-holder {
+      cursor: default;
+      border-top: none;
+      border-left: none;
+    }
+
     .note-control-selection-info {
       right: 0;
       bottom: 0;

--- a/src/sass/summernote.scss
+++ b/src/sass/summernote.scss
@@ -464,6 +464,12 @@ $background-color: #f5f5f5 !default;
       cursor: se-resize;
     }
 
+    .note-control-se.note-control-holder {
+      cursor: default;
+      border-top: none;
+      border-left: none;
+    }
+
     .note-control-selection-info {
       right: 0;
       bottom: 0;


### PR DESCRIPTION
#### What does this PR do?

Implement an option `disableResizeImage` to disable the image resizing functionality

#### Where should the reviewer start?

- start on the src/js/Renderer.js

#### How should this be manually tested?

- add variable `disableResizeImage: true` to `defaults.js`
- insert an image and click it
  - check the image popover, there are no resizing buttons 
  - check the south-east resizing icon became a corner

#### What are the relevant tickets?
https://github.com/summernote/summernote/issues/1241