### PR TITLE
Feature/508 latifz1 patch 1

### DIFF
--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -1879,7 +1879,7 @@
     if (options && options.tooltip) {
       $node.attr({
         title: options.tooltip,
-        "aria-label": options.tooltip
+        'aria-label': options.tooltip
       }).tooltip({
         container: 'body',
         trigger: 'hover',
@@ -1921,7 +1921,7 @@
           'data-event="', eventName, '" ',
           'data-value="', color, '" ',
           'title="', color, '" ',
-          'aria-label="', color,'" ',
+          'aria-label="', color, '" ',
           'data-toggle="button" tabindex="-1"></button>'
         ].join(''));
       }
@@ -5903,7 +5903,9 @@
                  '</div>' +
                  (!options.disableLinkTarget ?
                    '<div class="checkbox">' +
-                     '<label id="openInNewWindow">' + '<input type="checkbox" aria-labelledby="openInNewWindow" checked> ' + lang.link.openInNewWindow + '</label>' +
+                     '<label id="NewWindow">' + 
+                     '<input type="checkbox" aria-labelledby="NewWindow" checked> ' + 
+                     lang.link.openInNewWindow + '</label>' +
                    '</div>' : ''
                  );
       var footer = '<button href="#" class="btn btn-primary note-link-btn disabled" disabled>' + lang.link.insert + '</button>';
@@ -6120,9 +6122,9 @@
       }
 
       var body = '<div class="form-group note-group-select-from-files">' +
-                   '<label id="selectFromFiles">' + lang.image.selectFromFiles + '</label>' +
-                   '<input class="note-image-input form-control" type="file" name="files" accept="image/*" multiple="multiple" aria-labelledby="selectFromFiles" />' +
-                   imageLimitation +
+                  '<label id="Files">' + lang.image.selectFromFiles + '</label>' +
+                  '<input class="note-image-input form-control" type="file" name="files" accept="image/*" multiple="multiple" aria-labelledby="Files" />' +
+                 imageLimitation +
                  '</div>' +
                  '<div class="form-group note-group-image-url" style="overflow:auto;">' +
                    '<label id="imageURL">' + lang.image.url + '</label>' +


### PR DESCRIPTION
summernote pull request:

#### What does this PR do?

- It adds an aria-label to all of the buttons on summernote.

#### Where should the reviewer start?

- start on the src/summernote.js line 1882-1930
-changes made on line 1882 and 1924

`        title: options.tooltip,
        "aria-label": options.tooltip 
`

`   'title="', color, '" ',
     'aria-label="', color,'" ',
     'data-toggle="button" tabindex="-1"></button>'  
 `

var codable = renderer.create('<textarea class="note-codable" aria-label="codable"/>');

#### How should this be manually tested?

- Download the wave tool plugin from google chrome and run the wave tool against summernote and you will see the aria-label being implemented. 
-aria-label is not visible to the human eye only screen readers can pick it up. The wave tool makes it visible for us.  

#### Any background context you want to provide?

- Need to meet 508 compliance and this was holding me back.

#### What are the relevant tickets?


#### Screenshots (if for frontend)
- shows summernote running with wave tool

![screen shot 2016-09-29 at 12 25 33 pm](https://cloud.githubusercontent.com/assets/18424330/18962705/eba4a4ea-863f-11e6-9bed-5331d20c4de1.png)

![screen shot 2016-09-29 at 12 36 06 pm](https://cloud.githubusercontent.com/assets/18424330/18963074/628252be-8641-11e6-98e5-0d418bc7a8f1.png)


### Checklist
- [ x] didn't break anything to my knowledge 



I used the wave tool plugin on google chrome fixed all of the errors that popped up with summernote that indicated that the button tag does not have any content within it.
