### PR TITLE
support to save last range

### DIFF
--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -802,9 +802,10 @@ define([
      *
      * @param {Point} point
      * @param {Boolean} isInline
+     * @param {Boolean} isSkipBlankHTML
      * @return {Object}
      */
-    var splitPoint = function (point, isInline) {
+    var splitPoint = function (point, isInline, isSkipBlankHTML) {
       // find splitRoot, container
       //  - inline: splitRoot is a child of paragraph
       //  - block: splitRoot is a child of bodyContainer
@@ -822,9 +823,11 @@ define([
       }
 
       // if splitRoot is exists, split with splitTree
+      var isSkipPaddingBlankHTML = (typeof isSkipBlankHTML !== 'undefined') ? isSkipBlankHTML : isInline;
+      var isNotSplitEdgePoint = (typeof isSkipBlankHTML !== 'undefined') ? isSkipBlankHTML : isInline;
       var pivot = splitRoot && splitTree(splitRoot, point, {
-        isSkipPaddingBlankHTML: isInline,
-        isNotSplitEdgePoint: isInline
+        isSkipPaddingBlankHTML: isSkipPaddingBlankHTML,
+        isNotSplitEdgePoint: isNotSplitEdgePoint
       });
 
       // if container is point.node, find pivot with point.offset

--- a/src/js/base/core/range.js
+++ b/src/js/base/core/range.js
@@ -513,9 +513,9 @@ define([
        * @param {Node} node
        * @return {Node}
        */
-      this.insertNode = function (node) {
+      this.insertNode = function (node, isSkipBlankHTML) {
         var rng = this.wrapBodyInlineWithPara().deleteContents();
-        var info = dom.splitPoint(rng.getStartPoint(), dom.isInline(node));
+        var info = dom.splitPoint(rng.getStartPoint(), dom.isInline(node), isSkipBlankHTML);
 
         if (info.rightNode) {
           info.rightNode.parentNode.insertBefore(node, info.rightNode);
@@ -529,14 +529,14 @@ define([
       /**
        * insert html at current cursor
        */
-      this.pasteHTML = function (markup) {
+      this.pasteHTML = function (markup, isSkipBlankHTML) {
         var contentsContainer = $('<div></div>').html(markup)[0];
         var childNodes = list.from(contentsContainer.childNodes);
 
         var rng = this.wrapBodyInlineWithPara().deleteContents();
 
         return childNodes.reverse().map(function (childNode) {
-          return rng.insertNode(childNode);
+          return rng.insertNode(childNode, isSkipBlankHTML);
         }).reverse();
       };
   

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -55,6 +55,7 @@ define([
           }
         }
       }).on('keyup', function (event) {
+        context.memo('lastRange', range.create(editable));
         context.triggerEvent('keyup', event);
       }).on('focus', function (event) {
         context.triggerEvent('focus', event);
@@ -63,6 +64,7 @@ define([
       }).on('mousedown', function (event) {
         context.triggerEvent('mousedown', event);
       }).on('mouseup', function (event) {
+        context.memo('lastRange', range.create(editable));
         context.triggerEvent('mouseup', event);
       }).on('scroll', function (event) {
         context.triggerEvent('scroll', event);
@@ -409,6 +411,18 @@ define([
     });
 
     /**
+     * insertNodeAfter
+     * insert node after focus
+     * @param {Node} node
+     */
+    this.insertNodeAfter = this.wrapCommand(function (node) {
+      var rng = (context.memo('lastRange') || this.createRange()).select();
+      rng.insertNode(node, true);
+      lastRange = range.create(node, 1, node, 1).select();
+      lastRange.scrollIntoView(editable);
+    });
+
+    /**
      * insert text
      * @param {String} text
      */
@@ -416,6 +430,17 @@ define([
       var rng = this.createRange();
       var textNode = rng.insertNode(dom.createText(text));
       range.create(textNode, dom.nodeLength(textNode)).select();
+    });
+
+    /**
+     * insert text after focus
+     * @param {String} text
+     */
+    this.insertTextAfter = this.wrapCommand(function (text) {
+      var rng = (context.memo('lastRange') || this.createRange()).select();
+      var textNode = rng.insertNode(dom.createText(text), true);
+      lastRange = range.create(textNode, dom.nodeLength(textNode)).select();
+      lastRange.scrollIntoView(editable);
     });
 
     /**
@@ -440,6 +465,16 @@ define([
     this.pasteHTML = this.wrapCommand(function (markup) {
       var contents = this.createRange().pasteHTML(markup);
       range.createFromNodeAfter(list.last(contents)).select();
+    });
+
+    /**
+     * paste HTML after focus
+     * @param {String} markup
+     */
+    this.pasteHTMLAfter = this.wrapCommand(function (markup) {
+      var contents = (context.memo('lastRange') || this.createRange()).select().pasteHTML(markup);
+      lastRange = range.createFromNodeAfter(list.last(contents)).select();
+      lastRange.scrollIntoView(editable);
     });
 
     /**


### PR DESCRIPTION
#### What does this PR do?
- save last range 
- it will be not lost last focus when use new summernote's api
- add three methods ( insertTextAfter, insertNodeAfter, pasteHTMLAfter )
#### Where should the reviewer start?
- start on the src/js/base/Editor.js
- src/js/core/dom.js
- src/js/core/range.js
#### How should this be manually tested?
- run grunt server 

``` javascript
 $(".summernote").summernote("insertTextAfter", "xxx");

 $(".summernote").summernote("insertNodeAfter", $("<div >xxx</div>")[0]);

 $(".summernote").summernote("pasteHTMLAfter", "<div>xxxx</div>");
```
#### Any background context you want to provide?
- summernote is having last range when trigger keyup and mouseup event 
- also summernote is having last range when use with new insert method (insertTextAfter, insertNodeAfter, pasteHTMLAfter)
#### What are the relevant tickets?
#1671, #1520, #874,
#### Screenshots (if for frontend)
### Checklist
