### PR TITLE
Fix #1871 - disabled link dialog button on valid input content

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -558,6 +558,11 @@ define([
       var rng = linkInfo.range || this.createRange();
       var isTextChanged = rng.toString() !== linkText;
 
+      // handle spaced urls from input
+      if (typeof linkUrl === 'string') {
+        linkUrl = linkUrl.trim();
+      }
+
       if (options.onCreateLink) {
         linkUrl = options.onCreateLink(linkUrl);
       }
@@ -576,6 +581,10 @@ define([
       }
 
       $.each(anchors, function (idx, anchor) {
+        // if url doesn't match an URL schema, set http:// as default
+        linkUrl = /^[A-Za-z][A-Za-z0-9+-.]*\:[\/\/]?/.test(linkUrl) ?
+          linkUrl : 'http://' + linkUrl;
+
         $(anchor).attr('href', linkUrl);
         if (isNewWindow) {
           $(anchor).attr('target', '_blank');

--- a/src/js/bs3/module/LinkDialog.js
+++ b/src/js/bs3/module/LinkDialog.js
@@ -65,6 +65,11 @@ define([
         ui.onDialogShown(self.$dialog, function () {
           context.triggerEvent('dialog.shown');
 
+          // if no url was given, copy text to url
+          if (!linkInfo.url) {
+            linkInfo.url = linkInfo.text;
+          }
+
           $linkText.val(linkInfo.text);
 
           $linkText.on('input', function () {
@@ -74,12 +79,6 @@ define([
             linkInfo.text = $linkText.val();
           });
 
-          // if no url was given, copy text to url
-          if (!linkInfo.url) {
-            linkInfo.url = linkInfo.text || 'http://';
-            ui.toggleBtn($linkBtn, linkInfo.text);
-          }
-
           $linkUrl.on('input', function () {
             ui.toggleBtn($linkBtn, $linkText.val() && $linkUrl.val());
             // display same link on `Text to display` input
@@ -88,6 +87,8 @@ define([
               $linkText.val($linkUrl.val());
             }
           }).val(linkInfo.url).trigger('focus');
+
+          ui.toggleBtn($linkBtn, $linkText.val() && $linkUrl.val());
 
           self.bindEnterKey($linkUrl, $linkBtn);
           self.bindEnterKey($linkText, $linkBtn);


### PR DESCRIPTION
#### What does this PR do?

- Fix invalid behavior for Link Dialog confirmation button, when editing a link created using AutoLink feature

#### Where should the reviewer start?

- `src/js/bs3/module/LinkDialog.js`
- `src/js/base/module/Editor.js`

#### How should this be manually tested?

- follow steps described in #1871

#### Any background context you want to provide?

- This includes another fix previously submitted on PR #1278. Since it hasn't been merged yet, the previous solution was cherry-picked into this one

#### What are the relevant tickets?

#1871 
#1274 (from PR #1278)