### PR TITLE
Corrects the foreground color font tag behavior to compatible HTML5 (inline styling)

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -254,7 +254,7 @@ define([
     var commands = ['bold', 'italic', 'underline', 'strikethrough', 'superscript', 'subscript',
                     'justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull',
                     'formatBlock', 'removeFormat',
-                    'backColor', 'foreColor', 'fontName'];
+                    'backColor', 'fontName'];
 
     for (var idx = 0, len = commands.length; idx < len; idx ++) {
       this[commands[idx]] = (function (sCmd) {
@@ -659,6 +659,16 @@ define([
 
       if (foreColor) { document.execCommand('foreColor', false, foreColor); }
       if (backColor) { document.execCommand('backColor', false, backColor); }
+    });
+
+    /**
+     * Set foreground color
+     *
+     * @param {String} colorCode foreground color code
+     */
+    this.foreColor = this.wrapCommand(function (colorInfo) {
+      document.execCommand('styleWithCSS', false, true);
+      document.execCommand('foreColor', false, colorInfo);
     });
 
     /**

--- a/test/unit/bs3/module/Buttons.spec.js
+++ b/test/unit/bs3/module/Buttons.spec.js
@@ -117,10 +117,8 @@ define([
         var $button = $toolbar.find('[data-event=foreColor]').eq(10);
         $button.click();
 
-        // TODO <font> tag deprecated in HTML5
-        //  - https://github.com/summernote/summernote/issues/745
-        var $font = $editable.find('font');
-        expect($font).to.be.equalsStyle($button.data('value'), 'color');
+        var $span = $editable.find('span');
+        expect($span).to.be.equalsStyle('#FF9C00', 'color');
       });
     });
 


### PR DESCRIPTION
#### What does this PR do?
- Fixes #745 
#### Where should the reviewer start?
- start on the src/js/base/module/Editor.js and test/unit/bs3/module/Buttons.spec.js
#### How should this be manually tested?
- Type some text, change its foreground color, check HTML. It should now be inside a `<span>` with inline CSS style instead of inside a `<font>` tag.
#### Any background context you want to provide?
- the gem needed to be updated... yada yada
#### What are the relevant tickets?
#745
#### Screenshots (if for frontend)

<img width="494" alt="screenshot 2016-02-24 19 22 34" src="https://cloud.githubusercontent.com/assets/88818/13303093/ff1f2e06-db2b-11e5-80b0-93bc065abb3c.png">
### Checklist
- [x] fixes #745 
- [x] added relevant tests
- [x] didn't break anything
