### PR TITLE
disable or enable editor

### DIFF
--- a/src/js/bs3/module/HelpDialog.js
+++ b/src/js/bs3/module/HelpDialog.js
@@ -10,7 +10,6 @@ define([
     var options = context.options;
     var lang = options.langInfo;
 
-
     this.createShortCutList = function () {
       var keyMap = options.keyMap[agent.isMac ? 'mac' : 'pc'];
 

--- a/src/js/bs3/module/Toolbar.js
+++ b/src/js/bs3/module/Toolbar.js
@@ -43,13 +43,19 @@ define(function () {
       }
     };
 
-    this.activate = function () {
-      var $btn = $toolbar.find('button').not('.btn-codeview');
+    this.activate = function (isIncludeCodeview) {
+      var $btn = $toolbar.find('button');
+      if (!isIncludeCodeview) {
+        $btn = $btn.not('.btn-codeview');
+      }
       ui.toggleBtn($btn, true);
     };
 
-    this.deactivate = function () {
-      var $btn = $toolbar.find('button').not('.btn-codeview');
+    this.deactivate = function (isIncludeCodeview) {
+      var $btn = $toolbar.find('button');
+      if (!isIncludeCodeview) {
+        $btn = $btn.not('.btn-codeview');
+      }
       ui.toggleBtn($btn, false);
     };
   };

--- a/src/js/summernote.js
+++ b/src/js/summernote.js
@@ -73,6 +73,20 @@ define([
       }
     };
 
+    this.isDisabled = function () {
+      return this.layoutInfo.editable.attr('contenteditable') === 'false';
+    };
+
+    this.enable = function () {
+      this.layoutInfo.editable.attr('contenteditable', true);
+      this.invoke('toolbar.activate', true);
+    };
+
+    this.disable = function () {
+      this.layoutInfo.editable.attr('contenteditable', false);
+      this.invoke('toolbar.deactivate', true);
+    };
+
     this.triggerEvent = function () {
       var namespace = list.head(arguments);
       var args = list.tail(list.from(arguments));

--- a/src/js/summernote.js
+++ b/src/js/summernote.js
@@ -83,6 +83,10 @@ define([
     };
 
     this.disable = function () {
+      // close codeview if codeview is opend
+      if (this.invoke('codeview.isActivated')) {
+        this.invoke('codeview.deactivate');
+      }
       this.layoutInfo.editable.attr('contenteditable', false);
       this.invoke('toolbar.deactivate', true);
     };


### PR DESCRIPTION
#### What does this PR do?
- disable or enable editor

#### Where should the reviewer start?
- start on the src/summernote.js

#### How should this be manually tested?
- `$('.summernote').summernote('enable')` to enable editor
- `$('.summernote').summernote('disable')` to disable editor

#### What are the relevant tickets?
- #61, #231, #1398, #1109 