### PR TITLE
Better regex to match legit shorter vimeo video ids (ex.: https://vimeo.com/2)

### DIFF
--- a/src/js/bs3/module/VideoDialog.js
+++ b/src/js/bs3/module/VideoDialog.js
@@ -50,7 +50,7 @@ define([
       var vRegExp = /\/\/vine\.co\/v\/([a-zA-Z0-9]+)/;
       var vMatch = url.match(vRegExp);
 
-      var vimRegExp = /\/\/(player\.)?vimeo\.com\/([a-z]*\/)*([0-9]{1,11})[?]?.*/;
+      var vimRegExp = /\/\/(player\.)?vimeo\.com\/([a-z]*\/)*(\d+)[?]?.*/;
       var vimMatch = url.match(vimRegExp);
 
       var dmRegExp = /.+dailymotion.com\/(video|hub)\/([^_]+)[^#]*(#video=([^_&]+))?/;

--- a/src/js/bs3/module/VideoDialog.js
+++ b/src/js/bs3/module/VideoDialog.js
@@ -50,7 +50,7 @@ define([
       var vRegExp = /\/\/vine\.co\/v\/([a-zA-Z0-9]+)/;
       var vMatch = url.match(vRegExp);
 
-      var vimRegExp = /\/\/(player\.)?vimeo\.com\/([a-z]*\/)*([0-9]{6,11})[?]?.*/;
+      var vimRegExp = /\/\/(player\.)?vimeo\.com\/([a-z]*\/)*([0-9]{1,11})[?]?.*/;
       var vimMatch = url.match(vimRegExp);
 
       var dmRegExp = /.+dailymotion.com\/(video|hub)\/([^_]+)[^#]*(#video=([^_&]+))?/;


### PR DESCRIPTION
#### What does this PR do?

- simply allow user to post more legit vimeos videos

#### Where should the reviewer start?

- start on the  src/js/bs3/module/VideoDialog.js

#### How should this be manually tested?

- Test including this video https://vimeo.com/14786564 it works. Test including videos https://vimeo.com/2 it won't.
- Apply fix, re-test, both videos work.

#### Any background context you want to provide?

- User needed to include legit vimeo videos with shorted id, failing the regex
- Why was the vimeo ID supposed to be between 6 and 11 in length?
