### PR TITLE
Add image margin when floats

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -671,6 +671,8 @@ define([
      */
     this.floatMe = this.wrapCommand(function (value) {
       var $target = $(this.restoreTarget());
+      $target.toggleClass('note-float-left', value === 'left');
+      $target.toggleClass('note-float-right', value === 'right');
       $target.css('float', value);
     });
 

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -6,6 +6,9 @@
 @border-color: #a9a9a9;
 @background-color: #f5f5f5;
 
+@img-margin-left: 10px;
+@img-margin-right: 10px;
+
 /* Layout
  ------------------------------------------*/
 .note-editor {
@@ -53,6 +56,14 @@
       sub {
         vertical-align: sub;
       }
+    }
+
+    img.note-float-left {
+      margin-right: @img-margin-right;
+    }
+
+    img.note-float-right {
+      margin-left: @img-margin-left;
     }
   }
 }

--- a/src/less/summernote.scss
+++ b/src/less/summernote.scss
@@ -5,6 +5,9 @@
 $border-color: #a9a9a9;
 $background-color: #f5f5f5;
 
+$img-margin-left: 10px;
+$img-margin-right: 10px;
+
 /* Layout
  ------------------------------------------*/
 .note-editor {
@@ -51,6 +54,14 @@ $background-color: #f5f5f5;
 
       sub {
         vertical-align: sub;
+      }
+
+      img.note-float-left {
+        margin-right: $img-margin-right;
+      }
+
+      img.note-float-right {
+        margin-left: $img-margin-left;
       }
     }
   }


### PR DESCRIPTION
Replaces #1814 
- Adds `note-float-left` or `note-float-right` class to float element
- Creates custom rule in less and scss files to add margin to images
