### PR TITLE
Remove DOM element on "statusbar" module destroy event - fix #1791

### DIFF
--- a/src/js/base/module/Statusbar.js
+++ b/src/js/base/module/Statusbar.js
@@ -33,6 +33,7 @@ define(function () {
 
     this.destroy = function () {
       $statusbar.off();
+      $statusbar.remove();
     };
   };
 


### PR DESCRIPTION
#### What does this PR do?

- Removes the "statusbar" module completely when calling its destroy function. This is executed when calling `removeModule`'s `Context` API call for disposing the actual module.

#### Where should the reviewer start?

- `src/js/base/module/Statusbar.js` (it's just a simple `.remove()` call)

#### How should this be manually tested?

- Follow testing procedure in #1791.

#### What are the relevant tickets?

Needless to say (joking... it's #1791).