### PR TITLE
Prevent Firefox from submitting form by clicking toolbar button

### DIFF
--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -20,7 +20,7 @@ define([
   var airEditable = renderer.create('<div class="note-editable" contentEditable="true"/>');
 
   var buttonGroup = renderer.create('<div class="note-btn-group btn-group">');
-  var button = renderer.create('<button class="note-btn btn btn-default btn-sm">', function ($node, options) {
+  var button = renderer.create('<button type="button" class="note-btn btn btn-default btn-sm">', function ($node, options) {
     if (options && options.tooltip) {
       $node.attr({
         title: options.tooltip


### PR DESCRIPTION
Fix to prevent Firefox from submitting form while clicking button without type attribute set.