### PR TITLE
Tooltip can be shown/hidden by settings

### DIFF
--- a/src/js/base/core/agent.js
+++ b/src/js/base/core/agent.js
@@ -56,6 +56,11 @@ define(['jquery'], function ($) {
     }
   }
 
+  var isSupportTouch =
+    (('ontouchstart' in window) ||
+     (navigator.MaxTouchPoints > 0) ||
+     (navigator.msMaxTouchPoints > 0));
+
   /**
    * @class core.agent
    *
@@ -76,6 +81,7 @@ define(['jquery'], function ($) {
     browserVersion: browserVersion,
     jqueryVersion: parseFloat($.fn.jquery),
     isSupportAmd: isSupportAmd,
+    isSupportTouch: isSupportTouch,
     hasCodeMirror: hasCodeMirror,
     isFontInstalled: isFontInstalled,
     isW3CRangeSupport: !!document.createRange

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -108,6 +108,7 @@ define([
       shortcuts: true,
       textareaAutoSync: true,
       direction: null,
+      tooltip: 'auto',
 
       styleTags: ['p', 'blockquote', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
 

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -1,6 +1,7 @@
 define([
+  'summernote/base/core/agent',
   'summernote/base/renderer'
-], function (renderer) {
+], function (agent, renderer) {
   var editor = renderer.create('<div class="note-editor note-frame panel panel-default"/>');
   var toolbar = renderer.create('<div class="note-toolbar panel-heading"/>');
   var editingArea = renderer.create('<div class="note-editing-area"/>');
@@ -20,17 +21,6 @@ define([
   var airEditable = renderer.create('<div class="note-editable" contentEditable="true"/>');
 
   var buttonGroup = renderer.create('<div class="note-btn-group btn-group">');
-  var button = renderer.create('<button type="button" class="note-btn btn btn-default btn-sm" tabindex="-1">', function ($node, options) {
-    if (options && options.tooltip) {
-      $node.attr({
-        title: options.tooltip
-      }).tooltip({
-        container: 'body',
-        trigger: 'hover',
-        placement: 'bottom'
-      });
-    }
-  });
 
   var dropdown = renderer.create('<div class="dropdown-menu">', function ($node, options) {
     var markup = $.isArray(options.items) ? options.items.map(function (item) {
@@ -131,13 +121,28 @@ define([
     airEditor: airEditor,
     airEditable: airEditable,
     buttonGroup: buttonGroup,
-    button: button,
     dropdown: dropdown,
     dropdownCheck: dropdownCheck,
     palette: palette,
     dialog: dialog,
     popover: popover,
     icon: icon,
+    options: {},
+
+    button: function ($node, options) {
+      var showTooltips = (self.options.tooltip === true) || (self.options.tooltip === 'auto' && !agent.isSupportTouch);
+      return renderer.create('<button type="button" class="note-btn btn btn-default btn-sm" tabindex="-1">', function ($node, options) {
+        if (options && options.tooltip && showTooltips) {
+          $node.attr({
+            title: options.tooltip
+          }).tooltip({
+            container: 'body',
+            trigger: 'hover',
+            placement: 'bottom'
+          });
+        }
+      })($node, options);
+    },
 
     toggleBtn: function ($btn, isEnable) {
       $btn.toggleClass('disabled', !isEnable);
@@ -165,6 +170,7 @@ define([
     },
 
     createLayout: function ($note, options) {
+      self.options = options;
       var $editor = (options.airMode ? ui.airEditor([
         ui.editingArea([
           ui.airEditable()

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -1,7 +1,6 @@
 define([
-  'summernote/base/core/agent',
   'summernote/base/renderer'
-], function (agent, renderer) {
+], function (renderer) {
   var editor = renderer.create('<div class="note-editor note-frame panel panel-default"/>');
   var toolbar = renderer.create('<div class="note-toolbar panel-heading"/>');
   var editingArea = renderer.create('<div class="note-editing-area"/>');
@@ -130,9 +129,8 @@ define([
     options: {},
 
     button: function ($node, options) {
-      var showTooltips = (self.options.tooltip === true) || (self.options.tooltip === 'auto' && !agent.isSupportTouch);
       return renderer.create('<button type="button" class="note-btn btn btn-default btn-sm" tabindex="-1">', function ($node, options) {
-        if (options && options.tooltip && showTooltips) {
+        if (options && options.tooltip && self.options.tooltip) {
           $node.attr({
             title: options.tooltip
           }).tooltip({

--- a/src/js/summernote.js
+++ b/src/js/summernote.js
@@ -1,8 +1,9 @@
 define([
   'jquery',
+  'summernote/base/core/agent',
   'summernote/base/core/list',
   'summernote/base/Context'
-], function ($, list, Context) {
+], function ($, agent, list, Context) {
   $.fn.extend({
     /**
      * Summernote API
@@ -18,8 +19,11 @@ define([
       var options = hasInitOptions ? list.head(arguments) : {};
 
       options = $.extend({}, $.summernote.options, options);
+
+      // Update options
       options.langInfo = $.extend(true, {}, $.summernote.lang['en-US'], $.summernote.lang[options.lang]);
       options.icons = $.extend(true, {}, $.summernote.options.icons, options.icons);
+      options.tooltip = options.tooltip === 'auto' ? !agent.isSupportTouch : options.tooltip;
 
       this.each(function (idx, note) {
         var $note = $(note);


### PR DESCRIPTION
#### What does this PR do?
- This patch allows user can customize showing/hiding tooltip by settings.
- On mobile(touchable devices), tooltips are only obstacles, not good for user experiences.
- So I added a `tooltip` option in settings and make it `auto` by default.
#### Where should the reviewer start?
- `base/core/agent.js`
- `bs3/ui.js`
#### How should this be manually tested?
- Run summernote demo page on desktop and mobile devices
#### What are the relevant tickets?
- #1911, #1847, #1836, #1818
