### PR TITLE
Fix toggle state for subscript/superscript/strikethrough buttons

### DIFF
--- a/src/js/base/editing/Style.js
+++ b/src/js/base/editing/Style.js
@@ -133,7 +133,7 @@ define([
           'font-underline': document.queryCommandState('underline') ? 'underline' : 'normal',
           'font-subscript': document.queryCommandState('subscript') ? 'subscript' : 'normal',
           'font-superscript': document.queryCommandState('superscript') ? 'superscript' : 'normal',
-          'font-strikethrough': document.queryCommandState('strikeThrough') ? 'strikethrough' : 'normal'
+          'font-strikethrough': document.queryCommandState('strikethrough') ? 'strikethrough' : 'normal'
         });
       } catch (e) {}
 

--- a/src/js/bs3/module/Buttons.js
+++ b/src/js/bs3/module/Buttons.js
@@ -90,6 +90,7 @@ define([
 
       context.memo('button.strikethrough', function () {
         return ui.button({
+          className: 'note-btn-strikethrough',
           contents: ui.icon(options.icons.strikethrough),
           tooltip: lang.font.strikethrough + representShortcut('strikethrough'),
           click: context.createInvokeHandler('editor.strikethrough')
@@ -98,6 +99,7 @@ define([
 
       context.memo('button.superscript', function () {
         return ui.button({
+          className: 'note-btn-superscript',
           contents: ui.icon(options.icons.superscript),
           tooltip: lang.font.superscript,
           click: context.createInvokeHandler('editor.superscript')
@@ -106,6 +108,7 @@ define([
 
       context.memo('button.subscript', function () {
         return ui.button({
+          className: 'note-btn-subscript',
           contents: ui.icon(options.icons.subscript),
           tooltip: lang.font.subscript,
           click: context.createInvokeHandler('editor.subscript')
@@ -560,6 +563,15 @@ define([
         },
         '.note-btn-underline': function () {
           return styleInfo['font-underline'] === 'underline';
+        },
+        '.note-btn-subscript': function () {
+          return styleInfo['font-subscript'] === 'bold';
+        },
+        '.note-btn-superscript': function () {
+          return styleInfo['font-superscript'] === 'superscript';
+        },
+        '.note-btn-strikethrough': function () {
+          return styleInfo['font-strikethrough'] === 'strikethrough';
         }
       });
 

--- a/src/js/bs3/module/Buttons.js
+++ b/src/js/bs3/module/Buttons.js
@@ -565,7 +565,7 @@ define([
           return styleInfo['font-underline'] === 'underline';
         },
         '.note-btn-subscript': function () {
-          return styleInfo['font-subscript'] === 'bold';
+          return styleInfo['font-subscript'] === 'subscript';
         },
         '.note-btn-superscript': function () {
           return styleInfo['font-superscript'] === 'superscript';

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -445,3 +445,12 @@
     }
   }
 }
+
+/* Browser bug workarounds
+------------------------------------------*/
+sup {
+  vertical-align: super;
+}
+sub {
+  vertical-align: sub
+}


### PR DESCRIPTION
This PR contains two commits:
  - Add style for sub and sup tag.
    - Chrome does not handle subscript/superscript via queryCommandState by default.
    - Setting `vertical-align` for workaround.
  - Add styleInfo for subscript/superscript/strikethrough and apply them on buttons.