### PR TITLE
Add support for RFC 3986-compliant URI schemes on AutoLink module

### DIFF
--- a/src/js/base/module/AutoLink.js
+++ b/src/js/base/module/AutoLink.js
@@ -8,7 +8,7 @@ define([
   var AutoLink = function (context) {
     var self = this;
     var defaultScheme = 'http://';
-    var linkPattern = /^(https?:\/\/|ssh:\/\/|ftp:\/\/|file:\/|mailto:[A-Z0-9._%+-]+@)?(www\.)?(.+)$/i;
+    var linkPattern = /^([A-Za-z][A-Za-z0-9+-.]*\:[\/\/]?|mailto:[A-Z0-9._%+-]+@)?(www\.)?(.+)$/i;
 
     this.events = {
       'summernote.keyup': function (we, e) {


### PR DESCRIPTION
#### What does this PR do?

- This fix adds support to different URI schemes, expanding base RegEx for AutoLink parsing.

#### Where should the reviewer start?

- `src/js/base/module/AutoLink.js`

#### How should this be manually tested?

- follow reproducing steps on #1805.

#### Any background context you want to provide?

- The regular expression applied to the fix is based on the URI Scheme definition (Section 3.1) for [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt)

#### What are the relevant tickets?

#1805