### PR TITLE
Remove invalid `pointer-event` css property

### DIFF
--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -21,7 +21,6 @@
     color: @dropzone-color;
     background-color: white;
     opacity: 0.95;
-    pointer-event: none;
 
     .note-dropzone-message {
       display: table-cell;

--- a/src/less/summernote.scss
+++ b/src/less/summernote.scss
@@ -20,7 +20,6 @@ $background-color: #f5f5f5;
     color: $dropzone-color;
     background-color: white;
     opacity: 0.95;
-    pointer-event: none;
 
     .note-dropzone-message {
       display: table-cell;


### PR DESCRIPTION
#### What does this PR do?

The style for `.note-dropzone` defines the css property `pointer-event` which is not a valid css property. 

We originally thought this was intended to be [`pointer-events`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events), but when we corrected it, drag and drop functionality went back to the browser default (simply navigating to the file).

![summernote](https://cloud.githubusercontent.com/assets/60145/15410913/74d31508-1dea-11e6-838a-f8e35c1f415d.gif)


#### How should this be manually tested?

- Ensure that drag an drop image upload still works

