### PR TITLE
Remove image on backspace key event

### DIFF
--- a/src/js/bs3/module/ImagePopover.js
+++ b/src/js/bs3/module/ImagePopover.js
@@ -1,15 +1,23 @@
 define([
   'summernote/base/core/func',
   'summernote/base/core/list',
-  'summernote/base/core/dom'
-], function (func, list, dom) {
+  'summernote/base/core/dom',
+  'summernote/base/core/key'
+], function (func, list, dom, key) {
   var ImagePopover = function (context) {
+    var self = this;
     var ui = $.summernote.ui;
 
     var options = context.options;
 
     this.shouldInitialize = function () {
       return !list.isEmpty(options.popover.image);
+    };
+
+    this.events = {
+      'summernote.keydown': function (we, e) {
+        self.handleKeydown(e);
+      }
     };
 
     this.initialize = function () {
@@ -25,6 +33,10 @@ define([
       this.$popover.remove();
     };
 
+    this.isVisible = function () {
+      return this.$popover.is(':visible');
+    };
+
     this.update = function (target) {
       if (dom.isImg(target)) {
         var pos = dom.posFromPlaceholder(target);
@@ -33,6 +45,9 @@ define([
           left: pos.left,
           top: pos.top
         });
+
+        //be sure editor has focus to handle key events
+        context.invoke('editor.focus');
       } else {
         this.hide();
       }
@@ -40,6 +55,14 @@ define([
 
     this.hide = function () {
       this.$popover.hide();
+    };
+
+    this.handleKeydown = function (e) {
+      if (list.contains([key.code.BACKSPACE], e.keyCode)) {
+        if (this.isVisible()) {
+          context.invoke('editor.removeMedia');
+        }
+      }
     };
   };
 


### PR DESCRIPTION
When user clicks on an image, by pressing down backpsace key, the image is not removed.

This change allows remove image when popover image is active.
