### PR TITLE
Remove panel-body class from note-editable div

### DIFF
--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -5,7 +5,7 @@ define([
   var toolbar = renderer.create('<div class="note-toolbar panel-heading"/>');
   var editingArea = renderer.create('<div class="note-editing-area"/>');
   var codable = renderer.create('<textarea class="note-codable"/>');
-  var editable = renderer.create('<div class="note-editable panel-body" contentEditable="true"/>');
+  var editable = renderer.create('<div class="note-editable" contentEditable="true"/>');
   var statusbar = renderer.create([
     '<div class="note-statusbar">',
     '  <div class="note-resizebar">',

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -45,6 +45,7 @@
 
     .note-editable {
       outline: none;
+      display: table;
 
       sup {
         vertical-align: super;

--- a/src/less/summernote.scss
+++ b/src/less/summernote.scss
@@ -44,6 +44,7 @@ $background-color: #f5f5f5;
 
     .note-editable {
       outline: none;
+      display: table;
 
       sup {
         vertical-align: super;


### PR DESCRIPTION
#### What does this PR do?

- Fix #1700 

#### Where should the reviewer start?

- start on the src/js/bs3/ui.js

We declared `editable` with `note-editable` and `panel-body` classes. But it looks like we don't need to put `panel-body` into it and it causes a compatibility problem as reported on #1700.