### PR TITLE
(locale fr-FR) Add specialChar

### DIFF
--- a/lang/summernote-fr-FR.js
+++ b/lang/summernote-fr-FR.js
@@ -137,8 +137,11 @@
       history: {
         undo: 'Annuler la dernière action',
         redo: 'Restaurer la dernière action annulée'
+      },
+      specialChar: {
+        specialChar: 'CARACTÈRES SPÉCIAUX',
+        select: 'Choisir des caractères spéciaux'
       }
-
     }
   });
 })(jQuery);


### PR DESCRIPTION
#### What does this PR do?

- :globe_with_meridians: Add `specialChar` locales for `fr-FR`

#### Where should the reviewer start?

- start on the `lang/summernote-fr-FR.js`

#### How should this be manually tested?

- check `lang/summernote-fr-FR.js`

### Checklist
- [x] didn't break anything
