### PR TITLE
Fix tabindex, not focus to textarea on Firefox, Mac OS

### DIFF
--- a/src/js/base/module/Clipboard.js
+++ b/src/js/base/module/Clipboard.js
@@ -33,7 +33,7 @@ define([
       //  - IE11 and Firefox: CTRL+v hook
       //  - Webkit: event.clipboardData
       if (this.needKeydownHook()) {
-        this.$paste = $('<div />').attr('contenteditable', true).css({
+        this.$paste = $('<div tabindex="-1" />').attr('contenteditable', true).css({
           position: 'absolute',
           left: -100000,
           opacity: 0

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -20,7 +20,7 @@ define([
   var airEditable = renderer.create('<div class="note-editable" contentEditable="true"/>');
 
   var buttonGroup = renderer.create('<div class="note-btn-group btn-group">');
-  var button = renderer.create('<button type="button" class="note-btn btn btn-default btn-sm">', function ($node, options) {
+  var button = renderer.create('<button type="button" class="note-btn btn btn-default btn-sm" tabindex="-1">', function ($node, options) {
     if (options && options.tooltip) {
       $node.attr({
         title: options.tooltip


### PR DESCRIPTION
#### What does this PR do?

- Fix tabindex, not focus to textarea when press tab

#### Where should the reviewer start?

- start on the src/summernote.js

#### How should this be manually tested?

- Use Mac OS - Firefox
- Make an input above of summernote then press tab 
