### PR TITLE
Add support to custom styletags right into the style toolbar menu

### DIFF
--- a/src/js/base/Context.js
+++ b/src/js/base/Context.js
@@ -190,7 +190,8 @@ define([
     this.createInvokeHandler = function (namespace, value) {
       return function (event) {
         event.preventDefault();
-        self.invoke(namespace, value || $(event.target).closest('[data-value]').data('value'));
+        var $target = $(event.target);
+        self.invoke(namespace, value || $target.closest('[data-value]').data('value'), $target);
       };
     };
 

--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -593,7 +593,7 @@ define([
 
     /**
      * returns whether point is visible (can set cursor) or not.
-     * 
+     *
      * @param {BoundaryPoint} point
      * @return {Boolean}
      */
@@ -983,6 +983,18 @@ define([
       });
     };
 
+    /**
+     * @method isCustomStyleTag
+     *
+     * assert if a node contains a "note-styletag" class,
+     * which implies that's a custom-made style tag node
+     *
+     * @param {Node} an HTML DOM node
+     */
+    var isCustomStyleTag = function (node) {
+      return node && !dom.isText(node) && list.contains(node.classList, 'note-styletag');
+    };
+
     return {
       /** @property {String} NBSP_CHAR */
       NBSP_CHAR: NBSP_CHAR,
@@ -1069,7 +1081,8 @@ define([
       value: value,
       posFromPlaceholder: posFromPlaceholder,
       attachEvents: attachEvents,
-      detachEvents: detachEvents
+      detachEvents: detachEvents,
+      isCustomStyleTag: isCustomStyleTag
     };
   })();
 

--- a/src/js/base/editing/Typing.js
+++ b/src/js/base/editing/Typing.js
@@ -69,8 +69,8 @@ define([
             dom.remove(anchor);
           });
 
-          // replace empty heading or pre with P tag
-          if ((dom.isHeading(nextPara) || dom.isPre(nextPara)) && dom.isEmpty(nextPara)) {
+          // replace empty heading, pre or custom-made styleTag with P tag
+          if ((dom.isHeading(nextPara) || dom.isPre(nextPara) || dom.isCustomStyleTag(nextPara)) && dom.isEmpty(nextPara)) {
             nextPara = dom.replace(nextPara, 'p');
           }
         }

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -430,11 +430,20 @@ define([
      *
      * @param {String} tagName
      */
-    this.formatBlock = this.wrapCommand(function (tagName) {
+    this.formatBlock = this.wrapCommand(function (tagName, $target) {
+      var onApplyCustomStyle = context.options.callbacks.onApplyCustomStyle;
+      if (onApplyCustomStyle) {
+        onApplyCustomStyle.call(this, $target, context, this.onFormatBlock);
+      } else {
+        this.onFormatBlock(tagName);
+      }
+    });
+
+    this.onFormatBlock = function (tagName) {
       // [workaround] for MSIE, IE need `<`
       tagName = agent.isMSIE ? '<' + tagName + '>' : tagName;
       document.execCommand('FormatBlock', false, tagName);
-    });
+    };
 
     this.formatPara = function () {
       this.formatBlock('P');

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -36,7 +36,11 @@ define([
     var markup = $.isArray(options.items) ? options.items.map(function (item) {
       var value = (typeof item === 'string') ? item : (item.value || '');
       var content = options.template ? options.template(item) : item;
-      return '<li><a href="#" data-value="' + value + '">' + content + '</a></li>';
+      var option = (typeof item === 'object') ? item.option : undefined;
+
+      var dataValue = 'data-value="' + value + '"';
+      var dataOption = (option !== undefined) ? ' data-option="' + option + '"' : '';
+      return '<li><a href="#" ' + (dataValue + dataOption) + '>' + content + '</a></li>';
     }).join('') : options.items;
 
     $node.html(markup);


### PR DESCRIPTION
#### What does this PR do?

It adds the support to add custom-based styletags to the toolbar's style menu (the one with the magic wand icon). Some alternative solutions have been available as plugins, such as @creativeprogramming's [summernote-addclass](https://github.com/creativeprogramming/summernote-addclass/) and @nanakii's [summernote template plugin](http://code.nanakii.fr/summernote-plugins/examples/template.html). They're nice and awesome, but given the extensibility, they can't be integrated to the built-in style formatting feature.
#### Where should the reviewer start?
- `src/js/base/Context.js`
- `src/js/base/core/dom.js`
- `src/js/base/editing/Typing.js`
- `src/js/base/module/Editor.js`
- `src/js/bs3/ui.js`
#### Any background context you want to provide?

This feature is enabled by the use of a special callback function, `onApplyCustomStyle`. The application developer shall implement a function and attach it on the `callbacks` object in Summernote options.
This function receives three arguments from Summernote's `Editor.formatBlock` core implementation:
- `$target` - a jQuery based event object related to the target element (the selected item from style menu)
- `context` - the Summernote `context` object
- `onFormatBlock` - the default implementation from `Editor.formatBlock`, which uses `execCommand` API

The application developer is free to implement his tag elements the way he or she wants, given the use of the `onApplyCustomStyle` function.

Extra info may be passed through an `option` attribute applicable to the custom styletag menu item (this will be added as a `data-option` attribute for the related HTML element).
#### What are the relevant tickets?
#857
