### PR TITLE
Fixed #1595 by exposing an 'empty' method from the Editor module.

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -751,6 +751,17 @@ define([
     this.isEmpty = function () {
       return dom.isEmpty($editable[0]) || dom.emptyPara === $editable.html();
     };
+
+    /**
+     * Removes all contents and restores the editable instance to an _emptyPara_.
+     *
+     * @returns {String} The new HTML contents of the editable instance.
+     */
+    this.empty = function () {
+      $editable.html(dom.emptyPara);
+
+      return $editable.html();
+    };
   };
 
   return Editor;

--- a/test/unit/base/module/Editor.spec.js
+++ b/test/unit/base/module/Editor.spec.js
@@ -6,12 +6,52 @@
 /* jshint unused: false */
 define([
   'chai',
+  'summernote/base/core/dom',
   'summernote/base/module/Editor'
-], function (chai, Editor) {
+], function (chai, dom, Editor) {
   'use strict';
 
   var expect = chai.expect;
 
   describe('base:module.Editor', function () {
+
+    function context($editable) {
+      return {
+        layoutInfo: {
+          editable: $editable
+        },
+        options: {
+          langInfo: {
+            help: {}
+          }
+        },
+        memo: function () {},
+        triggerEvent: function () {}
+      };
+    }
+
+    describe('The empty function', function () {
+
+      var editor, $editable;
+
+      beforeEach(function () {
+        editor = new Editor(context($editable = $('<div class="note-editable" />')));
+      });
+
+      it('should resets the contents to an emptyPara', function () {
+        $editable.html('Hello');
+        editor.empty();
+
+        expect($editable.html()).to.equal(dom.emptyPara);
+      });
+
+      it('should return the new contents', function () {
+        $editable.html('Hello');
+
+        expect(editor.empty()).to.equal(dom.emptyPara);
+      });
+
+    });
+
   });
 });


### PR DESCRIPTION
#### What does this PR do?

- Expose an `empty` method in the Editor module

#### Where should the reviewer start?

- Start on src/js/base/module/Editor.js

#### How should this be manually tested?

- Well, simply initialize an editor, type some text the invoke the 'empty' command and check that the editor is actually empty.

#### Any background context you want to provide?

- Will be used by angular-summernote to fix https://github.com/summernote/angular-summernote/issues/105

#### What are the relevant tickets?

- #1595 

### Checklist
- [x] added relevant tests
- [x] didn't break anything, all tests pass on Chrome, Firefox and PhantomJS