### PR TITLE
Add missing dependencies in NPM definition (#2118)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "email": "<susukang98@gmail.com>"
   },
   "main": "dist/summernote.js",
+  "dependencies": {
+    "jquery": "^2.2.4",
+    "bootstrap": "^3.3.7"
+  },
   "devDependencies": {
     "chai": "^3.2.0",
     "chai-spies": "^0.7.1",


### PR DESCRIPTION
Example of what is proposed in issue #2118 to have explicit dependencies in the package.  Bootstrap itself depends simply on jquery `>=1.9.1` and I have performance issues with 3.x, so this example includes 2.x.