### PR TITLE
Link dialog changes

### DIFF
--- a/lang/summernote-es-ES.js
+++ b/lang/summernote-es-ES.js
@@ -36,15 +36,15 @@
       },
       video: {
         video: 'Vídeo',
-        videoLink: 'Link del vídeo',
+        videoLink: 'Enlace del vídeo',
         insert: 'Insertar vídeo',
         url: '¿URL del vídeo?',
         providers: '(YouTube, Vimeo, Vine, Instagram, DailyMotion o Youku)'
       },
       link: {
-        link: 'Link',
-        insert: 'Insertar link',
-        unlink: 'Quitar link',
+        link: 'Enlace',
+        insert: 'Insertar enlace',
+        unlink: 'Quitar enlace',
         edit: 'Editar',
         textToDisplay: 'Texto para mostrar',
         url: '¿Hacia que URL lleva el enlace?',

--- a/lang/summernote-es-ES.js
+++ b/lang/summernote-es-ES.js
@@ -47,7 +47,7 @@
         unlink: 'Quitar link',
         edit: 'Editar',
         textToDisplay: 'Texto para mostrar',
-        url: '¿Hacia que URL lleva el link?',
+        url: '¿Hacia que URL lleva el enlace?',
         openInNewWindow: 'Abrir en una nueva ventana'
       },
       table: {

--- a/src/js/bs3/module/LinkDialog.js
+++ b/src/js/bs3/module/LinkDialog.js
@@ -80,7 +80,7 @@ define([
 
           // if no url was given, copy text to url
           if (!linkInfo.url) {
-            if ($('<input>').attr('type', 'url').val(linkInfo.text).checkValidity()) {
+            if ($('<input>').attr('type', 'url').val(linkInfo.text).get(0).checkValidity()) {
               //only copy if it's valid (note that empty string is valid because of missing required attribute)
               linkInfo.url = linkInfo.text;
             }

--- a/src/js/bs3/module/LinkDialog.js
+++ b/src/js/bs3/module/LinkDialog.js
@@ -14,11 +14,11 @@ define([
 
       var body = '<div class="form-group">' +
                    '<label>' + lang.link.textToDisplay + '</label>' +
-                   '<input class="note-link-text form-control" type="text" />' +
+                   '<input class="note-link-text form-control" type="text" required />' +
                  '</div>' +
                  '<div class="form-group">' +
                    '<label>' + lang.link.url + '</label>' +
-                   '<input class="note-link-url form-control" type="text" value="http://" />' +
+                   '<input class="note-link-url form-control" type="url" value="" placeholder="http://" required />' +
                  '</div>' +
                  (!options.disableLinkTarget ?
                    '<div class="checkbox">' +
@@ -62,13 +62,17 @@ define([
         $linkBtn = self.$dialog.find('.note-link-btn'),
         $openInNewWindow = self.$dialog.find('input[type=checkbox]');
 
+        var toggleBtn = function () {
+          ui.toggleBtn($linkBtn, $linkText.get(0).checkValidity() && $linkUrl.get(0).checkValidity());
+        };
+
         ui.onDialogShown(self.$dialog, function () {
           context.triggerEvent('dialog.shown');
 
           $linkText.val(linkInfo.text);
 
           $linkText.on('input', function () {
-            ui.toggleBtn($linkBtn, $linkText.val() && $linkUrl.val());
+            toggleBtn();
             // if linktext was modified by keyup,
             // stop cloning text from linkUrl
             linkInfo.text = $linkText.val();
@@ -76,12 +80,17 @@ define([
 
           // if no url was given, copy text to url
           if (!linkInfo.url) {
-            linkInfo.url = linkInfo.text || 'http://';
-            ui.toggleBtn($linkBtn, linkInfo.text);
+            if ($('<input>').attr('type', 'url').val(linkInfo.text).checkValidity()) {
+              //only copy if it's valid (note that empty string is valid because of missing required attribute)
+              linkInfo.url = linkInfo.text;
+            }
+            else {
+              linkInfo.url = '';
+            }
           }
 
           $linkUrl.on('input', function () {
-            ui.toggleBtn($linkBtn, $linkText.val() && $linkUrl.val());
+            toggleBtn();
             // display same link on `Text to display` input
             // when create a new link
             if (!linkInfo.text) {
@@ -93,6 +102,8 @@ define([
           self.bindEnterKey($linkText, $linkBtn);
 
           $openInNewWindow.prop('checked', linkInfo.isNewWindow);
+
+          toggleBtn();
 
           $linkBtn.one('click', function (event) {
             event.preventDefault();


### PR DESCRIPTION
* Disable submit button if title or url inputs are invalid (now, you can add invalid urls)
* Move http:// value to placeholder
* Only clone text to url if text is empty or a valid url
* Replace "link" to "enlace" in spanish language