### PR TITLE
Remove onSubmit callback from settings (not supported)

### DIFF
--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -150,7 +150,6 @@ define([
         onEnter: null,
         onKeyup: null,
         onKeydown: null,
-        onSubmit: null,
         onImageUpload: null,
         onImageUploadError: null
       },

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -32,8 +32,7 @@ define([
         onBlur: null,
         onEnter: null,
         onKeyup: null,
-        onKeydown: null,
-        onSubmit: null
+        onKeydown: null
       },
 
       keyMap: {


### PR DESCRIPTION
#### What does this PR do?

- Remove unsupported `onSubmit` callback.

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/1457