### PR TITLE
add hint direction (top, bottom)

### DIFF
--- a/examples/hint-emoji.html
+++ b/examples/hint-emoji.html
@@ -31,7 +31,7 @@
 
         $('.summernote').summernote({
           height: 300,
-          hintDirection : 'top',
+          hintDirection: 'top',
           hint: [{
             search: function (keyword, callback) {
               callback($.grep(emojis, function (item) {

--- a/examples/hint-emoji.html
+++ b/examples/hint-emoji.html
@@ -31,6 +31,7 @@
 
         $('.summernote').summernote({
           height: 300,
+          hintDirection : 'top',
           hint: [{
             search: function (keyword, callback) {
               callback($.grep(emojis, function (item) {

--- a/src/js/bs3/module/HintPopover.js
+++ b/src/js/bs3/module/HintPopover.js
@@ -36,8 +36,8 @@ define([
       this.lastWordRange = null;
       this.$popover = ui.popover({
         className: 'note-hint-popover',
-        hideArrow : true,
-        direction : ''
+        hideArrow: true,
+        direction: ''
       }).render().appendTo('body');
 
       this.$popover.hide();

--- a/src/js/bs3/module/HintPopover.js
+++ b/src/js/bs3/module/HintPopover.js
@@ -9,7 +9,9 @@ define([
     var self = this;
     var ui = $.summernote.ui;
 
+    var POPOVER_DIST = 5;
     var hint = context.options.hint || [];
+    var direction = context.options.hintDirection || 'bottom';
     var hints = $.isArray(hint) ? hint : [hint];
 
     this.events = {
@@ -33,8 +35,12 @@ define([
     this.initialize = function () {
       this.lastWordRange = null;
       this.$popover = ui.popover({
-        className: 'note-hint-popover'
+        className: 'note-hint-popover',
+        hideArrow : true,
+        direction : ''
       }).render().appendTo('body');
+
+      this.$popover.hide();
 
       this.$content = this.$popover.find('.popover-content');
 
@@ -92,13 +98,17 @@ define([
 
     this.replace = function () {
       var $item = this.$content.find('.note-hint-item.active');
-      var node = this.nodeFromItem($item);
-      this.lastWordRange.insertNode(node);
-      range.createFromNode(node).collapse().select();
 
-      this.lastWordRange = null;
-      this.hide();
-      context.invoke('editor.focus');
+      if ($item.length) {
+        var node = this.nodeFromItem($item);
+        this.lastWordRange.insertNode(node);
+        range.createFromNode(node).collapse().select();
+
+        this.lastWordRange = null;
+        this.hide();
+        context.invoke('editor.focus');
+      }
+
     };
 
     this.nodeFromItem = function ($item) {
@@ -183,10 +193,8 @@ define([
 
           var bnd = func.rect2bnd(list.last(wordRange.getClientRects()));
           if (bnd) {
-            this.$popover.css({
-              left: bnd.left,
-              top: bnd.top + bnd.height
-            }).hide();
+
+            this.$popover.hide();
 
             this.lastWordRange = wordRange;
 
@@ -195,6 +203,20 @@ define([
                 self.createGroup(idx, keyword).appendTo(self.$content);
               }
             });
+
+            // set position for popover after group is created
+            if (direction === 'top') {
+              this.$popover.css({
+                left: bnd.left,
+                top: bnd.top - this.$popover.outerHeight() - POPOVER_DIST
+              });
+            } else {
+              this.$popover.css({
+                left: bnd.left,
+                top: bnd.top + bnd.height + POPOVER_DIST
+              });
+            }
+
           }
         } else {
           this.hide();

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -100,7 +100,7 @@ define([
     '  <div class="popover-content note-children-container"/>',
     '</div>'
   ].join(''), function ($node, options) {
-    var direction = typeof options.direction !== 'undefined' ? options.direction  :  'bottom';
+    var direction = typeof options.direction !== 'undefined' ? options.direction : 'bottom';
 
     $node.addClass(direction);
 

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -95,11 +95,19 @@ define([
   });
 
   var popover = renderer.create([
-    '<div class="note-popover popover bottom in">',
+    '<div class="note-popover popover in">',
     '  <div class="arrow"/>',
     '  <div class="popover-content note-children-container"/>',
     '</div>'
-  ].join(''));
+  ].join(''), function ($node, options) {
+    var direction = typeof options.direction !== 'undefined' ? options.direction  :  'bottom';
+
+    $node.addClass(direction);
+
+    if (options.hideArrow) {
+      $node.find('.arrow').hide();
+    }
+  });
 
   var icon = function (iconClassName, tagName) {
     tagName = tagName || 'i';


### PR DESCRIPTION
#### What does this PR do?

- add direction for hint popover 
- hint popover has two directions (top and bottom)
- you can use it by hintDirection Option 

#### Where should the reviewer start?

- start on the src/bs3/module/HintPopover.js

#### How should this be manually tested?

set hintDirection option

```javascript

$(".summernote").summernote({
    hintDirection : 'top',
    hint : {
         ... // code  
    }
});
```

#### What are the relevant tickets?

#1515

#### Screenshots (if for frontend)
<img width="410" alt="2015-12-29 1 17 18" src="https://cloud.githubusercontent.com/assets/591983/12021413/f30e5ef0-adc9-11e5-96aa-a55be5fe2ab4.png">