### PR TITLE
Updates missing 'video' translation from pt-PT

### DIFF
--- a/lang/summernote-pt-PT.js
+++ b/lang/summernote-pt-PT.js
@@ -24,6 +24,13 @@
         selectFromFiles: 'Selecione a partir dos arquivos',
         url: 'Endereço da imagem'
       },
+      video: {
+        video: 'Vídeo',
+        videoLink: 'Link para vídeo',
+        insert: 'Inserir vídeo',
+        url: 'URL do vídeo?',
+        providers: '(YouTube, Vimeo, Vine, Instagram, DailyMotion, ou Youku)'
+      },
       link: {
         link: 'Link',
         insert: 'Inserir ligação',


### PR DESCRIPTION
#### What does this PR do?

- addes 'video' part to pt-PT translation, from pt-BR version, which is identical

#### Where should the reviewer start?

- start on the lang/summernote-pt-PT.js

#### How should this be manually tested?

- set lang to `pt-PT` => $("#summernote").summernote({lang: 'pt-PT'});
- click on video, see that it's translated

#### Any background context you want to provide?

- none

#### What are the relevant tickets?

- #1509 

#### Screenshots (if for frontend)


### Checklist

Translation comes from pt-BR file which is identical.