### PR TITLE
Remove need to install global packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,22 +103,20 @@ The code view allows the user to enter script contents. Make sure to filter/[san
 
 #### build summernote
 ```bash
-# grunt-cli is need by grunt; you might have this installed already
-npm install -g grunt-cli
 npm install
 
 # build full version of summernote: dist/summernote.js
-grunt build
+npm run build
 
 # generate minified copy: dist/summernote.min.js, dist/summernote.css
-grunt dist
+npm run dist
 ```
 At this point, you should now have a `build/` directory populated with everything you need to use summernote.
 
 #### test summernote
 run tests with Karma and PhantomJS
 ```bash
-grunt test
+npm test
 ```
 If you want run tests on other browser,
 change the values for `broswers` properties in `Gruntfile.js`.
@@ -133,12 +131,12 @@ karma: {
 
 ```
 You can use `Chrome`, `ChromeCanary`, `Firefox`, `Opera`, `Safari`, `PhantomJS` and `IE` beside `PhantomJS`.
-Once you run `grunt test`, it will watch all javascript file. Therefore karma run tests every time you chage code.
+Once you run `npm test`, it will watch all javascript file. Therefore karma run tests every time you chage code.
 
 #### start local server for developing summernote.
 run local server with connect and watch.
 ```bash
-grunt server
+npm run server
 # Open a browser on http://localhost:3000.
 # If you change source code, automatically reload your page.
 ```

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "main": "dist/summernote.js",
   "scripts": {
     "test": "grunt test",
+    "server": "grunt server",
     "build": "grunt build",
     "dist": "grunt dist"
   },

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
     "email": "<susukang98@gmail.com>"
   },
   "main": "dist/summernote.js",
+  "scripts": {
+    "test": "grunt test",
+    "build": "grunt build",
+    "dist": "grunt dist"
+  },
   "dependencies": {
     "jquery": "^2.2.4",
     "bootstrap": "^3.3.7"
@@ -24,6 +29,7 @@
     "chai": "^3.2.0",
     "chai-spies": "^0.7.1",
     "grunt": "*",
+    "grunt-cli": "*",
     "grunt-contrib-clean": "^1.1.0",
     "grunt-contrib-compress": "*",
     "grunt-contrib-connect": "*",


### PR DESCRIPTION
#### What does this PR do?

Remove need to install global packages as well as providing a facade for Tooling with NPM Package Scripts

Those are best practices described in the following articles:

* https://www.joezimjs.com/javascript/no-more-global-npm-packages/
* https://bocoup.com/blog/a-facade-for-tooling-with-npm-scripts/


#### Where should the reviewer start?

- just read the modifications on `package.json` file

#### How should this be manually tested?

```shell
$ npm t
$ npm run build
$ npm run dist
```

#### Any background context you want to provide?

And another article along the same lines regarding everything that can be done with npm:
https://www.keithcirkel.co.uk/how-to-use-npm-as-a-build-tool/

#### What are the relevant tickets?

N/A

### Checklist
- [ ] added relevant tests
- [X] didn't break anything
