### PR TITLE
Added "reset" and "rewind" methods for History.

### DIFF
--- a/src/js/editing/History.js
+++ b/src/js/editing/History.js
@@ -29,6 +29,47 @@ define(['summernote/core/range'], function (range) {
     };
 
     /**
+    * @method rewind
+    * Rewinds the history stack back to the first snapshot taken.
+    * Leaves the stack intact, so that "Redo" can still be used.
+    */
+    this.rewind = function () {
+
+        // Create snap shot if not yet recorded
+        if ($editable.html() !== stack[stackOffset].contents) {
+            this.recordUndo();
+        }
+
+        // Return to the first available snapshot.
+        stackOffset = 0;
+
+        // Apply that snapshot.
+        applySnapshot(stack[stackOffset]);
+
+    };
+
+
+    /**
+    * @method reset
+    * Resets the history stack completely; reverting to an empty editor.
+    */
+    this.reset = function () {
+
+        // Clear the stack.
+        stack = [];
+
+        // Restore stackOffset to its original value.
+        stackOffset = -1;
+
+        // Clear the editable area.
+        $editable.html('');
+
+        // Record our first snapshot (of nothing).
+        this.recordUndo();
+
+    };
+
+    /**
      * undo
      */
     this.undo = function () {

--- a/src/js/editing/History.js
+++ b/src/js/editing/History.js
@@ -35,16 +35,16 @@ define(['summernote/core/range'], function (range) {
     */
     this.rewind = function () {
 
-        // Create snap shot if not yet recorded
-        if ($editable.html() !== stack[stackOffset].contents) {
-            this.recordUndo();
-        }
+      // Create snap shot if not yet recorded
+      if ($editable.html() !== stack[stackOffset].contents) {
+        this.recordUndo();
+      }
 
-        // Return to the first available snapshot.
-        stackOffset = 0;
+      // Return to the first available snapshot.
+      stackOffset = 0;
 
-        // Apply that snapshot.
-        applySnapshot(stack[stackOffset]);
+      // Apply that snapshot.
+      applySnapshot(stack[stackOffset]);
 
     };
 
@@ -55,17 +55,17 @@ define(['summernote/core/range'], function (range) {
     */
     this.reset = function () {
 
-        // Clear the stack.
-        stack = [];
+      // Clear the stack.
+      stack = [];
 
-        // Restore stackOffset to its original value.
-        stackOffset = -1;
+      // Restore stackOffset to its original value.
+      stackOffset = -1;
 
-        // Clear the editable area.
-        $editable.html('');
+      // Clear the editable area.
+      $editable.html('');
 
-        // Record our first snapshot (of nothing).
-        this.recordUndo();
+      // Record our first snapshot (of nothing).
+      this.recordUndo();
 
     };
 

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -145,6 +145,29 @@ define([
     };
 
     /**
+    * @method reset
+    * Resets the history stack completely; reverting to an empty editor.
+    * @param {jQuery} $editable
+    */
+    this.reset = function ($editable) {
+        triggerOnBeforeChange($editable);
+        $editable.data('NoteHistory').reset();
+        triggerOnChange($editable);
+    };
+
+    /**
+    * @method rewind
+    * Rewinds the history stack back to the first snapshot taken.
+    * Leaves the stack intact, so that "Redo" can still be used.
+    * @param {jQuery} $editable
+    */
+    this.rewind = function ($editable) {
+        triggerOnBeforeChange($editable);
+        $editable.data('NoteHistory').rewind();
+        triggerOnChange($editable);
+    };
+
+    /**
      * @method undo
      * undo
      * @param {jQuery} $editable

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -150,9 +150,9 @@ define([
     * @param {jQuery} $editable
     */
     this.reset = function ($editable) {
-        triggerOnBeforeChange($editable);
-        $editable.data('NoteHistory').reset();
-        triggerOnChange($editable);
+      triggerOnBeforeChange($editable);
+      $editable.data('NoteHistory').reset();
+      triggerOnChange($editable);
     };
 
     /**

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -162,16 +162,16 @@ define([
     * @param {jQuery} $editable
     */
     this.rewind = function ($editable) {
-        triggerOnBeforeChange($editable);
-        $editable.data('NoteHistory').rewind();
-        triggerOnChange($editable);
+      triggerOnBeforeChange($editable);
+      $editable.data('NoteHistory').rewind();
+      triggerOnChange($editable);
     };
 
     /**
-     * @method undo
-     * undo
-     * @param {jQuery} $editable
-     */
+    * @method undo
+    * undo
+    * @param {jQuery} $editable
+    */
     this.undo = function ($editable) {
       triggerOnBeforeChange($editable);
       $editable.data('NoteHistory').undo();


### PR DESCRIPTION
#### What does this PR do?
* Allows a developer to clear the contents of the editor; preventing `undo` from restoring the editor's previous contents.
* Allows a developer to rewind all changes made to the editor since it was initialised. Equivalent to `undo`, `undo`, `undo`, `undo` ..., but in a single step.
* Adds "reset" and "rewind" methods to History.
* Exposes methods publicly via the Editor API (see below)


#### How should this be manually tested?
* Create an editor.
* Type something in it.
* Call either of the new API methods below.


#### What are the relevant tickets?
* Fixes my own feature-request issue: #1321 


----

## reset
````
$('.summernote').summernote('editor.reset');
````
Resets the history stack completely; reverting to an empty editor.

## rewind
````
$('.summernote').summernote('editor.rewind');
````
Rewinds the history stack back to the first snapshot taken.
Leaves the stack intact, so that "Redo" can still be used.