### PR TITLE
Allow dialog fade via dialogsFade option

### DIFF
--- a/src/js/bs3/module/HelpDialog.js
+++ b/src/js/bs3/module/HelpDialog.js
@@ -36,6 +36,7 @@ define([
 
       this.$dialog = ui.dialog({
         title: lang.options.help,
+        fade: options.dialogsFade,
         body: this.createShortCutList(),
         footer: body,
         callback: function ($node) {

--- a/src/js/bs3/module/ImageDialog.js
+++ b/src/js/bs3/module/ImageDialog.js
@@ -33,6 +33,7 @@ define([
 
       this.$dialog = ui.dialog({
         title: lang.image.insert,
+        fade: options.dialogsFade,
         body: body,
         footer: footer
       }).render().appendTo($container);

--- a/src/js/bs3/module/LinkDialog.js
+++ b/src/js/bs3/module/LinkDialog.js
@@ -30,6 +30,7 @@ define([
       this.$dialog = ui.dialog({
         className: 'link-dialog',
         title: lang.link.insert,
+        fade: options.dialogsFade,
         body: body,
         footer: footer
       }).render().appendTo($container);

--- a/src/js/bs3/module/VideoDialog.js
+++ b/src/js/bs3/module/VideoDialog.js
@@ -20,6 +20,7 @@ define([
 
       this.$dialog = ui.dialog({
         title: lang.video.insert,
+        fade: options.dialogsFade,
         body: body,
         footer: footer
       }).render().appendTo($container);

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -139,6 +139,7 @@ define([
       },
 
       dialogsInBody: false,
+      dialogsFade: false,
 
       maximumImageFileSize: null,
 

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -80,6 +80,9 @@ define([
   });
 
   var dialog = renderer.create('<div class="modal" aria-hidden="false" tabindex="-1"/>', function ($node, options) {
+    if (options.fade) {
+      $node.addClass('fade');
+    }
     $node.html([
       '<div class="modal-dialog">',
       '  <div class="modal-content">',


### PR DESCRIPTION
Add `dialogsFade` option to add fade effect on modal dialogs. (default: `false`)
This PR is for #294.