### PR TITLE
Feature/hexcolor html5 colorpicker

### DIFF
--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -5266,7 +5266,7 @@
                 '  <div class="note-holder" data-event="backColor"/>',
 
                 '  <div class="btn-sm">',
-                '    <input type="color" id="html5backcolorpicker" class="note-btn btn-default" value="#EFEFEF" style="width:100%;" data-value="colorpicker">',
+                '    <input type="color" id="html5bcp" class="note-btn btn-default" value="#EFEFEF" style="width:100%;" data-value="cp">',
                 '    <button type="button" class="note-color-reset btn" data-event="backColor" data-value="cpbackColor">',
                 lang.color.cpSelect,
                 '    </button>',
@@ -5283,7 +5283,7 @@
                 '  <div class="note-holder" data-event="foreColor"/>',
                 
                 '  <div class="btn-sm">',
-                '    <input type="color" id="html5forecolorpicker" class="note-btn btn-default" value="#21104A" style="width:100%;" data-value="colorpicker">',
+                '    <input type="color" id="html5fcp" class="note-btn btn-default" value="#21104A" style="width:100%;" data-value="cp">',
                 '    <button type="button" class="note-color-reset btn" data-event="foreColor" data-value="cpforeColor">',
                 lang.color.cpSelect,
                 '    </button>',
@@ -5306,14 +5306,17 @@
                 var eventName = $button.data('event');
                 var value = $button.data('value');
 
-                var foreinput = document.getElementById("html5forecolorpicker").value;
-                var backinput = document.getElementById("html5backcolorpicker").value;
-                if (value ==='colorpicker')
-                	event.stopPropagation();
-                else if (value === 'cpbackColor')
+                var foreinput = document.getElementById('html5fcp').value;
+                var backinput = document.getElementById('html5bcp').value;
+                if (value === 'cp') {
+                  event.stopPropagation();
+                }
+                else if (value === 'cpbackColor') {
                   value = backinput;
-                else if (value === 'cpforeColor')
+                }
+                else if (value === 'cpforeColor') {
                   value = foreinput;
+                }
                 
                 if (eventName && value) {
                   var key = eventName === 'backColor' ? 'background-color' : 'color';

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -5263,6 +5263,12 @@
                 '    </button>',
                 '  </div>',
                 '  <div class="note-holder" data-event="backColor"/>',
+
+                '  <div class="btn-sm">',
+                '    <input type="color" id="html5backcolorpicker" class="note-btn btn-default" value="#EFEFEF" style="width:100%;" data-value="colorpicker">',
+                '    <button type="button" class="note-color-reset btn" data-event="backColor" data-value="cpbackColor">select</button>',
+                '  </div>',
+                
                 '</div>',
                 '<div class="btn-group">',
                 '  <div class="note-palette-title">' + lang.color.foreground + '</div>',
@@ -5272,6 +5278,12 @@
                 '    </button>',
                 '  </div>',
                 '  <div class="note-holder" data-event="foreColor"/>',
+                
+                '  <div class="btn-sm">',
+                '    <input type="color" id="html5forecolorpicker" class="note-btn btn-default" value="#21104A" style="width:100%;" data-value="colorpicker">',
+                '    <button type="button" class="note-color-reset btn" data-event="foreColor" data-value="cpforeColor">select</button>',
+                '  </div>',
+
                 '</div>',
                 '</li>'
               ].join(''),
@@ -5289,6 +5301,15 @@
                 var eventName = $button.data('event');
                 var value = $button.data('value');
 
