### PR TITLE
typo correction for a Turkish word

### DIFF
--- a/dist/lang/summernote-tr-TR.js
+++ b/dist/lang/summernote-tr-TR.js
@@ -119,7 +119,7 @@
         'justifyLeft': 'Yazıyı sola hizalar',
         'justifyCenter': 'Yazıyı ortalar',
         'justifyRight': 'Yazıyı sağa hizalar',
-        'justifyFull': 'Yazıyı her iki tarafa yazlar',
+        'justifyFull': 'Yazıyı her iki tarafa yaslar',
         'insertUnorderedList': 'Madde işaretli liste ekler',
         'insertOrderedList': 'Numaralı liste ekler',
         'outdent': 'Aktif paragrafın girintisini azaltır',


### PR DESCRIPTION
correct word is "yaslamak" -> "yaslar". not "yazlar"

#### What does this PR do?

- fix translation word

#### Where should the reviewer start?

- Turkish translation file

#### Any background context you want to provide?

- no

### Checklist
- [x] didn't break anything
