### PR TITLE
change position for initialize content

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -66,6 +66,10 @@ define([
         context.triggerEvent('paste', event);
       });
 
+
+      // init content before set event
+      $editable.html(dom.html($note) || dom.emptyPara);
+
       // [workaround] IE doesn't have input events for contentEditable
       // - see: https://goo.gl/4bfIvA
       var changeEventName = agent.isMSIE ? 'DOMCharacterDataModified DOMSubtreeModified DOMNodeInserted' : 'input';
@@ -89,7 +93,6 @@ define([
         $editable.css('min-height', options.minHeight);
       }
 
-      $editable.html(dom.html($note) || dom.emptyPara);
       history.recordUndo();
     };
 

--- a/test/unit/base/Context.spec.js
+++ b/test/unit/base/Context.spec.js
@@ -1,0 +1,40 @@
+/**
+ * Context.spec.js
+ * (c) 2015~ Summernote Team
+ * summernote may be freely distributed under the MIT license./
+ */
+/* jshint unused: false */
+define([
+  'chai',
+  'spies',
+  'helper',
+  'jquery',
+  'summernote/lite/settings',
+  'summernote/base/core/agent',
+  'summernote/base/core/dom',
+  'summernote/base/Context'
+], function (chai, spies, helper, $, settings, agent, dom, Context) {
+  'use strict';
+
+  var expect = chai.expect;
+  chai.use(spies);
+
+  describe('Context.Initialize.Check', function () {
+    var options = $.extend({}, $.summernote.options);
+    options.langInfo = $.extend(true, {}, $.summernote.lang['en-US'], $.summernote.lang[options.lang]);
+    var context = new Context($('<div><p>hello</p></div>'), options);
+
+    var $note = context.layoutInfo.note;
+    var spy = chai.spy();
+
+    $note.on('summernote.change', spy);
+
+    expect(spy).to.have.not.been.called();
+
+    var expectToHaveBeenCalled = function () {
+      expect(spy).to.have.been.called();
+    };
+
+    expect(expectToHaveBeenCalled).throw(chai.AssertionError);
+  });
+});

--- a/test/unit/base/Context.spec.js
+++ b/test/unit/base/Context.spec.js
@@ -31,8 +31,12 @@ define([
       var context = new Context($note, options);
       expect(spy).to.have.not.been.called();
 
-      context.invoke('insertText', 'hello');
-      expect(spy).to.have.been.called();
+      // [workaround]
+      //  - IE8-11 can't create range in headless mode
+      if (!agent.isMSIE) {
+        context.invoke('insertText', 'hello');
+        expect(spy).to.have.been.called();
+      }
     });
   });
 });

--- a/test/unit/base/Context.spec.js
+++ b/test/unit/base/Context.spec.js
@@ -19,22 +19,20 @@ define([
   var expect = chai.expect;
   chai.use(spies);
 
-  describe('Context.Initialize.Check', function () {
-    var options = $.extend({}, $.summernote.options);
-    options.langInfo = $.extend(true, {}, $.summernote.lang['en-US'], $.summernote.lang[options.lang]);
-    var context = new Context($('<div><p>hello</p></div>'), options);
+  describe('Context', function () {
+    it('should be initialized without calling callback', function () {
+      var options = $.extend({}, $.summernote.options);
+      options.langInfo = $.extend(true, {}, $.summernote.lang['en-US'], $.summernote.lang[options.lang]);
 
-    var $note = context.layoutInfo.note;
-    var spy = chai.spy();
+      var spy = chai.spy();
+      var $note = $('<div><p>hello</p></div>');
+      $note.on('summernote.change', spy);
 
-    $note.on('summernote.change', spy);
+      var context = new Context($note, options);
+      expect(spy).to.have.not.been.called();
 
-    expect(spy).to.have.not.been.called();
-
-    var expectToHaveBeenCalled = function () {
+      context.invoke('insertText', 'hello');
       expect(spy).to.have.been.called();
-    };
-
-    expect(expectToHaveBeenCalled).throw(chai.AssertionError);
+    });
   });
 });


### PR DESCRIPTION
#### What does this PR do?

- initialize content before set summernote.change event 

#### Where should the reviewer start?

- start on the src/base/module/Editor.js

#### How should this be manually tested?

- http://summernote.easylogic.co.kr/tree/bugfix/%231621/  on IE 

#### Any background context you want to provide?

- In IE, summernote.change event is set differently.
- when DOMCharacterDataModified, DOMSubtreeModified and DOMNodeInserted event were fired, it is run summernote.change event  

#### What are the relevant tickets?

#1621 
summernote/angular-summernote/issues/98