### PR TITLE
Record disabled status for orthogonality of reset function

### DIFF
--- a/src/js/base/Context.js
+++ b/src/js/base/Context.js
@@ -41,9 +41,14 @@ define([
      * destory modules and other resources and initialize it again
      */
     this.reset = function () {
+      var disabled = self.isDisabled();
       this.code(dom.emptyPara);
       this._destroy();
       this._initialize();
+
+      if (disabled) {
+        self.disable();
+      }
     };
 
     this._initialize = function () {

--- a/test/unit/base/Context.spec.js
+++ b/test/unit/base/Context.spec.js
@@ -38,5 +38,19 @@ define([
         expect(spy).to.have.been.called();
       }
     });
+
+    it('should preserve disabled status after reset', function () {
+      var options = $.extend({}, $.summernote.options);
+      options.langInfo = $.extend(true, {}, $.summernote.lang['en-US'], $.summernote.lang[options.lang]);
+
+      var $note = $('<div><p>hello</p></div>');
+      var context = new Context($note, options);
+
+      expect(context.isDisabled()).to.be.false;
+      context.disable();
+      expect(context.isDisabled()).to.be.true;
+      context.reset();
+      expect(context.isDisabled()).to.be.true;
+    });
   });
 });


### PR DESCRIPTION
#### What does this PR do?

- Record editor's disabled status for orthogonality of `reset` function

#### Where should the reviewer start?

- start on the src/js/base/Context.js

#### How should this be manually tested?

- Disable editor with `disable` and run `reset` for it

#### What are the relevant tickets?

- To fix #1622 