### PR TITLE
Allow drag and drop of image from browser

### DIFF
--- a/src/js/base/module/Dropzone.js
+++ b/src/js/base/module/Dropzone.js
@@ -85,8 +85,10 @@ define(function () {
       $dropzone.on('drop', function (event) {
         var dataTransfer = event.originalEvent.dataTransfer;
 
+        // stop the browser from opening the dropped content
+        event.preventDefault();
+
         if (dataTransfer && dataTransfer.files && dataTransfer.files.length) {
-          event.preventDefault();
           $editable.focus();
           context.invoke('editor.insertImagesOrCallback', dataTransfer.files);
         } else {


### PR DESCRIPTION
#### What does this PR do?

It allows the user to drag and drop image from a browser
#### Where should the reviewer start?
- start on the src/js/base/module/Dropzone.js
#### How should this be manually tested?
- drop an image into the composer by dragging from chrome
#### Any background context you want to provide?
- none
#### What are the relevant tickets?
- https://github.com/summernote/summernote/issues/1943
- https://github.com/summernote/summernote/issues/215
