### PR TITLE
Fix reset foreground text color

### DIFF
--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -5316,7 +5316,7 @@
       context.memo('button.color', function () {
         var $defaultForeColor = $('.note-editor.note-frame .note-editing-area .note-editable').css('color');
         if (!$defaultForeColor) {
-        $defaultForeColor = '#000';
+          $defaultForeColor = '#000';
         }
         return ui.buttonGroup({
           className: 'note-color',
@@ -5361,7 +5361,7 @@
                 '<div class="btn-group">',
                 '  <div class="note-palette-title">' + lang.color.foreground + '</div>',
                 '  <div>',
-                '    <button type="button" class="note-color-reset btn btn-default" data-event="foreColor"    '+
+                '    <button type="button" class="note-color-reset btn btn-default" data-event="foreColor"    ' +
                 ', data-value="' + $defaultForeColor + '">',
                 lang.color.resetToDefault,
                 '    </button>',

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -5314,11 +5314,11 @@
       });
 
       context.memo('button.color', function () {
-	var $defaultForeColor = $('.note-editor.note-frame .note-editing-area .note-editable').css('color');
-	if (!$defaultForeColor) {
-		$defaultForeColor = '#000';
-  }
-	return ui.buttonGroup({
+        var $defaultForeColor = $('.note-editor.note-frame .note-editing-area .note-editable').css('color');
+        if (!$defaultForeColor) {
+		      $defaultForeColor = '#000';
+        }
+	      return ui.buttonGroup({
           className: 'note-color',
           children: [
             ui.button({
@@ -5361,7 +5361,7 @@
                 '<div class="btn-group">',
                 '  <div class="note-palette-title">' + lang.color.foreground + '</div>',
                 '  <div>',
-                '    <button type="button" class="note-color-reset btn btn-default" data-event="foreColor"  ' + 
+                '    <button type="button" class="note-color-reset btn btn-default" data-event="foreColor"'+
                 ', data-value="' + $defaultForeColor + '">',
                 lang.color.resetToDefault,
                 '    </button>',

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -5316,8 +5316,8 @@
       context.memo('button.color', function () {
 	var $defaultForeColor = $('.note-editor.note-frame .note-editing-area .note-editable').css('color');
 	if (!$defaultForeColor) {
-		$defaultForeColor = "#000";
-	}
+		$defaultForeColor = '#000';
+  }
 	return ui.buttonGroup({
           className: 'note-color',
           children: [
@@ -5361,7 +5361,8 @@
                 '<div class="btn-group">',
                 '  <div class="note-palette-title">' + lang.color.foreground + '</div>',
                 '  <div>',
-                '    <button type="button" class="note-color-reset btn btn-default" data-event="foreColor" data-value="' + $defaultForeColor + '">',
+                '    <button type="button" class="note-color-reset btn btn-default" data-event="foreColor"  ' + 
+                ', data-value="' + $defaultForeColor + '">',
                 lang.color.resetToDefault,
                 '    </button>',
                 '  </div>',

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -5316,9 +5316,9 @@
       context.memo('button.color', function () {
         var $defaultForeColor = $('.note-editor.note-frame .note-editing-area .note-editable').css('color');
         if (!$defaultForeColor) {
-		      $defaultForeColor = '#000';
+        $defaultForeColor = '#000';
         }
-	      return ui.buttonGroup({
+        return ui.buttonGroup({
           className: 'note-color',
           children: [
             ui.button({
@@ -5361,7 +5361,7 @@
                 '<div class="btn-group">',
                 '  <div class="note-palette-title">' + lang.color.foreground + '</div>',
                 '  <div>',
-                '    <button type="button" class="note-color-reset btn btn-default" data-event="foreColor"'+
+                '    <button type="button" class="note-color-reset btn btn-default" data-event="foreColor"    '+
                 ', data-value="' + $defaultForeColor + '">',
                 lang.color.resetToDefault,
                 '    </button>',

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -5314,7 +5314,11 @@
       });
 
       context.memo('button.color', function () {
-        return ui.buttonGroup({
+	var $defaultForeColor = $('.note-editor.note-frame .note-editing-area .note-editable').css('color');
+	if (!$defaultForeColor) {
+		$defaultForeColor = "#000";
+	}
+	return ui.buttonGroup({
           className: 'note-color',
           children: [
             ui.button({
@@ -5357,7 +5361,7 @@
                 '<div class="btn-group">',
                 '  <div class="note-palette-title">' + lang.color.foreground + '</div>',
                 '  <div>',
-                '    <button type="button" class="note-color-reset btn btn-default" data-event="foreColor" data-value="#000">',
+                '    <button type="button" class="note-color-reset btn btn-default" data-event="foreColor" data-value="' + $defaultForeColor + '">',
                 lang.color.resetToDefault,
                 '    </button>',
                 '  </div>',

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -5357,7 +5357,7 @@
                 '<div class="btn-group">',
                 '  <div class="note-palette-title">' + lang.color.foreground + '</div>',
                 '  <div>',
-                '    <button type="button" class="note-color-reset btn btn-default" data-event="removeFormat" data-value="foreColor">',
+                '    <button type="button" class="note-color-reset btn btn-default" data-event="foreColor" data-value="#000">',
                 lang.color.resetToDefault,
                 '    </button>',
                 '  </div>',


### PR DESCRIPTION
#### What does this PR do?

- Fixed the color `Reset to default` command
- Reset the text foreground color to the default css foreground color

#### Where should the reviewer start?

- Start on the src/summernote.js

#### How should this be manually tested?

- Type any text then make it bold or apply to it any other non-color text formatting option.
- Apply a different foreground color to the already formatted text.
- Reset the foreground color reverting it back to the original css defined foreground color, but still maintaining any other formatting options.

#### What are the relevant tickets?

ForeColor ResetToDefault [#2125](https://github.com/summernote/summernote/issues/2125)

### Checklist
- Checked that the reset to default command only restores the text color.

