### PR TITLE
Prevent focusing on editable when invoke('code') is executed.

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -719,16 +719,23 @@ define([
     });
 
     /**
+     * returns whether editable area has focus or not.
+     */
+    this.hasFocus = function () {
+      return $editable.is(':focus');
+    };
+
+    /**
      * set focus
      */
     this.focus = function () {
       // [workaround] Screen will move when page is scolled in IE.
       //  - do focus when not focused
-      if (!$editable.is(':focus')) {
+      if (!this.hasFocus()) {
         $editable.focus();
 
         // [workaround] for firefox bug http://goo.gl/lVfAaI
-        if (!$editable.is(':focus') && agent.isFF) {
+        if (!this.hasFocus() && agent.isFF) {
           range.createFromNode($editable[0])
                .normalize()
                .collapse()

--- a/src/js/bs3/module/LinkPopover.js
+++ b/src/js/bs3/module/LinkPopover.js
@@ -40,6 +40,12 @@ define([
     };
 
     this.update = function () {
+      // Prevent focusing on editable when invoke('code') is executed
+      if (!context.invoke('editor.hasFocus')) {
+        this.hide();
+        return;
+      }
+
       var rng = context.invoke('editor.createRange');
       if (rng.isCollapsed() && rng.isOnAnchor()) {
         var anchor = dom.ancestor(rng.sc, dom.isAnchor);


### PR DESCRIPTION
#### What does this PR do?

- Prevent focus when `invoke('code')` is executed.

#### How should this be manually tested?

- 1. initialize editor with onChange callback
```
$('.summernote').summernote({
  callbacks: {
    onChange: function () {
      console.log('change');
    }
  }
});
```
- 2. Open developer tools and execute below codes.
```
$('.summernote').summernote('code');
console.log($('.summernote').summernote('hasFocus'));
```

#### What are the relevant tickets?
#1564, #1504, #1552