### PR TITLE
fix InvalidCharacterError when pasting an image in Firefox

### DIFF
--- a/src/js/base/module/Clipboard.js
+++ b/src/js/base/module/Clipboard.js
@@ -58,9 +58,8 @@ define([
     this.pasteByHook = function () {
       var node = this.$paste[0].firstChild;
 
-      if (dom.isImg(node)) {
-        var dataURI = node.src;
-        var decodedData = atob(dataURI.split(',')[1]);
+      if (dom.isImg(node) && node.src.startsWith('data:')) {
+        var decodedData = atob(node.src.split(',')[1]);
         var array = new Uint8Array(decodedData.length);
         for (var i = 0; i < decodedData.length; i++) {
           array[i] = decodedData.charCodeAt(i);


### PR DESCRIPTION
#### What does this PR do?

Fixes #2283 by making sure the img tag's source starts with `data:`. This isn't a perfect check (doesn't validate if the string is actually base64) but it avoids the issue where the string is a url.

#### Where should the reviewer start?

`src/js/base/module/Clipboard.js`

#### How should this be manually tested?

1. In Firefox, right click on an image and select 'Copy Image'
2. Paste the image into a summernote textarea using ctrl+V

If successful the image will show properly. If not, an error will show in the JS console.

#### What are the relevant tickets?

#2283
