### PR TITLE
IE8 TextRange fixed

### DIFF
--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -2930,7 +2930,7 @@
           ec = nativeRng.endContainer;
           eo = nativeRng.endOffset;
         } else { // IE8: TextRange
-          var textRange = document.body.createTextRange();
+          var textRange = document.document.createRange();
           var textRangeEnd = textRange.duplicate();
           textRangeEnd.collapse(false);
           var textRangeStart = textRange;

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -2930,7 +2930,7 @@
           ec = nativeRng.endContainer;
           eo = nativeRng.endOffset;
         } else { // IE8: TextRange
-          var textRange = document.body.createRange();
+          var textRange = document.body.createTextRange();
           var textRangeEnd = textRange.duplicate();
           textRangeEnd.collapse(false);
           var textRangeStart = textRange;

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -2930,7 +2930,7 @@
           ec = nativeRng.endContainer;
           eo = nativeRng.endOffset;
         } else { // IE8: TextRange
-          var textRange = document.selection.createRange();
+          var textRange = document.body.createRange();
           var textRangeEnd = textRange.duplicate();
           textRangeEnd.collapse(false);
           var textRangeStart = textRange;

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -2930,7 +2930,7 @@
           ec = nativeRng.endContainer;
           eo = nativeRng.endOffset;
         } else { // IE8: TextRange
-          var textRange = document.document.createRange();
+          var textRange = document.selection.createRange();
           var textRangeEnd = textRange.duplicate();
           textRangeEnd.collapse(false);
           var textRangeStart = textRange;

--- a/src/js/base/core/range.js
+++ b/src/js/base/core/range.js
@@ -686,7 +686,7 @@ define([
           ec = nativeRng.endContainer;
           eo = nativeRng.endOffset;
         } else { // IE8: TextRange
-          var textRange = document.selection.createRange();
+          var textRange = document.body.createRange();
           var textRangeEnd = textRange.duplicate();
           textRangeEnd.collapse(false);
           var textRangeStart = textRange;

--- a/src/js/base/core/range.js
+++ b/src/js/base/core/range.js
@@ -686,7 +686,7 @@ define([
           ec = nativeRng.endContainer;
           eo = nativeRng.endOffset;
         } else { // IE8: TextRange
-          var textRange = document.body.createRange();
+          var textRange = document.body.createTextRange();
           var textRangeEnd = textRange.duplicate();
           textRangeEnd.collapse(false);
           var textRangeStart = textRange;


### PR DESCRIPTION
#### What does this PR do?

Fix ie8 textrange, range created by document.selection.createRange() doesn't has a duplicate() method, thus would throw an error on ie8. Use document.body.createTextRange() to create a textRange instead.

references:
Range object: https://msdn.microsoft.com/en-us/library/hh772133(v=vs.85).aspx
TextRange object: https://msdn.microsoft.com/en-us/library/ms535872(v=vs.85).aspx

#### Where should the reviewer start?

- start on the src/js/base/core/range.js

#### How should this be manually tested?

- try on ie8 browser

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshots (if for frontend)


### Checklist


