### PR TITLE
Apply options.width on editable

### DIFF
--- a/src/js/base/module/Codeview.js
+++ b/src/js/base/module/Codeview.js
@@ -54,7 +54,6 @@ define([
      */
     this.activate = function () {
       $codable.val(dom.html($editable, options.prettifyHtml));
-      $codable.width($editable.width());
       $codable.height($editable.height());
 
       context.invoke('toolbar.updateCodeview', true);
@@ -75,7 +74,7 @@ define([
         }
 
         // CodeMirror hasn't Padding.
-        cmEditor.setSize($editable.outerWidth(), $editable.outerHeight());
+        cmEditor.setSize(null, $editable.outerHeight());
         $codable.data('cmEditor', cmEditor);
       }
     };
@@ -95,6 +94,7 @@ define([
       var isChange = $editable.html() !== value;
 
       $editable.html(value);
+      $editable.height(options.height ? $codable.height() : 'auto');
       $editor.removeClass('codeview');
 
       if (isChange) {

--- a/src/js/base/module/Codeview.js
+++ b/src/js/base/module/Codeview.js
@@ -54,6 +54,7 @@ define([
      */
     this.activate = function () {
       $codable.val(dom.html($editable, options.prettifyHtml));
+      $codable.width($editable.width());
       $codable.height($editable.height());
 
       context.invoke('toolbar.updateCodeview', true);
@@ -74,7 +75,7 @@ define([
         }
 
         // CodeMirror hasn't Padding.
-        cmEditor.setSize(null, $editable.outerHeight());
+        cmEditor.setSize($editable.outerWidth(), $editable.outerHeight());
         $codable.data('cmEditor', cmEditor);
       }
     };
@@ -94,7 +95,6 @@ define([
       var isChange = $editable.html() !== value;
 
       $editable.html(value);
-      $editable.height(options.height ? $codable.height() : 'auto');
       $editor.removeClass('codeview');
 
       if (isChange) {

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -82,14 +82,19 @@ define([
         context.triggerEvent('focusout', event);
       });
 
-      if (!options.airMode && options.height) {
-        this.setHeight(options.height);
-      }
-      if (!options.airMode && options.maxHeight) {
-        $editable.css('max-height', options.maxHeight);
-      }
-      if (!options.airMode && options.minHeight) {
-        $editable.css('min-height', options.minHeight);
+      if (!options.airMode) {
+        if (options.width) {
+          $editable.outerWidth(options.width);
+        }
+        if (options.height) {
+          $editable.outerHeight(options.height);
+        }
+        if (options.maxHeight) {
+          $editable.css('max-height', options.maxHeight);
+        }
+        if (options.minHeight) {
+          $editable.css('min-height', options.minHeight);
+        }
       }
 
       history.recordUndo();
@@ -732,13 +737,6 @@ define([
      */
     this.empty = function () {
       context.invoke('code', dom.emptyPara);
-    };
-
-    /**
-     * set height for editable
-     */
-    this.setHeight = function (height) {
-      $editable.outerHeight(height);
     };
   };
 

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -84,7 +84,7 @@ define([
 
       if (!options.airMode) {
         if (options.width) {
-          $editable.outerWidth(options.width);
+          $editor.outerWidth(options.width);
         }
         if (options.height) {
           $editable.outerHeight(options.height);

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -114,7 +114,7 @@
     position: fixed;
     top: 0;
     left: 0;
-    width: 100%;
+    width: 100% !important;
     z-index: 1050; /* bs3 modal-backdrop: 1030, bs2: 1040 */
     .note-editable {
       background-color: white;

--- a/src/less/summernote.scss
+++ b/src/less/summernote.scss
@@ -113,7 +113,7 @@ $background-color: #f5f5f5;
     position: fixed;
     top: 0;
     left: 0;
-    width: 100%;
+    width: 100% !important;
     z-index: 1050; /* bs3 modal-backdrop: 1030, bs2: 1040 */
     .note-editable {
       background-color: white;


### PR DESCRIPTION
#### What does this PR do?

- summernote bs3 settings provide `width` option, but it is not used.
- This patch makes `width` option works.

#### How should this be manually tested?

- Toggle codeview
- I didn't test this with Codemirror.