### PR TITLE
508 compliance

### DIFF
--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -5894,12 +5894,12 @@
       var $container = options.dialogsInBody ? $(document.body) : $editor;
 
       var body = '<div class="form-group">' +
-                   '<label id="Display">' + lang.link.textToDisplay + '</label>' +
-                   '<input class="note-link-text form-control" type="text" aria-labelledby="Display" />' +
+                   '<label id="textToDisplay">' + lang.link.textToDisplay + '</label>' +
+                   '<input class="note-link-text form-control" type="text" aria-labelledby="textToDisplay" />' +
                  '</div>' +
                  '<div class="form-group">' +
-                   '<label id="url">' + lang.link.url + '</label>' +
-                   '<input class="note-link-url form-control" type="text" value="http://" aria-labelledby="url" />' +
+                   '<label id="LinkUrl">' + lang.link.url + '</label>' +
+                   '<input class="note-link-url form-control" type="text" value="http://" aria-labelledby="LinkUrl" />' +
                  '</div>' +
                  (!options.disableLinkTarget ?
                    '<div class="checkbox">' +
@@ -6125,8 +6125,8 @@
                    imageLimitation +
                  '</div>' +
                  '<div class="form-group note-group-image-url" style="overflow:auto;">' +
-                   '<label id="imageURL">' + lang.image.url + '</label>' +
-                   '<input class="note-image-url form-control col-md-12" type="text" aria-labelledby="imageURL" />' +
+                   '<label id="ImageURL">' + lang.image.url + '</label>' +
+                   '<input class="note-image-url form-control col-md-12" type="text" aria-labelledby="ImageURL" />' +
                  '</div>';
       var footer = '<button href="#" class="btn btn-primary note-image-btn disabled" disabled>' + lang.image.insert + '</button>';
 
@@ -6271,8 +6271,8 @@
       var $container = options.dialogsInBody ? $(document.body) : $editor;
 
       var body = '<div class="form-group row-fluid">' +
-          '<label id="videoURL">' + lang.video.url + ' <small class="text-muted">' + lang.video.providers + '</small></label>' +
-          '<input class="note-video-url form-control span12" type="text" aria-labelledby="videoURL" />' +
+          '<label id="VideoURL">' + lang.video.url + ' <small class="text-muted">' + lang.video.providers + '</small></label>' +
+          '<input class="note-video-url form-control span12" type="text" aria-labelledby="VideoURL" />' +
           '</div>';
       var footer = '<button href="#" class="btn btn-primary note-video-btn disabled" disabled>' + lang.video.insert + '</button>';
 

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -5894,12 +5894,12 @@
       var $container = options.dialogsInBody ? $(document.body) : $editor;
 
       var body = '<div class="form-group">' +
-                   '<label id="textToDisplay">' + lang.link.textToDisplay + '</label>' +
-                   '<input class="note-link-text form-control" type="text" aria-labelledby="textToDisplay" />' +
+                   '<label>' + lang.link.textToDisplay + '</label>' +
+                   '<input class="note-link-text form-control" type="text" />' +
                  '</div>' +
                  '<div class="form-group">' +
-                   '<label id="LinkUrl">' + lang.link.url + '</label>' +
-                   '<input class="note-link-url form-control" type="text" value="http://" aria-labelledby="LinkUrl" />' +
+                   '<label>' + lang.link.url + '</label>' +
+                   '<input class="note-link-url form-control" type="text" value="http://" />' +
                  '</div>' +
                  (!options.disableLinkTarget ?
                    '<div class="checkbox">' +
@@ -6125,8 +6125,8 @@
                    imageLimitation +
                  '</div>' +
                  '<div class="form-group note-group-image-url" style="overflow:auto;">' +
-                   '<label id="ImageURL">' + lang.image.url + '</label>' +
-                   '<input class="note-image-url form-control col-md-12" type="text" aria-labelledby="ImageURL" />' +
+                   '<label>' + lang.image.url + '</label>' +
+                   '<input class="note-image-url form-control col-md-12" type="text" />' +
                  '</div>';
       var footer = '<button href="#" class="btn btn-primary note-image-btn disabled" disabled>' + lang.image.insert + '</button>';
 
@@ -6271,8 +6271,8 @@
       var $container = options.dialogsInBody ? $(document.body) : $editor;
 
       var body = '<div class="form-group row-fluid">' +
-          '<label id="VideoURL">' + lang.video.url + ' <small class="text-muted">' + lang.video.providers + '</small></label>' +
-          '<input class="note-video-url form-control span12" type="text" aria-labelledby="VideoURL" />' +
+          '<label>' + lang.video.url + ' <small class="text-muted">' + lang.video.providers + '</small></label>' +
+          '<input class="note-video-url form-control span12" type="text" />' +
           '</div>';
       var footer = '<button href="#" class="btn btn-primary note-video-btn disabled" disabled>' + lang.video.insert + '</button>';
 


### PR DESCRIPTION
summernote pull request:
#### What does this PR do?
- It adds an aria-label to all of the buttons on summernote.
#### Where should the reviewer start?
- start on the src/summernote.js line 1882-1930
  -changes made on line 1882 and 1924

`title: options.tooltip,
        'aria-label': options.tooltip 
`

`'title="', color, '" ',
     'aria-label="', color,'" ',
     'data-toggle="button" tabindex="-1"></button>'  
`

var codable = renderer.create('<textarea class="note-codable" aria-label="codable"/>');
#### How should this be manually tested?
- Download the wave tool plugin from google chrome and run the wave tool against summernote and you will see the aria-label being implemented. 
  -aria-label is not visible to the human eye only screen readers can pick it up. The wave tool makes it visible for us.  
#### Any background context you want to provide?
- Need to meet 508 compliance and this was holding me back.
### Checklist
- [ x] didn't break anything to my knowledge 

I used the wave tool plugin on google chrome fixed all of the errors that popped up with summernote that indicated that the button tag does not have any content within it.
