### PR TITLE
isRightEdgeOf(), returns 0 if ancestor is null

### DIFF
--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -471,6 +471,9 @@ define([
      * @return {Boolean}
      */
     var isRightEdgeOf = function (node, ancestor) {
+      if (!ancestor) {
+        return false;
+      }
       while (node && node !== ancestor) {
         if (position(node) !== nodeLength(node.parentNode) - 1) {
           return false;
@@ -593,7 +596,7 @@ define([
 
     /**
      * returns whether point is visible (can set cursor) or not.
-     * 
+     *
      * @param {BoundaryPoint} point
      * @return {Boolean}
      */


### PR DESCRIPTION
The function isRightEdgeOf() throws an error if ancestor is null.

```
TypeError: node is null
https://cdnjs.cloudflare.com/ajax/libs/summernote/0.8.1/summernote.js
Line 633
return node.childNodes.length;
```

How reproduce the problem:
https://jsfiddle.net/JoniJnm/aLme2k6s/3/