### PR TITLE
add a callback 'onInsertImages(files){}'

### DIFF
--- a/src/js/EventHandler.js
+++ b/src/js/EventHandler.js
@@ -117,6 +117,7 @@ define([
         bindCustomEvent($holder, callbacks, 'image.upload')(files);
       // else insert Image as dataURL
       } else {
+        if (options.onInsertImages) options.onInsertImages(files);        
         $.each(files, function (idx, file) {
           var filename = file.name;
           if (options.maximumImageFileSize && options.maximumImageFileSize < file.size) {


### PR DESCRIPTION
Original source provides a callback "onImageUpload" to do custom images uploading, thus the pretty good functionality of dataURL will be missing, and users could not control the uploading time. So it becomes nothing meaningful when they cancel submitting.
Here is how to do images uploading by user himself at anytime, retaining the using of dataURL.
https://github.com/summernote/summernote/issues/1318