### PR TITLE
Correct exit from fullscreen

### DIFF
--- a/src/js/base/module/Fullscreen.js
+++ b/src/js/base/module/Fullscreen.js
@@ -25,7 +25,7 @@ define([
         resize({
           h: $window.height() - $toolbar.outerHeight()
         });
-      }
+      };
 
       $editor.toggleClass('fullscreen');
       if (this.isFullscreen()) {

--- a/src/js/base/module/Fullscreen.js
+++ b/src/js/base/module/Fullscreen.js
@@ -21,20 +21,21 @@ define([
           $codable.data('cmeditor').setsize(null, size.h);
         }
       };
+      var fullscreenResize = function () {
+        resize({
+          h: $window.height() - $toolbar.outerHeight()
+        });
+      }
 
       $editor.toggleClass('fullscreen');
       if (this.isFullscreen()) {
         $editable.data('orgHeight', $editable.css('height'));
 
-        $window.on('resize', function () {
-          resize({
-            h: $window.height() - $toolbar.outerHeight()
-          });
-        }).trigger('resize');
+        $window.on('resize', fullscreenResize).trigger('resize');
 
         $scrollbar.css('overflow', 'hidden');
       } else {
-        $window.off('resize');
+        $window.off('resize', fullscreenResize);
         resize({
           h: $editable.data('orgHeight')
         });


### PR DESCRIPTION
When exit from full screen on line #37 there where removed all windows resize callback function registerd to the event.
I changed the code in order to remove only the callback added by the plugin.

#### What does this PR do?

- does not remove other callback functions registered to the window resize event

#### Where should the reviewer start?

- start on the src/js/base/module/Fullscreen.js

#### How should this be manually tested?

- register some function on window resize event
- click the fullscreen mode button (so far everythink is ok)
- click the fullscreen mode button to exit fullscreen (the registered event is not working anymore)

#### Any background context you want to provide?

- the fullscreen function should not interfere with other functions registered on windows resize event

#### What are the relevant tickets?

#### Screenshots (if for frontend)

### Checklist
