### PR TITLE
Fixed #1410 using a configurable blockquote breaking level.

### DIFF
--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -731,11 +731,17 @@ define([
      * @param {Object} [options]
      * @param {Boolean} [options.isSkipPaddingBlankHTML] - default: false
      * @param {Boolean} [options.isNotSplitEdgePoint] - default: false
+     * @param {Boolean} [options.isDiscardEmptySplits] - default: false, implies: isSkipPaddingBlankHTML
      * @return {Node} right node of boundaryPoint
      */
     var splitNode = function (point, options) {
       var isSkipPaddingBlankHTML = options && options.isSkipPaddingBlankHTML;
       var isNotSplitEdgePoint = options && options.isNotSplitEdgePoint;
+      var isDiscardEmptySplits = options && options.isDiscardEmptySplits;
+
+      if (isDiscardEmptySplits) {
+        isSkipPaddingBlankHTML = true;
+      }
 
       // edge case
       if (isEdgePoint(point) && (isText(point.node) || isNotSplitEdgePoint)) {
@@ -757,6 +763,18 @@ define([
         if (!isSkipPaddingBlankHTML) {
           paddingBlankHTML(point.node);
           paddingBlankHTML(clone);
+        }
+
+        if (isDiscardEmptySplits) {
+          if (isEmpty(point.node)) {
+            remove(point.node);
+          }
+
+          if (isEmpty(clone)) {
+            remove(clone);
+
+            return point.node.nextSibling;
+          }
         }
 
         return clone;

--- a/src/js/base/editing/Typing.js
+++ b/src/js/base/editing/Typing.js
@@ -10,10 +10,10 @@ define([
    * Typing
    *
    */
-  var Typing = function () {
+  var Typing = function (context) {
 
-    // a Bullet instance to toggle lists off
-    var bullet = new Bullet();
+    var bullet = new Bullet(), // a Bullet instance to toggle lists off
+        options = $.extend({ blockquoteBreakingLevel: 2 }, context && context.options); // Break all levels by default
 
     /**
      * insert tab
@@ -33,9 +33,12 @@ define([
 
     /**
      * insert paragraph
+     *
+     * @param {jQuery} $editable
+     * @param {WrappedRange} rng Can be used in unit tests to "mock" the range
      */
-    this.insertParagraph = function ($editable) {
-      var rng = range.create();
+    this.insertParagraph = function ($editable, rng) {
+      rng = rng || range.create();
 
       // deleteContents on range.
       rng = rng.deleteContents();
@@ -43,10 +46,10 @@ define([
       // Wrap range if it needs to be wrapped by paragraph
       rng = rng.wrapBodyInlineWithPara();
 
-      // finding paragraph
-      var splitRoot = dom.ancestor(rng.sc, dom.isPara);
+      var splitRoot = dom.ancestor(rng.sc, dom.isPara), // finding paragraph
+          nextPara,
+          blockquoteBreakingLevel = options.blockquoteBreakingLevel;
 
-      var nextPara;
       // on paragraph: split paragraph
       if (splitRoot) {
         // if it is an empty line with li
@@ -54,25 +57,47 @@ define([
           // toogle UL/OL and escape
           bullet.toggleList(splitRoot.parentNode.nodeName);
           return;
-        // if it is an empty line with para on blockquote
-        } else if (dom.isEmpty(splitRoot) && dom.isPara(splitRoot) && dom.isBlockquote(splitRoot.parentNode)) {
-          // escape blockquote
-          dom.insertAfter(splitRoot, splitRoot.parentNode);
-          nextPara = splitRoot;
-        // if new line has content (not a line break)
         } else {
-          nextPara = dom.splitTree(splitRoot, rng.getStartPoint());
+          var blockquote = null;
 
-          var emptyAnchors = dom.listDescendant(splitRoot, dom.isEmptyAnchor);
-          emptyAnchors = emptyAnchors.concat(dom.listDescendant(nextPara, dom.isEmptyAnchor));
+          if (blockquoteBreakingLevel === 1) {
+            blockquote = dom.ancestor(splitRoot, dom.isBlockquote);
+          } else if (blockquoteBreakingLevel === 2) {
+            blockquote = dom.lastAncestor(splitRoot, dom.isBlockquote);
+          }
 
-          $.each(emptyAnchors, function (idx, anchor) {
-            dom.remove(anchor);
-          });
+          // We're inside a blockquote and options ask us to break it
+          if (blockquote) {
+            nextPara = $(dom.emptyPara)[0];
 
-          // replace empty heading or pre with P tag
-          if ((dom.isHeading(nextPara) || dom.isPre(nextPara)) && dom.isEmpty(nextPara)) {
-            nextPara = dom.replace(nextPara, 'p');
+            // If the split is right before a <br>, remove it so that there's no "empty line"
+            // after the split in the new blockquote created
+            if (dom.isRightEdgePoint(rng.getStartPoint()) && dom.isBR(rng.sc.nextSibling)) {
+              $(rng.sc.nextSibling).remove();
+            }
+
+            var split = dom.splitTree(blockquote, rng.getStartPoint(), { isDiscardEmptySplits: true });
+
+            if (split) {
+              split.parentNode.insertBefore(nextPara, split);
+            } else {
+              dom.insertAfter(nextPara, blockquote); // There's no split if we were at the end of the blockquote
+            }
+          // not a blockquote, just insert the paragraph
+          } else {
+            nextPara = dom.splitTree(splitRoot, rng.getStartPoint());
+
+            var emptyAnchors = dom.listDescendant(splitRoot, dom.isEmptyAnchor);
+            emptyAnchors = emptyAnchors.concat(dom.listDescendant(nextPara, dom.isEmptyAnchor));
+
+            $.each(emptyAnchors, function (idx, anchor) {
+              dom.remove(anchor);
+            });
+
+            // replace empty heading or pre with P tag
+            if ((dom.isHeading(nextPara) || dom.isPre(nextPara)) && dom.isEmpty(nextPara)) {
+              nextPara = dom.replace(nextPara, 'p');
+            }
           }
         }
       // no paragraph: insert empty paragraph

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -32,7 +32,7 @@ define([
 
     var style = new Style();
     var table = new Table();
-    var typing = new Typing();
+    var typing = new Typing(context);
     var bullet = new Bullet();
     var history = new History($editable);
 

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -106,6 +106,7 @@ define([
       shortcuts: true,
       textareaAutoSync: true,
       direction: null,
+      blockquoteBreakingLevel: 2,
 
       styleTags: ['p', 'blockquote', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
 

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -25,6 +25,7 @@ define([
       shortcuts: true,
       textareaAutoSync: true,
       direction: null,
+      blockquoteBreakingLevel: 2,
 
       callbacks: {
         onInit: null,

--- a/test/unit/base/core/dom.spec.js
+++ b/test/unit/base/core/dom.spec.js
@@ -268,6 +268,22 @@ define([
           helper.equalsToUpperCase($para.html(), '<b>b</b><u>u</u><s>strike</s><i>i</i>', expect);
           helper.equalsToUpperCase($para.next().html(), '<i><br></i>', expect); // right hand side
         });
+
+        it('should discard first split if empty and isDiscardEmptySplits=true', function () {
+          var $u = $para.find('u');
+          dom.splitTree($para[0], {node: $u[0], offset: 0 }, { isDiscardEmptySplits: true });
+
+          helper.equalsToUpperCase($para.html(), '<b>b</b>', expect);
+          helper.equalsToUpperCase($para.next().html(), '<u>u</u><s>strike</s><i>i</i>', expect); // right hand side
+        });
+
+        it('should discard second split if empty and isDiscardEmptySplits=true', function () {
+          var $u = $para.find('u');
+          dom.splitTree($para[0], {node: $u[0], offset: 1 }, { isDiscardEmptySplits: true });
+
+          helper.equalsToUpperCase($para.html(), '<b>b</b><u>u</u>', expect);
+          helper.equalsToUpperCase($para.next().html(), '<s>strike</s><i>i</i>', expect); // right hand side
+        });
       });
 
       describe('textNode case', function () {

--- a/test/unit/base/editing/Typing.spec.js
+++ b/test/unit/base/editing/Typing.spec.js
@@ -4,14 +4,89 @@
  * summernote may be freely distributed under the MIT license./
  */
 /* jshint unused: false */
+/* jshint -W101 */
 define([
   'chai',
+  'helper',
+  'summernote/base/core/range',
   'summernote/base/editing/Typing'
-], function (chai, Typing) {
+], function (chai, helper, range, Typing) {
   'use strict';
 
   var expect = chai.expect;
 
+  function typing(level) {
+    return new Typing({ options: { blockquoteBreakingLevel: level } });
+  }
+
   describe('base:editing.Typing', function () {
+
+    describe('insertParagraph', function () {
+
+      describe('blockquote breaking support', function () {
+
+        var $editable, quote;
+
+        function check(html) {
+          helper.equalsToUpperCase($editable.html(), html, expect);
+        }
+
+        beforeEach(function () {
+          $editable = $('<div class="note-editable"><blockquote id="1">Part1<blockquote id="2">Part2.1<br>Part2.2</blockquote>Part3</blockquote></div>');
+        });
+
+        it('should not break blockquote if blockquoteBreakingLevel=0', function () {
+          typing(0).insertParagraph($editable, range.create($('#2', $editable)[0].firstChild, 1));
+
+          check('<blockquote id="1">Part1<blockquote id="2"><p>P</p><p>art2.1<br>Part2.2</p></blockquote>Part3</blockquote>');
+        });
+
+        it('should break the first blockquote if blockquoteBreakingLevel=1', function () {
+          typing(1).insertParagraph($editable, range.create($('#2', $editable)[0].firstChild, 1));
+
+          check('<blockquote id="1">Part1<blockquote id="2"><p>P</p></blockquote><p><br></p><blockquote id="2"><p>art2.1<br>Part2.2</p></blockquote>Part3</blockquote>');
+        });
+
+        it('should break all blockquotes if blockquoteBreakingLevel=2', function () {
+          typing(2).insertParagraph($editable, range.create($('#2', $editable)[0].firstChild, 1));
+
+          check('<blockquote id="1">Part1<blockquote id="2"><p>P</p></blockquote></blockquote><p><br></p><blockquote id="1"><blockquote id="2"><p>art2.1<br>Part2.2</p></blockquote>Part3</blockquote>');
+        });
+
+        it('should break all blockquotes if option is not defined', function () {
+          typing().insertParagraph($editable, range.create($('#2', $editable)[0].firstChild, 1));
+
+          check('<blockquote id="1">Part1<blockquote id="2"><p>P</p></blockquote></blockquote><p><br></p><blockquote id="1"><blockquote id="2"><p>art2.1<br>Part2.2</p></blockquote>Part3</blockquote>');
+        });
+
+        it('should break all blockquotes if context is not given', function () {
+          new Typing().insertParagraph($editable, range.create($('#2', $editable)[0].firstChild, 1));
+
+          check('<blockquote id="1">Part1<blockquote id="2"><p>P</p></blockquote></blockquote><p><br></p><blockquote id="1"><blockquote id="2"><p>art2.1<br>Part2.2</p></blockquote>Part3</blockquote>');
+        });
+
+        it('should remove leading BR from split, when breaking is on the right edge of a line', function () {
+          typing(1).insertParagraph($editable, range.create($('#2', $editable)[0].firstChild, 7));
+
+          check('<blockquote id="1">Part1<blockquote id="2"><p>Part2.1</p></blockquote><p><br></p><blockquote id="2"><p>Part2.2</p></blockquote>Part3</blockquote>');
+        });
+
+        it('should insert new paragraph after the blockquote, if break happens at the end of the blockquote', function () {
+          typing().insertParagraph($editable, range.create($('#1', $editable)[0].lastChild, 5));
+
+          check('<blockquote id="1"><p>Part1<blockquote id="2">Part2.1<br>Part2.2</blockquote>Part3</p></blockquote><p><br></p>');
+        });
+
+        it('should insert new paragraph before the blockquote, if break happens at the beginning of the blockquote', function () {
+          typing().insertParagraph($editable, range.create($('#1', $editable)[0].firstChild, 0));
+
+          check('<p><br></p><blockquote id="1"><p>Part1<blockquote id="2">Part2.1<br>Part2.2</blockquote>Part3</p></blockquote>');
+        });
+
+      });
+
+    });
+
   });
+
 });


### PR DESCRIPTION
#### What does this PR do?
- Implement a configurable blockquote breaking level to tell summernote what to do when 'Enter' is pressed inside a blockquote. The levels are:
- 0 - No break, the new paragraph remains inside the quote
- 1 - Break the first blockquote in the ancestors list
- 2 - Break all blockquotes, so that the new paragraph is not quoted (this is the default)
#### Where should the reviewer start?
- start on src/js/base/editing/Typing.js
#### How should this be manually tested?
- Play with any sample editor, add blockquotes, nested blockquotes, etc. and try to break them with 'Enter' using various scenarios
#### Any background context you want to provide?
- We're currently developing a Angular-based webmail for the OpenPaas project  (https://github.com/linagora/openpaas-esn) and we're using summernote as our primary editor for email messages. When we reply to emails, we often reply "inline" to comment the original text, and the user expects blockquotes to break in this case.
#### What are the relevant tickets?
- #1410
- #97 
- Probably some other tickets :)
### Checklist
- [x] Added relevant tests
- [x] Didn't break anything
- [x] Tests pass on Chrome, Firefox and PhantomJS, I'll let saucelabs check the other platforms!
