### PR TITLE
Add singleRun option into karma:all

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -218,6 +218,7 @@ module.exports = function (grunt) {
       },
       all: {
         // Chrome, ChromeCanary, Firefox, Opera, Safari, PhantomJS, IE
+        singleRun: true,
         browsers: ['PhantomJS'],
         reporters: ['progress']
       },


### PR DESCRIPTION
#### What does this PR do?

- karma doesn't stop itself without `singleRun` option.

#### Where should the reviewer start?

- `karma:all` section of `Gruntfile.js`

#### How should this be manually tested?

- Just run `grunt test` and watch whether it ends itself or not.

XRef: http://karma-runner.github.io/1.0/config/configuration-file.html