### PR TITLE
Extend instagram regex in video plugin

### DIFF
--- a/plugin/summernote-ext-video.js
+++ b/plugin/summernote-ext-video.js
@@ -28,7 +28,7 @@
     var ytRegExp = /^(?:https?:\/\/)?(?:www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/;
     var ytMatch = url.match(ytRegExp);
 
-    var igRegExp = /\/\/instagram.com\/p\/(.[a-zA-Z0-9]*)/;
+    var igRegExp = /\/\/instagram.com\/p\/(.[a-zA-Z0-9_-]*)/;
     var igMatch = url.match(igRegExp);
 
     var vRegExp = /\/\/vine.co\/v\/(.[a-zA-Z0-9]*)/;


### PR DESCRIPTION
Instagram image ids may contain dashes or underscores (e.g. https://instagram.com/p/7WNy-_KRij/). In this example the current pattern only matches https://instagram.com/p/7WNy and strips everthing after - or _.