### PR TITLE
Add missing locales (spanish and catalan)

### DIFF
--- a/lang/summernote-ca-ES.js
+++ b/lang/summernote-ca-ES.js
@@ -7,7 +7,10 @@
         underline: 'Subratllat',
         clear: 'Treure estil de lletra',
         height: 'Alçada de línia',
+        name: 'Font',
         strikethrough: 'Ratllat',
+        subscript: 'Subíndex',
+        superscript: 'Superíndex',
         size: 'Mida de lletra'
       },
       image: {
@@ -16,18 +19,26 @@
         resizeFull: 'Redimensionar a mida completa',
         resizeHalf: 'Redimensionar a la meitat',
         resizeQuarter: 'Redimensionar a un quart',
-        floatLeft: 'Surar a l%27esquerra',
-        floatRight: 'Surar a la dreta',
-        floatNone: 'No surar',
-        dragImageHere: 'Arrossegueu una imatge aquí',
+        floatLeft: 'Alinear a l\'esquerra',
+        floatRight: 'Alinear a la dreta',
+        floatNone: 'No alinear',
+        shapeRounded: 'Forma: Arrodonit',
+        shapeCircle: 'Forma: Cercle',
+        shapeThumbnail: 'Forma: Marc',
+        shapeNone: 'Forma: Cap',
+        dragImageHere: 'Arrossegueu una imatge o text aquí',
+        dropImage: 'Deixa anar aquí una imatge o un text',
         selectFromFiles: 'Seleccioneu des dels arxius',
-        url: 'URL de la imatge'
+        maximumFileSize: 'Mida màxima de l\'arxiu',
+        maximumFileSizeError: 'La mida màxima de l\'arxiu s\'ha superat.',
+        url: 'URL de la imatge',
+        remove: 'Eliminar imatge'
       },
       video: {
-        video: 'Video',
-        videoLink: 'Enllaç del video',
-        insert: 'Inserir video',
-        url: 'URL del video?',
+        video: 'Vídeo',
+        videoLink: 'Enllaç del vídeo',
+        insert: 'Inserir vídeo',
+        url: 'URL del vídeo?',
         providers: '(YouTube, Vimeo, Vine, Instagram, DailyMotion, o Youku)'
       },
       link: {
@@ -91,11 +102,45 @@
         textFormatting: 'Format de text',
         action: 'Acció',
         paragraphFormatting: 'Format de paràgraf',
-        documentStyle: 'Estil del document'
+        documentStyle: 'Estil del document',
+        extraKeys: 'Tecles adicionals'
+      },
+      help : {
+        'insertParagraph': 'Inserir paràgraf',
+        'undo': 'Desfer l\'última acció',
+        'redo': 'Refer l\'última acció',
+        'tab': 'Tabular',
+        'untab': 'Eliminar tabulació',
+        'bold': 'Establir estil negreta',
+        'italic': 'Establir estil cursiva',
+        'underline': 'Establir estil subratllat',
+        'strikethrough': 'Establir estil ratllat',
+        'removeFormat': 'Netejar estil',
+        'justifyLeft': 'Alinear a l\'esquerra',
+        'justifyCenter': 'Alinear al centre',
+        'justifyRight': 'Alinear a la dreta',
+        'justifyFull': 'Justificar',
+        'insertUnorderedList': 'Inserir llista desendreçada',
+        'insertOrderedList': 'Inserir llista endreçada',
+        'outdent': 'Reduïr tabulació del paràgraf',
+        'indent': 'Augmentar tabulació del paràgraf',
+        'formatPara': 'Canviar l\'estil del bloc com a un paràgraf (etiqueta P)',
+        'formatH1': 'Canviar l\'estil del bloc com a un H1',
+        'formatH2': 'Canviar l\'estil del bloc com a un H2',
+        'formatH3': 'Canviar l\'estil del bloc com a un H3',
+        'formatH4': 'Canviar l\'estil del bloc com a un H4',
+        'formatH5': 'Canviar l\'estil del bloc com a un H5',
+        'formatH6': 'Canviar l\'estil del bloc com a un H6',
+        'insertHorizontalRule': 'Inserir una línia horitzontal',
+        'linkDialog.show': 'Mostrar panel d\'enllaços'
       },
       history: {
         undo: 'Desfer',
         redo: 'Refer'
+      },
+      specialChar: {
+        specialChar: 'CARÀCTERS ESPECIALS',
+        select: 'Selecciona caràcters especials'
       }
     }
   });

