### PR TITLE
Feature | Added target blank option

### DIFF
--- a/examples/link-blank.html
+++ b/examples/link-blank.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>summernote</title>
+  <!-- include jquery -->
+  <script src="http://code.jquery.com/jquery-1.11.3.min.js"></script>
+
+  <!-- include libraries BS3 -->
+  <link rel="stylesheet" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.1/css/bootstrap.min.css" />
+  <script type="text/javascript" src="http://netdna.bootstrapcdn.com/bootstrap/3.0.1/js/bootstrap.min.js"></script>
+
+  <!-- include summernote -->
+  <link rel="stylesheet" href="../dist/summernote.css">
+  <script type="text/javascript" src="../dist/summernote.js"></script>
+  <script type="text/javascript" src="../lang/summernote-ko-KR.js"></script>
+
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $('.summernote').summernote({
+        height: 200,
+        tabsize: 2,
+        linkTargetBlank: false
+      });
+    });
+  </script>
+</head>
+<body>
+<textarea class="summernote"></textarea>
+</body>
+</html>

--- a/src/js/bs3/module/LinkDialog.js
+++ b/src/js/bs3/module/LinkDialog.js
@@ -107,7 +107,7 @@ define([
           self.bindEnterKey($linkUrl, $linkBtn);
           self.bindEnterKey($linkText, $linkBtn);
 
-          $openInNewWindow.prop('checked', linkInfo.isNewWindow);
+          $openInNewWindow.prop('checked', context.options.linkTargetBlank || linkInfo.isNewWindow);
 
           $linkBtn.one('click', function (event) {
             event.preventDefault();

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -62,7 +62,7 @@ define([
       },
 
       buttons: {},
-      
+
       lang: 'en-US',
 
       // toolbar
@@ -101,6 +101,7 @@ define([
 
       width: null,
       height: null,
+      linkTargetBlank: null,
 
       focus: false,
       tabSize: 4,


### PR DESCRIPTION
#### What does this PR do?

- Added new option for select default behavior on links (target blank)

#### Where should the reviewer start?

- src/js/bs3/settings.js
- src/js/bs3/module/LinkDialog.js

#### How should this be manually tested?

-       $('.summernote').summernote({
          linkTargetBlank: true
        });

#### Any background context you want to provide?

- https://github.com/summernote/summernote/issues/1546
