### PR TITLE
Fix autolink with scheme test

### DIFF
--- a/src/js/base/module/AutoLink.js
+++ b/src/js/base/module/AutoLink.js
@@ -9,6 +9,7 @@ define([
     var self = this;
 
     var linkPattern = /^(https?:\/\/|ssh:\/\/|ftp:\/\/|file:\/|www\.|(?:mailto:)?[A-Z0-9._%+-]+@)(.+)$/i;
+    var schemePattern = /^([a-z]+:)(\/\/)?/i;
 
     this.events = {
       'summernote.keyup': function (we, e) {
@@ -47,7 +48,8 @@ define([
     };
 
     this.nodeFromKeyword = function (keyword) {
-      return $('<a />').html(keyword).attr('href', keyword)[0];
+      var link = schemePattern.test(keyword) ? keyword : 'http://' + keyword;
+      return $('<a />').html(keyword).attr('href', link)[0];
     };
 
     this.handleKeydown = function (e) {

--- a/src/js/base/module/AutoLink.js
+++ b/src/js/base/module/AutoLink.js
@@ -7,9 +7,8 @@ define([
 ], function (func, list, dom, range, key) {
   var AutoLink = function (context) {
     var self = this;
-
-    var linkPattern = /^(https?:\/\/|ssh:\/\/|ftp:\/\/|file:\/|www\.|(?:mailto:)?[A-Z0-9._%+-]+@)(.+)$/i;
-    var schemePattern = /^([a-z]+:)(\/\/)?/i;
+    var defaultScheme = 'http://';
+    var linkPattern = /^(https?:\/\/|ssh:\/\/|ftp:\/\/|file:\/|mailto:[A-Z0-9._%+-]+@)?(www\.)?(.+)$/i;
 
     this.events = {
       'summernote.keyup': function (we, e) {
@@ -36,20 +35,17 @@ define([
       }
 
       var keyword = this.lastWordRange.toString();
+      var match = keyword.match(linkPattern);
 
-      if (linkPattern.test(keyword)) {
-        var node = this.nodeFromKeyword(keyword);
+      if (match[1] || match[2]) {
+        var link = match[1] ? keyword : defaultScheme + keyword;
+        var node = $('<a />').html(keyword).attr('href', link)[0];
 
         this.lastWordRange.insertNode(node);
         this.lastWordRange = null;
         context.invoke('editor.focus');
       }
 
-    };
-
-    this.nodeFromKeyword = function (keyword) {
-      var link = schemePattern.test(keyword) ? keyword : 'http://' + keyword;
-      return $('<a />').html(keyword).attr('href', link)[0];
     };
 
     this.handleKeydown = function (e) {


### PR DESCRIPTION
If a link string does not have scheme(like www.cnn.com), add default scheme for it.