### PR TITLE
Update version and fixed #228

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "summernote",
   "description": "Super simple WYSIWYG editor",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "keywords": [
     "editor",

--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -100,6 +100,8 @@ define([
       return node && /^H[1-7]/.test(node.nodeName.toUpperCase());
     };
 
+    var isPre = makePredByNodeName('PRE');
+
     var isLi = makePredByNodeName('LI');
 
     var isPurePara = function (node) {
@@ -1004,6 +1006,7 @@ define([
       isBodyInline: isBodyInline,
       isBody: isBody,
       isParaInline: isParaInline,
+      isPre: isPre,
       isList: isList,
       isTable: isTable,
       isCell: isCell,

--- a/src/js/base/editing/Typing.js
+++ b/src/js/base/editing/Typing.js
@@ -70,8 +70,8 @@ define([
             dom.remove(anchor);
           });
 
-          // replace empty heading with P tag
-          if (dom.isHeading(nextPara) && dom.isEmpty(nextPara)) {
+          // replace empty heading or pre with P tag
+          if ((dom.isHeading(nextPara) || dom.isPre(nextPara)) && dom.isEmpty(nextPara)) {
             nextPara = dom.replace(nextPara, 'p');
           }
         }


### PR DESCRIPTION
#### What does this PR do?
 * fixed #228
 * In `<pre>` only continue in the code block if Shift+Enter is clicked, while if Enter is clicked it should exit the code block and continue with normal formatting.