### PR TITLE
Reduce code with wrapCommand

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -251,42 +251,46 @@ define([
     };
 
     /**
+     * wrapCommand
+     * run given function between beforeCommand and afterCommand
+     * @param {Boolean} isPreventTrigger
+     */
+    this.wrapCommand = function (fn) {
+      var that = this;
+      return function () {
+        beforeCommand();
+        fn.apply(that, arguments);
+        afterCommand();
+      };
+    };
+
+    /**
      * insertParagraph
      *
      * insert paragraph
      */
-    this.insertParagraph = function () {
-      beforeCommand();
+    this.insertParagraph = this.wrapCommand(function () {
       typing.insertParagraph($editable);
-      afterCommand();
-    };
+    });
 
     /**
      * insertOrderedList
      */
-    this.insertOrderedList = function () {
-      beforeCommand();
+    this.insertOrderedList = this.wrapCommand(function () {
       bullet.insertOrderedList($editable);
-      afterCommand();
-    };
+    });
 
-    this.insertUnorderedList = function () {
-      beforeCommand();
+    this.insertUnorderedList = this.wrapCommand(function () {
       bullet.insertUnorderedList($editable);
-      afterCommand();
-    };
+    });
 
-    this.indent = function () {
-      beforeCommand();
+    this.indent = this.wrapCommand(function () {
       bullet.indent($editable);
-      afterCommand();
-    };
+    });
 
-    this.outdent = function () {
-      beforeCommand();
+    this.outdent = this.wrapCommand(function () {
       bullet.outdent($editable);
-      afterCommand();
-    };
+    });
 
     /**
      * insert image
@@ -313,52 +317,42 @@ define([
      * insert node
      * @param {Node} node
      */
-    this.insertNode = function (node) {
-      beforeCommand();
+    this.insertNode = this.wrapCommand(function (node) {
       range.create().insertNode(node);
       range.createFromNodeAfter(node).select();
-      afterCommand();
-    };
+    });
 
     /**
      * insert text
      * @param {String} text
      */
-    this.insertText = function (text) {
-      beforeCommand();
+    this.insertText = this.wrapCommand(function (text) {
       var textNode = range.create().insertNode(dom.createText(text));
       range.create(textNode, dom.nodeLength(textNode)).select();
-      afterCommand();
-    };
+    });
 
     /**
      * paste HTML
      * @param {String} markup
      */
-    this.pasteHTML = function (markup) {
-      beforeCommand();
+    this.pasteHTML = this.wrapCommand(function (markup) {
       var contents = range.create().pasteHTML(markup);
       range.createFromNodeAfter(list.last(contents)).select();
-      afterCommand();
-    };
+    });
 
     /**
      * formatBlock
      *
      * @param {String} tagName
      */
-    this.formatBlock = function (tagName) {
-      beforeCommand();
+    this.formatBlock = this.wrapCommand(function (tagName) {
       // [workaround] for MSIE, IE need `<`
       tagName = agent.isMSIE ? '<' + tagName + '>' : tagName;
       document.execCommand('FormatBlock', false, tagName);
-      afterCommand();
-    };
+    });
 
     this.formatPara = function () {
-      beforeCommand();
       this.formatBlock('P');
-      afterCommand();
     };
 
     /* jshint ignore:start */
@@ -406,17 +400,13 @@ define([
     /**
      * insert horizontal rule
      */
-    this.insertHorizontalRule = function () {
-      beforeCommand();
-
+    this.insertHorizontalRule = this.wrapCommand(function () {
       var rng = range.create();
       var hrNode = rng.insertNode($('<HR/>')[0]);
       if (hrNode.nextSibling) {
         range.create(hrNode.nextSibling, 0).normalize().select();
       }
-
-      afterCommand();
-    };
+    });
 
     /**
      * remove bogus node and character
@@ -445,13 +435,11 @@ define([
      * lineHeight
      * @param {String} value
      */
-    this.lineHeight = function (value) {
-      beforeCommand();
+    this.lineHeight = this.wrapCommand(function (value) {
       style.stylePara(range.create(), {
         lineHeight: value
       });
-      afterCommand();
-    };
+    });
 
     /**
      * unlink
@@ -476,14 +464,12 @@ define([
      *
      * @param {Object} linkInfo
      */
-    this.createLink = function (linkInfo) {
+    this.createLink = this.wrapCommand(function (linkInfo) {
       var linkUrl = linkInfo.url;
       var linkText = linkInfo.text;
       var isNewWindow = linkInfo.isNewWindow;
       var rng = linkInfo.range || this.createRange();
       var isTextChanged = rng.toString() !== linkText;
-
-      beforeCommand();
 
       if (options.onCreateLink) {
         linkUrl = options.onCreateLink(linkUrl);
@@ -522,9 +508,7 @@ define([
         endPoint.node,
         endPoint.offset
       ).select();
-
-      afterCommand();
-    };
+    });
 
     /**
      * returns link info
@@ -558,59 +542,47 @@ define([
      * @param {String} sObjColor.foreColor foreground color
      * @param {String} sObjColor.backColor background color
      */
-    this.color = function (colorInfo) {
+    this.color = this.wrapCommand(function (colorInfo) {
       var foreColor = colorInfo.foreColor;
       var backColor = colorInfo.backColor;
 
-      beforeCommand();
-
       if (foreColor) { document.execCommand('foreColor', false, foreColor); }
       if (backColor) { document.execCommand('backColor', false, backColor); }
-
-      afterCommand();
-    };
+    });
 
     /**
      * insert Table
      *
      * @param {String} sDim dimension of table (ex : "5x5")
      */
-    this.insertTable = function (sDim) {
+    this.insertTable = this.wrapCommand(function (sDim) {
       var dimension = sDim.split('x');
-      beforeCommand();
 
       var rng = range.create().deleteContents();
       rng.insertNode(table.createTable(dimension[0], dimension[1], options));
-      afterCommand();
-    };
+    });
 
     /**
      * float me
      *
      * @param {String} value
      */
-    this.floatMe = function (value) {
-      beforeCommand();
+    this.floatMe = this.wrapCommand(function (value) {
       var $target = $(this.restoreTarget());
       $target.css('float', value);
-      afterCommand();
-    };
+    });
 
     /**
      * resize overlay element
      * @param {String} value
      */
-    this.resize = function (value) {
-      beforeCommand();
-
+    this.resize = this.wrapCommand(function (value) {
       var $target = $(this.restoreTarget());
       $target.css({
         width: value * 100 + '%',
         height: ''
       });
-
-      afterCommand();
-    };
+    });
 
     /**
      * @param {Position} pos
@@ -639,12 +611,10 @@ define([
     /**
      * remove media object
      */
-    this.removeMedia = function () {
-      beforeCommand();
+    this.removeMedia = this.wrapCommand(function () {
       var $target = $(this.restoreTarget()).detach();
       summernote.triggerEvent('media.delete', $target, $editable);
-      afterCommand();
-    };
+    });
 
     /**
      * set focus

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -252,14 +252,13 @@ define([
 
     /**
      * wrapCommand
+     *
      * run given function between beforeCommand and afterCommand
-     * @param {Boolean} isPreventTrigger
      */
     this.wrapCommand = function (fn) {
-      var that = this;
       return function () {
         beforeCommand();
-        fn.apply(that, arguments);
+        fn.apply(self, arguments);
         afterCommand();
       };
     };


### PR DESCRIPTION
There were several codes using `beforeCommand` and `afterCommand` in `Editor.js`.
They have same patterns so I removed it via `wrapCommand` wrapper.