+                var foreinput = document.getElementById("html5forecolorpicker").value;
+                var backinput = document.getElementById("html5backcolorpicker").value;
+                if (value ==='colorpicker')
+                	event.stopPropagation();
+                else if (value === 'cpbackColor')
+                  value = backinput;
+                else if (value === 'cpforeColor')
+                  value = foreinput;
+                
                 if (eventName && value) {
                   var key = eventName === 'backColor' ? 'background-color' : 'color';
                   var $color = $button.closest('.note-color').find('.note-recent-color');

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -2109,7 +2109,8 @@
         transparent: 'Transparent',
         setTransparent: 'Set transparent',
         reset: 'Reset',
-        resetToDefault: 'Reset to default'
+        resetToDefault: 'Reset to default',
+        cpselect: 'Select'
       },
       shortcut: {
         shortcuts: 'Keyboard shortcuts',
@@ -5266,7 +5267,9 @@
 
                 '  <div class="btn-sm">',
                 '    <input type="color" id="html5backcolorpicker" class="note-btn btn-default" value="#EFEFEF" style="width:100%;" data-value="colorpicker">',
-                '    <button type="button" class="note-color-reset btn" data-event="backColor" data-value="cpbackColor">select</button>',
+                '    <button type="button" class="note-color-reset btn" data-event="backColor" data-value="cpbackColor">',
+                lang.color.cpselect,
+                '    </button>',
                 '  </div>',
                 
                 '</div>',
@@ -5281,7 +5284,9 @@
                 
                 '  <div class="btn-sm">',
                 '    <input type="color" id="html5forecolorpicker" class="note-btn btn-default" value="#21104A" style="width:100%;" data-value="colorpicker">',
-                '    <button type="button" class="note-color-reset btn" data-event="foreColor" data-value="cpforeColor">select</button>',
+                '    <button type="button" class="note-color-reset btn" data-event="foreColor" data-value="cpforeColor">',
+                lang.color.cpselect,
+                '    </button>',
                 '  </div>',
 
                 '</div>',

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -2110,7 +2110,7 @@
         setTransparent: 'Set transparent',
         reset: 'Reset',
         resetToDefault: 'Reset to default',
-        cpselect: 'Select'
+        cpSelect: 'Select'
       },
       shortcut: {
         shortcuts: 'Keyboard shortcuts',
@@ -5268,7 +5268,7 @@
                 '  <div class="btn-sm">',
                 '    <input type="color" id="html5backcolorpicker" class="note-btn btn-default" value="#EFEFEF" style="width:100%;" data-value="colorpicker">',
                 '    <button type="button" class="note-color-reset btn" data-event="backColor" data-value="cpbackColor">',
-                lang.color.cpselect,
+                lang.color.cpSelect,
                 '    </button>',
                 '  </div>',
                 
@@ -5285,7 +5285,7 @@
                 '  <div class="btn-sm">',
                 '    <input type="color" id="html5forecolorpicker" class="note-btn btn-default" value="#21104A" style="width:100%;" data-value="colorpicker">',
                 '    <button type="button" class="note-color-reset btn" data-event="foreColor" data-value="cpforeColor">',
-                lang.color.cpselect,
+                lang.color.cpSelect,
                 '    </button>',
                 '  </div>',
 

--- a/examples/toolbar-container.html
+++ b/examples/toolbar-container.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>summernote</title>
+  <!-- include jquery -->
+  <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
+
+  <!-- include libraries BS3 -->
+  <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.3/css/bootstrap.min.css" />
+  <script type="text/javascript" src="//netdna.bootstrapcdn.com/bootstrap/3.0.3/js/bootstrap.min.js"></script>
+
+  <!-- include summernote -->
+  <link rel="stylesheet" href="../dist/summernote.css">
+  <script type="text/javascript" src="../dist/summernote.js"></script>
+
+  <script type="text/javascript">
+    $(function() {
+      $('.summernote').summernote({
+        height: 200,
+        tabsize: 2,
+        toolbarContainer : "#toolbar"
+      });
+    });
+  </script>
+</head>
+<body>
+Here is a toolbar.
+<div id="toolbar"></div>
+
+<p>Here is a summernote.</p>
+<textarea class="summernote">Seasons coming up</textarea>
+</body>
+</html>

--- a/lang/summernote-ar-AR.js
+++ b/lang/summernote-ar-AR.js
@@ -85,7 +85,8 @@
         transparent: 'شفاف',
         setTransparent: 'بدون خلفية',
         reset: 'إعادة الضبط',
-        resetToDefault: 'إعادة الضبط'
+        resetToDefault: 'إعادة الضبط',
+        cpSelect: 'اختار',
       },
       shortcut: {
         shortcuts: 'إختصارات',

--- a/lang/summernote-bg-BG.js
+++ b/lang/summernote-bg-BG.js
@@ -80,7 +80,8 @@
         transparent: 'Прозрачен',
         setTransparent: 'Направете прозрачен',
         reset: 'Възстанови',
-        resetToDefault: 'Възстанови оригиналните'
+        resetToDefault: 'Възстанови оригиналните',
+        cpSelect: 'Изберете'
       },
       shortcut: {
         shortcuts: 'Клавишни комбинации',

--- a/lang/summernote-cs-CZ.js
+++ b/lang/summernote-cs-CZ.js
@@ -83,7 +83,8 @@
         transparent: 'Průhlednost',
         setTransparent: 'Nastavit průhlednost',
         reset: 'Obnovit',
-        resetToDefault: 'Obnovit výchozí'
+        resetToDefault: 'Obnovit výchozí',
+        cpSelect: 'Vybrat'
       },
       shortcut: {
         shortcuts: 'Klávesové zkratky',

--- a/lang/summernote-ko-KR.js
+++ b/lang/summernote-ko-KR.js
@@ -92,7 +92,8 @@
         transparent: '투명',
         setTransparent: '투명',
         reset: '취소',
-        resetToDefault: '기본 값으로 변경'
+        resetToDefault: '기본 값으로 변경',
+        cpSelect: '고르다'
       },
       shortcut: {
         shortcuts: '키보드 단축키',

--- a/lang/summernote-pt-BR.js
+++ b/lang/summernote-pt-BR.js
@@ -84,7 +84,8 @@
         transparent: 'Transparente',
         setTransparent: 'Fundo transparente',
         reset: 'Restaurar',
-        resetToDefault: 'Restaurar padrão'
+        resetToDefault: 'Restaurar padrão',
+        cpSelect: 'Selecionar'
       },
       shortcut: {
         shortcuts: 'Atalhos do teclado',

--- a/lang/summernote-pt-PT.js
+++ b/lang/summernote-pt-PT.js
@@ -84,7 +84,8 @@
         transparent: 'Transparente',
         setTransparent: 'Fundo transparente',
         reset: 'Restaurar',
-        resetToDefault: 'Restaurar padrão'
+        resetToDefault: 'Restaurar padrão',
+        cpSelect: 'Selecionar'
       },
       shortcut: {
         shortcuts: 'Atalhos do teclado',

--- a/src/js/bs3/module/Toolbar.js
+++ b/src/js/bs3/module/Toolbar.js
@@ -3,6 +3,7 @@ define(function () {
     var ui = $.summernote.ui;
 
     var $note = context.layoutInfo.note;
+    var $editor = context.layoutInfo.editor;
     var $toolbar = context.layoutInfo.toolbar;
     var options = context.options;
 
@@ -23,6 +24,8 @@ define(function () {
         $toolbar.appendTo(options.toolbarContainer);
       }
 
+      this.changeContainer(false);
+
       $note.on('summernote.keyup summernote.mouseup summernote.change', function () {
         context.invoke('buttons.updateCurrentStyle');
       });
@@ -34,8 +37,20 @@ define(function () {
       $toolbar.children().remove();
     };
 
+    this.changeContainer = function (isFullscreen) {
+      if (isFullscreen) {
+        $toolbar.prependTo($editor);
+      } else {
+        if (options.toolbarContainer) {
+          $toolbar.appendTo(options.toolbarContainer);
+        }
+      }
+    };
+
     this.updateFullscreen = function (isFullscreen) {
       ui.toggleBtnActive($toolbar.find('.btn-fullscreen'), isFullscreen);
+
+      this.changeContainer(isFullscreen);
     };
 
     this.updateCodeview = function (isCodeview) {


### PR DESCRIPTION
#### What does this PR do?

- Addition of html5 color input using colorpicker
- Added to color dropdown for foreground color and background color

#### Where should the reviewer start?

- start on the dist/summernote.js
- start on lang/summernote-*.js

#### How should this be manually tested?

- Select any text in the editor and edit the foreground and background color using the new color picker.
- Or, select the colors first and change using the recent color icon

#### What are the relevant tickets?

- #1885 (Is it possible to show colors in HEX) solved, labels: feature-request, pull-request-wanted.

#### Any background context you want to provide?

- Different browsers show different results due to use of input type color


#### Screenshots (if for frontend)
![148172016491595](https://cloud.githubusercontent.com/assets/13736648/21183714/18a0131a-c201-11e6-9c3d-1fb9fd9b8a84.png)


### Checklist
- [ ] added relevant tests
- [x] didn't break anything
- [x] added language variable `cpSelect` for ColorPicker
- [x]  made changes to a few files in lang
