### PR TITLE
Translation to brazilian portuguese of help screen.

### DIFF
--- a/lang/summernote-pt-BR.js
+++ b/lang/summernote-pt-BR.js
@@ -97,6 +97,35 @@
       history: {
         undo: 'Desfazer',
         redo: 'Refazer'
+      },
+      help: {
+        'insertParagraph': 'Inserir Parágrafo',
+        'undo': 'Desfazer o último comando',
+        'redo': 'Refazer o último comando',
+        'tab': 'Tab',
+        'untab': 'Desfazer tab',
+        'bold': 'Colocar em negrito',
+        'italic': 'Colocar em itálico',
+        'underline': 'Sublinhado',
+        'strikethrough': 'Tachado',
+        'removeFormat': 'Remover estilo',
+        'justifyLeft': 'Alinhar à esquerda',
+        'justifyCenter': 'Centralizar',
+        'justifyRight': 'Alinhar à esquerda',
+        'justifyFull': 'Justificar',
+        'insertUnorderedList': 'Lista não ordenada',
+        'insertOrderedList': 'Lista ordenada',
+        'outdent': 'Recuar parágrafo atual',
+        'indent': 'Avançar parágrafo atual',
+        'formatPara': 'Alterar formato do bloco para parágrafo(tag P)',
+        'formatH1': 'Alterar formato do bloco para H1',
+        'formatH2': 'Alterar formato do bloco para H2',
+        'formatH3': 'Alterar formato do bloco para H3',
+        'formatH4': 'Alterar formato do bloco para H4',
+        'formatH5': 'Alterar formato do bloco para H5',
+        'formatH6': 'Alterar formato do bloco para H6',
+        'insertHorizontalRule': 'Inserir régua horizontal',
+        'linkDialog.show': 'Inserir um Hiperlink'
       }
     }
   });

--- a/lang/summernote-pt-BR.js
+++ b/lang/summernote-pt-BR.js
@@ -48,6 +48,7 @@
       },
       style: {
         style: 'Estilo',
+        normal: 'Normal',
         p: 'p',
         blockquote: 'Citação',
         pre: 'Código',

--- a/lang/summernote-pt-BR.js
+++ b/lang/summernote-pt-BR.js
@@ -49,7 +49,6 @@
       style: {
         style: 'Estilo',
         normal: 'Normal',
-        p: 'p',
         blockquote: 'Citação',
         pre: 'Código',
         h1: 'Título 1',


### PR DESCRIPTION
#### What does this PR do?

- Adds translation of help window to brazilian portuguese.
- Removes some strange keys in pt-BR translation file.

#### Where should the reviewer start?

- Verify the **lang/summernote-pt-BR.js** file

#### How should this be manually tested?

- Create a summernote editor like this:
```javascript
$(document).ready(function() {
  $('#summernote').summernote({
    lang: 'pt-BR'
  });
});
```

- With this running, just click the question mark with the tooltip "Ajuda"
- Now, check out the translation to brazilian portuguese

#### Any background context you want to provide?

- I'm using summernote for the new CMS feature of my actual project and would like to contribute with my modifications.

#### Screenshots (if for frontend)
![screen shot 2016-03-27 at 10 50 15 pm](https://cloud.githubusercontent.com/assets/4092969/14069601/87015c90-f472-11e5-9718-6cf6c907d6a3.png)

