### PR TITLE
Add margin to floating elements

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -671,6 +671,10 @@ define([
      */
     this.floatMe = this.wrapCommand(function (value) {
       var $target = $(this.restoreTarget());
+      $target.css({
+        'margin-left': value === 'right' ? '10px' : '',
+        'margin-right': value === 'left' ? '10px' : ''
+      });
       $target.css('float', value);
     });
 


### PR DESCRIPTION
Adds 10px of margin to floating elements, like images.

Maybe it could add an extra class, something like float_left, float_right to custom the value from css.