### PR TITLE
Prevent default shortcuts of contentEditable

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -51,7 +51,7 @@ define([
           if (options.shortcuts) {
             self.handleKeyMap(event);
           } else {
-            return self.preventDefaultEditableShortCuts(event);
+            self.preventDefaultEditableShortCuts(event);
           }
         }
       }).on('keyup', function (event) {
@@ -132,7 +132,11 @@ define([
 
     this.preventDefaultEditableShortCuts = function (event) {
       if ((event.ctrlKey || event.metaKey) &&
-        //              Bold / Italic / Underline
+        /**
+         *            Bold      : B(66) / b(98)
+         *            Italic    : I(73) / i(105)
+         *            Underline : U(85) / u(117)
+         */
         list.contains([66, 98, 73, 105, 85, 117], event.keyCode)) {
         return false;
       }

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -134,9 +134,8 @@ define([
       // B(Bold, 66) / I(Italic, 73) / U(Underline, 85)
       if ((event.ctrlKey || event.metaKey) &&
         list.contains([66, 73, 85], event.keyCode)) {
-        return false;
+        event.preventDefault();
       }
-      return true;
     };
 
     /**

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -131,13 +131,9 @@ define([
     };
 
     this.preventDefaultEditableShortCuts = function (event) {
+      // B(Bold, 66) / I(Italic, 73) / U(Underline, 85)
       if ((event.ctrlKey || event.metaKey) &&
-        /**
-         *            Bold      : B(66) / b(98)
-         *            Italic    : I(73) / i(105)
-         *            Underline : U(85) / u(117)
-         */
-        list.contains([66, 98, 73, 105, 85, 117], event.keyCode)) {
+        list.contains([66, 73, 85], event.keyCode)) {
         return false;
       }
       return true;

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -47,8 +47,12 @@ define([
         }
         context.triggerEvent('keydown', event);
 
-        if (options.shortcuts && !event.isDefaultPrevented()) {
-          self.handleKeyMap(event);
+        if (!event.isDefaultPrevented()) {
+          if (options.shortcuts) {
+            self.handleKeyMap(event);
+          } else {
+            return self.preventDefaultEditableShortCuts(event);
+          }
         }
       }).on('keyup', function (event) {
         context.triggerEvent('keyup', event);
@@ -124,6 +128,15 @@ define([
       } else if (key.isEdit(event.keyCode)) {
         this.afterCommand();
       }
+    };
+
+    this.preventDefaultEditableShortCuts = function (event) {
+      if ((event.ctrlKey || event.metaKey) &&
+        //              Bold / Italic / Underline
+        list.contains([66, 98, 73, 105, 85, 117], event.keyCode)) {
+        return false;
+      }
+      return true;
     };
 
     /**


### PR DESCRIPTION
#### What does this PR do?

- Fixes #1732 by disabling default shortcuts of `contentEditable`

#### Where should the reviewer start?

- start on the src/js/base/module/Editor.js

#### How should this be manually tested?

- Set `shortcuts` as `false` and press shortcuts (like `cmd+b`)

#### Any background context you want to provide?

- http://stackoverflow.com/questions/7207291/is-it-possible-to-disable-or-control-commands-in-contenteditable-elements
