### PR TITLE
LinkDialog and some checkbox library mixed, checkbox state is not visible

### DIFF
--- a/src/js/bs3/module/LinkDialog.js
+++ b/src/js/bs3/module/LinkDialog.js
@@ -22,7 +22,8 @@ define([
                  '</div>' +
                  (!options.disableLinkTarget ?
                    '<div class="checkbox">' +
-                     '<label>' + '<input type="checkbox" checked> ' + lang.link.openInNewWindow + '</label>' +
+                     '<input type="checkbox" id="checkbox-open-in-new-window" checked> ' +
+                     '<label for="checkbox-open-in-new-window">' + lang.link.openInNewWindow + '</label>' +
                    '</div>' : ''
                  );
       var footer = '<button href="#" class="btn btn-primary note-link-btn disabled" disabled>' + lang.link.insert + '</button>';


### PR DESCRIPTION
When adding a link, open in new tag checkbox add "id" and "for" attributes, to solve and some checkbox library mixed, checkbox state is not visible.


### Checklist
- [ ] didn't break anything
- [ ] only edit LinkDialog.js
