### PR TITLE
Update .scss to reflect .less changes from #1220

### DIFF
--- a/src/sass/summernote.scss
+++ b/src/sass/summernote.scss
@@ -61,11 +61,6 @@ $background-color: #f5f5f5 !default;
     display: table;
   }
 
-  .note-toolbar {
-    margin: -5px -10px 0 -10px;
-    padding: 0;
-  }
-
   /* fullscreen mode */
   &.fullscreen {
     position: fixed;
@@ -170,7 +165,7 @@ $background-color: #f5f5f5 !default;
 
 /* Popover and Toolbar (Button container)
  ------------------------------------------*/
-.note-popover .popover .popover-content, .note-toolbar {
+.note-popover .popover .popover-content, .panel-heading.note-toolbar {
   margin: 0;
   padding: 0 0 5px 5px;
 


### PR DESCRIPTION
#1220 included some breaking changes for `.scss` which were never fixed. This fix reflects the [deletions made to the `.less` stylesheet](https://github.com/summernote/summernote/commit/0acbe268f89c6ea9e7eeb6d9d88e7ae365c71a6e#diff-190bd6171ffd5ae2b277799c87eaf7fc) committed by @hackerwins.