### PR TITLE
508 compliance update on summernote.js

### DIFF
--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -1859,7 +1859,7 @@
   var editor = renderer.create('<div class="note-editor note-frame panel panel-default"/>');
   var toolbar = renderer.create('<div class="note-toolbar panel-heading"/>');
   var editingArea = renderer.create('<div class="note-editing-area"/>');
-  var codable = renderer.create('<textarea class="note-codable"/>');
+  var codable = renderer.create('<textarea class="note-codable" aria-label="codable"/>');
   var editable = renderer.create('<div class="note-editable panel-body" contentEditable="true"/>');
   var statusbar = renderer.create([
     '<div class="note-statusbar">',
@@ -1878,7 +1878,8 @@
   var button = renderer.create('<button type="button" class="note-btn btn btn-default btn-sm" tabindex="-1">', function ($node, options) {
     if (options && options.tooltip) {
       $node.attr({
-        title: options.tooltip
+        title: options.tooltip,
+        "aria-label": options.tooltip
       }).tooltip({
         container: 'body',
         trigger: 'hover',
@@ -1920,6 +1921,7 @@
           'data-event="', eventName, '" ',
           'data-value="', color, '" ',
           'title="', color, '" ',
+          'aria-label="', color,'" ',
           'data-toggle="button" tabindex="-1"></button>'
         ].join(''));
       }
@@ -5892,16 +5894,16 @@
       var $container = options.dialogsInBody ? $(document.body) : $editor;
 
       var body = '<div class="form-group">' +
-                   '<label>' + lang.link.textToDisplay + '</label>' +
+                   '<label id="textToDisplay">' + lang.link.textToDisplay + '</label>' +
                    '<input class="note-link-text form-control" type="text" />' +
                  '</div>' +
                  '<div class="form-group">' +
-                   '<label>' + lang.link.url + '</label>' +
-                   '<input class="note-link-url form-control" type="text" value="http://" />' +
+                   '<label id="url">' + lang.link.url + '</label>' +
+                   '<input class="note-link-url form-control" type="text" value="http://" aria-labelledby="url" />' +
                  '</div>' +
                  (!options.disableLinkTarget ?
                    '<div class="checkbox">' +
-                     '<label>' + '<input type="checkbox" checked> ' + lang.link.openInNewWindow + '</label>' +
+                     '<label id="openInNewWindow">' + '<input type="checkbox" aria-labelledby="openInNewWindow" checked> ' + lang.link.openInNewWindow + '</label>' +
                    '</div>' : ''
                  );
       var footer = '<button href="#" class="btn btn-primary note-link-btn disabled" disabled>' + lang.link.insert + '</button>';
@@ -6118,13 +6120,13 @@
       }
 
       var body = '<div class="form-group note-group-select-from-files">' +
-                   '<label>' + lang.image.selectFromFiles + '</label>' +
-                   '<input class="note-image-input form-control" type="file" name="files" accept="image/*" multiple="multiple" />' +
+                   '<label id="selectFromFiles">' + lang.image.selectFromFiles + '</label>' +
+                   '<input class="note-image-input form-control" type="file" name="files" accept="image/*" multiple="multiple" aria-labelledby="selectFromFiles" />' +
                    imageLimitation +
                  '</div>' +
                  '<div class="form-group note-group-image-url" style="overflow:auto;">' +
-                   '<label>' + lang.image.url + '</label>' +
-                   '<input class="note-image-url form-control col-md-12" type="text" />' +
+                   '<label id="imageURL">' + lang.image.url + '</label>' +
+                   '<input class="note-image-url form-control col-md-12" type="text" aria-labelledby="imageURL" />' +
                  '</div>';
       var footer = '<button href="#" class="btn btn-primary note-image-btn disabled" disabled>' + lang.image.insert + '</button>';
 
@@ -6269,8 +6271,8 @@
       var $container = options.dialogsInBody ? $(document.body) : $editor;
 
       var body = '<div class="form-group row-fluid">' +
-          '<label>' + lang.video.url + ' <small class="text-muted">' + lang.video.providers + '</small></label>' +
-          '<input class="note-video-url form-control span12" type="text" />' +
+          '<label id="videoURL">' + lang.video.url + ' <small class="text-muted">' + lang.video.providers + '</small></label>' +
+          '<input class="note-video-url form-control span12" type="text" aria-labelledby="videoURL" />' +
           '</div>';
       var footer = '<button href="#" class="btn btn-primary note-video-btn disabled" disabled>' + lang.video.insert + '</button>';
 


### PR DESCRIPTION
summernote pull request:

#### What does this PR do?

- It adds an aria-label to all of the buttons on summernote.

#### Where should the reviewer start?

- start on the src/summernote.js line 1882-1930
-changes made on line 1882 and 1924
-Check lines:
   * 1859-1865
   * 1878-1885
   * 1921-1927
   * 5894-5909
   * 6120-6132
   * 6271-6278

`
  var codable = renderer.create('<textarea class="note-codable" aria-label="codable"/>');

`

`       
 title: options.tooltip,
"aria-label": options.tooltip 

`

`   
'title="', color, '" ',
 'aria-label="', color,'" ',
 'data-toggle="button" tabindex="-1"></button>'  
 `

`
                   '<label id="textToDisplay">' + lang.link.textToDisplay + '</label>' +
                   '<input class="note-link-text form-control" type="text" aria-labelledby="textToDisplay" />' +

                   '<label id="url">' + lang.link.url + '</label>' +
                   '<input class="note-link-url form-control" type="text" value="http://" aria-labelledby="url" />' +

                     '<label id="openInNewWindow">' + '<input type="checkbox" aria-labelledby="openInNewWindow" checked> ' + lang.link.openInNewWindow + '</label>' +

`

`
                   '<label id="selectFromFiles">' + lang.image.selectFromFiles + '</label>' +
                   '<input class="note-image-input form-control" type="file" name="files" accept="image/*" multiple="multiple" aria-labelledby="selectFromFiles" />' +

                   '<label id="imageURL">' + lang.image.url + '</label>' +
                   '<input class="note-image-url form-control col-md-12" type="text" aria-labelledby="imageURL" />' +

`

`
          '<label id="videoURL">' + lang.video.url + ' <small class="text-muted">' + lang.video.providers + '</small></label>' +
          '<input class="note-video-url form-control span12" type="text" aria-labelledby="videoURL" />' +

`

var codable = renderer.create('<textarea class="note-codable" aria-label="codable"/>');

#### How should this be manually tested?

- Download the wave tool plugin from google chrome and run the wave tool against summernote and you will see the aria-label being implemented. 
-aria-label is not visible to the human eye only screen readers can pick it up. The wave tool makes it visible for us.  

#### Any background context you want to provide?

- Need to meet 508 compliance and this was holding me back.

#### What are the relevant tickets?


#### Screenshots (if for frontend)
- shows summernote running with wave tool

![screen shot 2016-09-29 at 12 25 33 pm](https://cloud.githubusercontent.com/assets/18424330/18962705/eba4a4ea-863f-11e6-9bed-5331d20c4de1.png)
![screen shot 2016-09-29 at 12 36 06 pm](https://cloud.githubusercontent.com/assets/18424330/18963074/628252be-8641-11e6-98e5-0d418bc7a8f1.png)
![screen shot 2016-09-29 at 1 21 24 pm](https://cloud.githubusercontent.com/assets/18424330/18965605/ec42376c-864b-11e6-91cd-dfb0ec5fd6b1.png)
![screen shot 2016-09-29 at 1 21 34 pm](https://cloud.githubusercontent.com/assets/18424330/18965604/ec3cd3ee-864b-11e6-8c8a-366e650007d8.png)
![screen shot 2016-09-29 at 1 21 55 pm](https://cloud.githubusercontent.com/assets/18424330/18965603/ec3a8c92-864b-11e6-91a0-15c1fb3d47c6.png)
![screen shot 2016-09-29 at 1 22 04 pm](https://cloud.githubusercontent.com/assets/18424330/18965610/efceb716-864b-11e6-9f30-5222b7bfffe1.png)



### Checklist
- [ x] didn't break anything to my knowledge 



I used the wave tool plugin on google chrome fixed all of the errors that popped up with summernote that indicated that the button tag does not have any content within it.
