### PR TITLE
Fixes pt-BR translation

### DIFF
--- a/lang/summernote-pt-BR.js
+++ b/lang/summernote-pt-BR.js
@@ -22,7 +22,7 @@
         floatNone: 'Float None',
         dragImageHere: 'Arraste uma imagem para cá',
         selectFromFiles: 'Selecione a partir dos arquivos',
-        url: 'URL da image'
+        url: 'URL da imagem'
       },
       video: {
         video: 'Vídeo',


### PR DESCRIPTION
#### What does this PR do?

- Fixes pt-BR translation

#### Where should the reviewer start?

- start on the lang/summernote-pt-BR.js

#### How should this be manually tested?

- set lang to `pt-BR` => $("#summernote").summernote({lang: 'pt-BR'});
- click on image, see that it's written `URL da image` instead of `URL da imagem`

#### Any background context you want to provide?

- nope

#### What are the relevant tickets?

- none

#### Screenshots (if for frontend)

<img width="580" alt="screenshot 2016-02-22 19 05 01" src="https://cloud.githubusercontent.com/assets/88818/13234404/3899d956-d997-11e5-88a3-acf45914850d.png">

### Checklist
- [ ] added relevant tests
- [ ] didn't break anything

Should be 'imagem' instead of 'image'