### PR TITLE
Link image PR valid with summernote v0.8 #226

### DIFF
--- a/src/js/bs3/module/LinkDialog.js
+++ b/src/js/bs3/module/LinkDialog.js
@@ -12,7 +12,7 @@ define([
     this.initialize = function () {
       var $container = options.dialogsInBody ? $(document.body) : $editor;
 
-      var body = '<div class="form-group">' +
+      var body = '<div class="form-group note-group-link-text">' +
                    '<label>' + lang.link.textToDisplay + '</label>' +
                    '<input class="note-link-text form-control" type="text" />' +
                  '</div>' +
@@ -62,13 +62,19 @@ define([
         $linkBtn = self.$dialog.find('.note-link-btn'),
         $openInNewWindow = self.$dialog.find('input[type=checkbox]');
 
+        var toggleSubmitBtn = function () {
+          return ui.toggleBtn($linkBtn, (linkInfo.node || $linkText.val()) && $linkUrl.val());
+        };
+
         ui.onDialogShown(self.$dialog, function () {
           context.triggerEvent('dialog.shown');
+
+          self.$dialog.find('.note-group-link-text').toggleClass('hidden', !!linkInfo.node);
 
           $linkText.val(linkInfo.text);
 
           $linkText.on('input', function () {
-            ui.toggleBtn($linkBtn, $linkText.val() && $linkUrl.val());
+            toggleSubmitBtn();
             // if linktext was modified by keyup,
             // stop cloning text from linkUrl
             linkInfo.text = $linkText.val();
@@ -77,11 +83,10 @@ define([
           // if no url was given, copy text to url
           if (!linkInfo.url) {
             linkInfo.url = linkInfo.text || 'http://';
-            ui.toggleBtn($linkBtn, linkInfo.text);
           }
 
           $linkUrl.on('input', function () {
-            ui.toggleBtn($linkBtn, $linkText.val() && $linkUrl.val());
+            toggleSubmitBtn();
             // display same link on `Text to display` input
             // when create a new link
             if (!linkInfo.text) {
@@ -101,10 +106,13 @@ define([
               range: linkInfo.range,
               url: $linkUrl.val(),
               text: $linkText.val(),
-              isNewWindow: $openInNewWindow.is(':checked')
+              isNewWindow: $openInNewWindow.is(':checked'),
+              node: linkInfo.node
             });
             self.$dialog.modal('hide');
           });
+
+          toggleSubmitBtn();
         });
 
         ui.onDialogHidden(self.$dialog, function () {

--- a/src/js/bs3/module/LinkPopover.js
+++ b/src/js/bs3/module/LinkPopover.js
@@ -49,15 +49,22 @@ define([
       var rng = context.invoke('editor.createRange');
       if (rng.isCollapsed() && rng.isOnAnchor()) {
         var anchor = dom.ancestor(rng.sc, dom.isAnchor);
-        var href = $(anchor).attr('href');
-        this.$popover.find('a').attr('href', href).html(href);
+        var $anchor = $(anchor);
+        if ($anchor.find('img').size()) {
+          //don't show link popover if contains an image (prevents appear both popovers)
+          this.hide();
+        }
+        else {
+          var href = $anchor.attr('href');
+          this.$popover.find('a').attr('href', href).html(href);
 
-        var pos = dom.posFromPlaceholder(anchor);
-        this.$popover.css({
-          display: 'block',
-          left: pos.left,
-          top: pos.top
-        });
+          var pos = dom.posFromPlaceholder(anchor);
+          this.$popover.css({
+            display: 'block',
+            left: pos.left,
+            top: pos.top
+          });
+        }
       } else {
         this.hide();
       }

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -62,7 +62,7 @@ define([
       },
 
       buttons: {},
-      
+
       lang: 'en-US',
 
       // toolbar
@@ -82,6 +82,7 @@ define([
         image: [
           ['imagesize', ['imageSize100', 'imageSize50', 'imageSize25']],
           ['float', ['floatLeft', 'floatRight', 'floatNone']],
+          ['link', ['linkDialogShow', 'unlink']],
           ['remove', ['removeMedia']]
         ],
         link: [


### PR DESCRIPTION
#226 Link image PR valid with summernote v0.8.2

Changes:
- Image popover shows two new buttons: edit link and remove link
- Link dialog hides link text if an image was selected
- Prevents show link popover when an image has a link

TODO:
- Only show remove link button when image has link
