### PR TITLE
Fix class attribute definition for custom styleTags elements

### DIFF
--- a/src/js/bs3/module/Buttons.js
+++ b/src/js/bs3/module/Buttons.js
@@ -71,7 +71,7 @@ define([
               var tag = item.tag;
               var title = item.title;
               var style = item.style ? ' style="' + item.style + '" ' : '';
-              var className = item.className ? ' className="' + item.className + '"' : '';
+              var className = item.className ? ' class="' + item.className + '"' : '';
 
               return '<' + tag + style + className + '>' + title + '</' + tag +  '>';
             },


### PR DESCRIPTION
#### What does this PR do?

- Fixes element attribute definition for class names when using custom `styleTags` in Summernote `options`

#### Where should the reviewer start?

- `src/js/bs3/module/Buttons.js`

#### How should this be manually tested?

- It can be tested by implementing custom `styleTags` for the Format Style dropdown option, such as the example in this [fiddle](https://jsfiddle.net/n6hfn0wk)
- This creates a dropdown item element with a `classname` HTML attribute instead of a `class` attribute

