### PR TITLE
Fixed #1595 by exposing an 'empty' method from the Editor module

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -751,6 +751,13 @@ define([
     this.isEmpty = function () {
       return dom.isEmpty($editable[0]) || dom.emptyPara === $editable.html();
     };
+
+    /**
+     * Removes all contents and restores the editable instance to an _emptyPara_.
+     */
+    this.empty = function () {
+      context.invoke('code', dom.emptyPara);
+    };
   };
 
   return Editor;

--- a/test/unit/base/module/Editor.spec.js
+++ b/test/unit/base/module/Editor.spec.js
@@ -6,12 +6,50 @@
 /* jshint unused: false */
 define([
   'chai',
+  'summernote/base/core/dom',
   'summernote/base/module/Editor'
-], function (chai, Editor) {
+], function (chai, dom, Editor) {
   'use strict';
 
   var expect = chai.expect;
 
   describe('base:module.Editor', function () {
+
+    function mockedContext() {
+      return {
+        layoutInfo: {
+          editable: {}
+        },
+        options: {
+          langInfo: {
+            help: {}
+          }
+        },
+        memo: function () {},
+        triggerEvent: function () {}
+      };
+    }
+
+    describe('The empty function', function () {
+
+      var editor, context;
+
+      beforeEach(function () {
+        editor = new Editor(context = mockedContext());
+      });
+
+      it('should invoke the "code" api method with dom.emptyPara as argument', function (done) {
+        context.invoke = function (name, args) {
+          expect(name).to.equal('code');
+          expect(args).to.equal(dom.emptyPara);
+
+          done();
+        };
+
+        editor.empty();
+      });
+
+    });
+
   });
 });


### PR DESCRIPTION
See #1596 and the discussion in there.
This is required for https://github.com/summernote/angular-summernote/pull/106

Thanks !