### PR TITLE
Don't show shortcut text if it's disabled

### DIFF
--- a/src/js/bs3/module/Buttons.js
+++ b/src/js/bs3/module/Buttons.js
@@ -15,6 +15,9 @@ define([
     var invertedKeyMap = func.invertObject(options.keyMap[agent.isMac ? 'mac' : 'pc']);
 
     var representShortcut = this.representShortcut = function (editorMethod) {
+      if (!options.shortcuts) {
+        return '';
+      }
       var shortcut = invertedKeyMap[editorMethod];
       if (agent.isMac) {
         shortcut = shortcut.replace('CMD', '⌘').replace('SHIFT', '⇧');


### PR DESCRIPTION
Don't show shortcut text in toolbar buttons when options.shortcuts is false

```js
$('#summernote').summernote({
    shortcuts: false
});
```

![patch-1](https://cloud.githubusercontent.com/assets/577282/13492548/fd45df86-e138-11e5-97a7-4d1a653045b9.png)
