### PR TITLE
Show fontname dropdown items as their own styles

### DIFF
--- a/src/js/bs3/module/Buttons.js
+++ b/src/js/bs3/module/Buttons.js
@@ -48,6 +48,19 @@ define([
           ui.dropdown({
             className: 'dropdown-style',
             items: context.options.styleTags,
+            template : function (item) {
+
+              if (typeof item === 'string') {
+                item = { tag : item, title : item };
+              }
+
+              var tag = item.tag;
+              var title = item.title;
+              var style = item.style ? ' style="' + item.style + '" ' : '';
+              var className = item.className ? ' className="' + item.className + '"' : '';
+
+              return '<' + tag + style + className + '>' + title + '</' + tag +  '>';
+            },
             click: context.createInvokeHandler('editor.formatBlock')
           })
         ]).render();

--- a/src/js/bs3/module/Buttons.js
+++ b/src/js/bs3/module/Buttons.js
@@ -129,6 +129,9 @@ define([
               return agent.isFontInstalled(name) ||
                 list.contains(options.fontNamesIgnoreCheck, name);
             }),
+            display: function (item) {
+              return '<span style="font-family:' + item + '">' + item + '</span>';
+            },
             click: context.createInvokeHandler('editor.fontName')
           })
         ]).render();

--- a/src/js/bs3/module/Buttons.js
+++ b/src/js/bs3/module/Buttons.js
@@ -48,10 +48,10 @@ define([
           ui.dropdown({
             className: 'dropdown-style',
             items: context.options.styleTags,
-            template : function (item) {
+            template: function (item) {
 
               if (typeof item === 'string') {
-                item = { tag : item, title : item };
+                item = { tag: item, title: item };
               }
 
               var tag = item.tag;
@@ -137,7 +137,7 @@ define([
           }),
           ui.dropdownCheck({
             className: 'dropdown-fontname',
-            checkClassName : options.icons.menuCheck,
+            checkClassName: options.icons.menuCheck,
             items: options.fontNames.filter(function (name) {
               return agent.isFontInstalled(name) ||
                 list.contains(options.fontNamesIgnoreCheck, name);
@@ -162,7 +162,7 @@ define([
           }),
           ui.dropdownCheck({
             className: 'dropdown-fontsize',
-            checkClassName : options.icons.menuCheck,
+            checkClassName: options.icons.menuCheck,
             items: options.fontSizes,
             click: context.createInvokeHandler('editor.fontSize')
           })
@@ -174,7 +174,7 @@ define([
           className: 'note-color',
           children: [
             ui.button({
-              className : 'note-current-color-button',
+              className: 'note-current-color-button',
               contents: ui.icon(options.icons.font + ' note-recent-color'),
               tooltip: lang.color.recent,
               click: context.createInvokeHandler('editor.color'),
@@ -346,7 +346,7 @@ define([
           }),
           ui.dropdownCheck({
             items: options.lineHeights,
-            checkClassName : options.icons.menuCheck,
+            checkClassName: options.icons.menuCheck,
             className: 'dropdown-line-height',
             click: context.createInvokeHandler('editor.lineHeight')
           })

--- a/src/js/bs3/module/Buttons.js
+++ b/src/js/bs3/module/Buttons.js
@@ -129,7 +129,7 @@ define([
               return agent.isFontInstalled(name) ||
                 list.contains(options.fontNamesIgnoreCheck, name);
             }),
-            display: function (item) {
+            template: function (item) {
               return '<span style="font-family:' + item + '">' + item + '</span>';
             },
             click: context.createInvokeHandler('editor.fontName')

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -42,7 +42,8 @@ define([
 
   var dropdownCheck = renderer.create('<div class="dropdown-menu note-check">', function ($node, options) {
     var markup = $.isArray(options.items) ? options.items.map(function (item) {
-      return '<li><a href="#" data-value="' + item + '">' + icon(options.checkClassName) + ' ' + item + '</a></li>';
+      return '<li><a href="#" data-value="' + item + '">' +
+      icon(options.checkClassName) + ' ' + (options.display ? options.display(item) : item) + '</a></li>';
     }).join('') : options.items;
     $node.html(markup);
   });

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -34,7 +34,9 @@ define([
 
   var dropdown = renderer.create('<div class="dropdown-menu">', function ($node, options) {
     var markup = $.isArray(options.items) ? options.items.map(function (item) {
-      return '<li><a href="#" data-value="' + item + '">' + item + '</a></li>';
+      var value = (typeof item === 'string') ? item : (item.value || '');
+      var content = options.template ? options.template(item) : item;
+      return '<li><a href="#" data-value="' + value + '">' + content + '</a></li>';
     }).join('') : options.items;
 
     $node.html(markup);
@@ -42,8 +44,9 @@ define([
 
   var dropdownCheck = renderer.create('<div class="dropdown-menu note-check">', function ($node, options) {
     var markup = $.isArray(options.items) ? options.items.map(function (item) {
-      return '<li><a href="#" data-value="' + item + '">' +
-      icon(options.checkClassName) + ' ' + (options.display ? options.display(item) : item) + '</a></li>';
+      var value = (typeof item === 'string') ? item : (item.value || '');
+      var content = options.template ? options.template(item) : item;
+      return '<li><a href="#" data-value="' + value + '">' + icon(options.checkClassName) + ' ' + content + '</a></li>';
     }).join('') : options.items;
     $node.html(markup);
   });


### PR DESCRIPTION
#### What does this PR do?

- Displays fontname dropdown items as their own styles with `font-family` style.

#### Where should the reviewer start?

- start on the src/js/bs3/module/Buttons.js

This also brings a change on `ui.dropdownCheck` - I added `display` function to allow modification on display name of each items. Please review its name `display` is properly named.

#### Screenshots (if for frontend)
![screen shot 2016-01-11 at 11 56 22 pm](https://cloud.githubusercontent.com/assets/579366/12236923/8d0d9020-b8bf-11e5-8f40-e3e11eaf51e0.png)
