### PR TITLE
Add <input> as a void element type

### DIFF
--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -84,7 +84,7 @@ define([
      * @see http://www.w3.org/html/wg/drafts/html/master/syntax.html#void-elements
      */
     var isVoid = function (node) {
-      return node && /^BR|^IMG|^HR|^IFRAME|^BUTTON/.test(node.nodeName.toUpperCase());
+      return node && /^BR|^IMG|^HR|^IFRAME|^BUTTON|^INPUT/.test(node.nodeName.toUpperCase());
     };
 
     var isPara = function (node) {


### PR DESCRIPTION
#### What does this PR do?

Add `<input>` as a void element type.

Fixes `<input>`s duplicating when pressing enter key. (a bug in paragraph split behavior)

#### Where should the reviewer start?

`dom.isVoid` is called by...

* `dom.paddingBlankHTML`
* `dom.isVisiblePoint`
* `WrappedRange.normalize`
* `range.createFromNode`

However I don't think this will affect many users as chance of having `<input>` in the editing content should be rare.

#### Any background context you want to provide?

I have `<input type=button>` in editing content.
Put caret on the left or right of button, and press enter key, then button is duplicated.

It is caused by paragraph split logic executing on wrongly normalized range. And normalization logic depends on `isVoid`.

#### What are the relevant tickets?

It will fix #2342 too.

Also, issues seem to be related (but not fixed by this PR): #2276 #2253 #1819 

#### Screenshots (if for frontend)

nope

### Checklist
- [x] added relevant tests
- [x] didn't break anything
