### PR TITLE
Fix URL protocol on links added from selected text

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -558,6 +558,11 @@ define([
       var rng = linkInfo.range || this.createRange();
       var isTextChanged = rng.toString() !== linkText;
 
+      // handle spaced urls from input
+      if (typeof linkUrl === 'string') {
+        linkUrl = linkUrl.trim();
+      }
+
       if (options.onCreateLink) {
         linkUrl = options.onCreateLink(linkUrl);
       }
@@ -576,6 +581,10 @@ define([
       }
 
       $.each(anchors, function (idx, anchor) {
+        // if url doesn't match an URL schema, set http:// as default
+        linkUrl = /^[A-Za-z][A-Za-z0-9+-.]*\:[\/\/]?/.test(linkUrl) ?
+          linkUrl : 'http://' + linkUrl;
+
         $(anchor).attr('href', linkUrl);
         if (isNewWindow) {
           $(anchor).attr('target', '_blank');


### PR DESCRIPTION
#### What does this PR do?

- Provides "http://" as default URI schema protocol, when creating links from selected text in editor

#### Where should the reviewer start?

- `src/js/module/Editor.js`

#### How should this be manually tested?

Follow steps in #1274.

#### Any background context you want to provide?

- This is quite useful when creating links such as `github.com`.
- It fixes a bug for external domains, as described above, but is still invalid for relative links in the same domain (needs review).

#### What are the relevant tickets?

#1274