### PR TITLE
diablse sauce labs tests on pull request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_script:
 - npm install -g grunt-cli
 script:
 - grunt test --verbose
-- grunt saucelabs-test
+- if [[ $TRAVIS_PULL_REQUEST == "false" ]]; then grunt saucelabs-test; fi
 - grunt karma:travis
 - grunt coveralls:travis
 before_deploy:


### PR DESCRIPTION
* refer <http://docs.travis-ci.com/user/pull-requests/>
* For security reason, travis build for PR can't use
  encrypted data or environment variables. So, tests in
  sauce labs can't run on PR. See details in
  <https://github.com/travis-ci/travis-ci/issues/1946>

#1279