### PR TITLE
Base en-US wasn't updated for normal vs p

### DIFF
--- a/src/js/base/summernote-en-US.js
+++ b/src/js/base/summernote-en-US.js
@@ -64,7 +64,7 @@ define([
       },
       style: {
         style: 'Style',
-        normal: 'Normal',
+        p: 'Normal',
         blockquote: 'Quote',
         pre: 'Code',
         h1: 'Header 1',


### PR DESCRIPTION
I noticed that everywhere else, last year `normal` was renamed `p`.  Seeing how the current NPM version of Summernote displays "p" instead of "Normal" in the Style drop-down, I connected the dots...