### PR TITLE
Better checks before using non-standard require methods. Fixes #1723.

### DIFF
--- a/src/js/base/core/agent.js
+++ b/src/js/base/core/agent.js
@@ -41,18 +41,18 @@ define(['jquery'], function ($) {
   var isEdge = /Edge\/\d+/.test(userAgent);
 
   var hasCodeMirror = !!window.CodeMirror;
-  if (!hasCodeMirror && isSupportAmd && require) {
-    if (require.hasOwnProperty('resolve')) {
+  if (!hasCodeMirror && isSupportAmd && typeof require !== 'undefined') {
+    if (typeof require.resolve !== 'undefined') {
       try {
         // If CodeMirror can't be resolved, `require.resolve` will throw an
         // exception and `hasCodeMirror` won't be set to `true`.
         require.resolve('codemirror');
         hasCodeMirror = true;
       } catch (e) {
-        hasCodeMirror = false;
+        // Do nothing.
       }
-    } else if (require.hasOwnProperty('specified')) {
-      hasCodeMirror = require.specified('codemirror');
+    } else if (typeof eval('require').specified !== 'undefined') {
+      hasCodeMirror = eval('require').specified('codemirror');
     }
   }
 


### PR DESCRIPTION
#### What does this PR do?

My stab at fixing #1723.

#### Where should the reviewer start?

The only modifications are in `src/js/base/core/agent.js`

#### How should this be manually tested?

Built the distributable using `grunt dist` and tested in a Webpack environment. Don't have an immediate access to a Summernote RequireJS build, maybe users like @jumplee can help.

#### Any background context you want to provide?

To get Webpack to play along, we cannot simply use runtime checks on `require` like is currently the case. I'm not familiar enough with RequireJS to know if [require.specified](https://github.com/jrburke/requirejs/blob/a1da39714bc3eea9ab85c77e47d544e815e2699f/require.js#L1491-L1494) works at bundle-time or a runtime. The current fix presumes that command is only executed at runtime. (I added a short `eval` to trick Webpack) It would be great to get feedback from Summernote RequireJS users about this fix, to end the cycle of breaking different bundlers back and forth across releases.

#### What are the relevant tickets?

- #379
- #487
- #1171
- #1723 