### PR TITLE
Deselect image when scrolling on the handle overlay

### DIFF
--- a/src/js/base/module/Handle.js
+++ b/src/js/base/module/Handle.js
@@ -69,6 +69,12 @@ define([
           }
         }
       });
+
+      // Listen for scrolling on the handle overlay.
+      this.$handle.on('wheel', function (e) {
+        e.preventDefault();
+        self.update();
+      });
     };
 
     this.destroy = function () {


### PR DESCRIPTION
Select the image and scroll wheel on the handle overlay box. It does not scroll the editor.

Especially when the image is larger than visible editing area, this bug makes editor unusable.