### PR TITLE
Don't loss buttons icons

### DIFF
--- a/src/js/summernote.js
+++ b/src/js/summernote.js
@@ -19,6 +19,7 @@ define([
 
       options = $.extend({}, $.summernote.options, options);
       options.langInfo = $.extend(true, {}, $.summernote.lang['en-US'], $.summernote.lang[options.lang]);
+      options.icons = $.extend(true, {}, $.summernote.options.icons, options.icons);
 
       this.each(function (idx, note) {
         var $note = $(note);


### PR DESCRIPTION
If the user set a custom icons list, the list must be merge with the default.

```js
$('#summernote').summernote({
    icons: {
        magic: 'note-icon-text-height'
    }
});
```

![patch-2](https://cloud.githubusercontent.com/assets/577282/13492484/979048e8-e138-11e5-8944-06f4e4694c4e.png)
