### PR TITLE
[Fix] dont add default URL schema with onCreateLink

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -582,6 +582,10 @@ define([
 
       if (options.onCreateLink) {
         linkUrl = options.onCreateLink(linkUrl);
+      } else {
+        // if url doesn't match an URL schema, set http:// as default
+        linkUrl = /^[A-Za-z][A-Za-z0-9+-.]*\:[\/\/]?/.test(linkUrl) ?
+          linkUrl : 'http://' + linkUrl;
       }
 
       var anchors = [];
@@ -598,10 +602,6 @@ define([
       }
 
       $.each(anchors, function (idx, anchor) {
-        // if url doesn't match an URL schema, set http:// as default
-        linkUrl = /^[A-Za-z][A-Za-z0-9+-.]*\:[\/\/]?/.test(linkUrl) ?
-          linkUrl : 'http://' + linkUrl;
-
         $(anchor).attr('href', linkUrl);
         if (isNewWindow) {
           $(anchor).attr('target', '_blank');


### PR DESCRIPTION
With `onCreateLink`, summernote allows developers to add their own custom link generation method. This fix makes sure that the linkURL returned by `onCreateLink` doesn't get modified. This fixes [a bug](https://github.com/summernote/summernote/issues/1037#issuecomment-269118500) which has been introduced in v0.8.2.