--- a/lang/summernote-es-ES.js
+++ b/lang/summernote-es-ES.js
@@ -22,15 +22,23 @@
         floatLeft: 'Flotar a la izquierda',
         floatRight: 'Flotar a la derecha',
         floatNone: 'No flotar',
-        dragImageHere: 'Arrastrar una imagen aquí',
+        shapeRounded: 'Forma: Redondeado',
+        shapeCircle: 'Forma: Círculo',
+        shapeThumbnail: 'Forma: Marco',
+        shapeNone: 'Forma: Ninguna',
+        dragImageHere: 'Arrastrar una imagen o texto aquí',
+        dropImage: 'Suelta la imagen o texto',
         selectFromFiles: 'Seleccionar desde los archivos',
-        url: 'URL de la imagen'
+        maximumFileSize: 'Tamaño máximo del archivo',
+        maximumFileSizeError: 'Has superado el tamaño máximo del archivo.',
+        url: 'URL de la imagen',
+        remove: 'Eliminar imagen'
       },
       video: {
-        video: 'Video',
-        videoLink: 'Link del video',
-        insert: 'Insertar video',
-        url: '¿URL del video?',
+        video: 'Vídeo',
+        videoLink: 'Link del vídeo',
+        insert: 'Insertar vídeo',
+        url: '¿URL del vídeo?',
         providers: '(YouTube, Vimeo, Vine, Instagram, DailyMotion, o Youku)'
       },
       link: {
@@ -94,11 +102,45 @@
         textFormatting: 'Formato de texto',
         action: 'Acción',
         paragraphFormatting: 'Formato de párrafo',
-        documentStyle: 'Estilo de documento'
+        documentStyle: 'Estilo de documento',
+        extraKeys: 'Teclas adicionales'
+      },
+      help : {
+        'insertParagraph': 'Insertar párrafo',
+        'undo': 'Deshacer última acción',
+        'redo': 'Rehacer última acción',
+        'tab': 'Tabular',
+        'untab': 'Eliminar tabulación',
+        'bold': 'Establecer estilo negrita',
+        'italic': 'Establecer estilo cursiva',
+        'underline': 'Establecer estilo subrayado',
+        'strikethrough': 'Establecer estilo tachado',
+        'removeFormat': 'Limpiar estilo',
+        'justifyLeft': 'Alinear a la izquierda',
+        'justifyCenter': 'Alinear al centro',
+        'justifyRight': 'Alinear a la derecha',
+        'justifyFull': 'Justificar',
+        'insertUnorderedList': 'Insertar lista desordenada',
+        'insertOrderedList': 'Insertar lista ordenada',
+        'outdent': 'Reducir tabulación del párrafo',
+        'indent': 'Aumentar tabulación del párrafo',
+        'formatPara': 'Cambiar estilo del bloque a párrafo (etiqueta P)',
+        'formatH1': 'Cambiar estilo del bloque a H1',
+        'formatH2': 'Cambiar estilo del bloque a H2',
+        'formatH3': 'Cambiar estilo del bloque a H3',
+        'formatH4': 'Cambiar estilo del bloque a H4',
+        'formatH5': 'Cambiar estilo del bloque a H5',
+        'formatH6': 'Cambiar estilo del bloque a H6',
+        'insertHorizontalRule': 'Insertar línea horizontal',
+        'linkDialog.show': 'Mostrar panel enlaces'
       },
       history: {
         undo: 'Deshacer',
         redo: 'Rehacer'
+      },
+      specialChar: {
+        specialChar: 'CARACTERES ESPECIALES',
+        select: 'Selecciona Caracteres especiales'
       }
     }
   });


### PR DESCRIPTION
#### What does this PR do?

- Adds some missing translations to the spanish and catalan locale files (some of the keys defined in `summernote/src/js/base/summernote-en-US.js` where not defined on those locales)

#### Where should the reviewer start?

- `summernote/lang/summernote-es-ES.js`
- `summernote/lang/summernote-ca-ES.js`

#### What are the relevant tickets?

#1465

### Checklist
- [x] didn't break anything