### PR TITLE
Fixed bugs related with image dialog.

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -650,7 +650,11 @@ define([
      * set focus
      */
     this.focus = function () {
-      $editable.focus();
+      // [workaround] Screen will move when page is scolled in IE.
+      //  - do focus when not focused
+      if (!$editable.is(':focus')) {
+        $editable.focus();
+      }
 
       // [workaround] for firefox bug http://goo.gl/lVfAaI
       if (agent.isFF) {

--- a/src/js/bs3/module/ImageDialog.js
+++ b/src/js/bs3/module/ImageDialog.js
@@ -78,6 +78,8 @@ define([
     this.show = function () {
       context.invoke('editor.saveRange');
       this.showImageDialog().then(function (data) {
+        // [workaround] hide dialog before restore range for IE range focus
+        ui.hideDialog(self.$dialog);
         context.invoke('editor.restoreRange');
 
         if (typeof data === 'string') {
@@ -109,7 +111,6 @@ define([
           $imageInput.replaceWith($imageInput.clone()
             .on('change', function () {
               deferred.resolve(this.files || this.value);
-              ui.hideDialog(self.$dialog);
             })
             .val('')
           );
@@ -118,7 +119,6 @@ define([
             event.preventDefault();
 
             deferred.resolve($imageUrl.val());
-            ui.hideDialog(self.$dialog);
           });
 
           $imageUrl.on('keyup paste', function () {

--- a/src/js/bs3/module/ImageDialog.js
+++ b/src/js/bs3/module/ImageDialog.js
@@ -121,15 +121,8 @@ define([
             ui.hideDialog(self.$dialog);
           });
 
-          $imageUrl.on('keyup paste', function (event) {
-            var url;
-            
-            if (event.type === 'paste') {
-              url = event.originalEvent.clipboardData.getData('text');
-            } else {
-              url = $imageUrl.val();
-            }
-            
+          $imageUrl.on('keyup paste', function () {
+            var url = $imageUrl.val();
             ui.toggleBtn($imageBtn, url);
           }).val('').trigger('focus');
           self.bindEnterKey($imageUrl, $imageBtn);

--- a/src/js/bs3/module/VideoDialog.js
+++ b/src/js/bs3/module/VideoDialog.js
@@ -136,6 +136,8 @@ define([
       var text = this.getTextOnRange();
       context.invoke('editor.saveRange');
       this.showVideoDialog(text).then(function (url) {
+        // [workaround] hide dialog before restore range for IE range focus
+        ui.hideDialog(self.$dialog);
         context.invoke('editor.restoreRange');
 
         // build node
@@ -171,7 +173,6 @@ define([
             event.preventDefault();
 
             deferred.resolve($videoUrl.val());
-            ui.hideDialog(self.$dialog);
           });
 
           self.bindEnterKey($videoUrl, $videoBtn);


### PR DESCRIPTION
#### What does this PR do?

- Do focus when not focused
- Fixed script error when user paste image's url on input on image dialog.
- Fixed image insertion always first line in IE11. Fixed #1364, #1060.

#### How should this be manually tested?
- Insert image at middle of text in IE11.
- Click bold button in IE. If screen is not moved fixed.
- Paste image's url at url input on imageDialog in IE11.