### PR TITLE
fix statusbar shown on disableResizeEditor

### DIFF
--- a/src/js/base/module/Statusbar.js
+++ b/src/js/base/module/Statusbar.js
@@ -9,6 +9,7 @@ define(function () {
 
     this.initialize = function () {
       if (options.airMode || options.disableResizeEditor) {
+        this.destroy();
         return;
       }
 


### PR DESCRIPTION
fixing issue #1931

#### What does this PR do?

- hides statusbar on disabled resize option

#### Where should the reviewer start?

- one line change only: src/js/base/Statusbar.js

#### How should this be manually tested?

- by option `disableResizeEditor:true`

#### Any background context you want to provide?

- nope

#### What are the relevant tickets?
#1931 

#### Screenshots (if for frontend)


### Checklist
- [x] added relevant tests
- [x] didn't break anything
