### PR TITLE
Fixed #2397

### DIFF
--- a/src/js/bs3/module/Buttons.js
+++ b/src/js/bs3/module/Buttons.js
@@ -245,7 +245,8 @@ define([
                   var $holder = $(this);
                   $holder.append(ui.palette({
                     colors: options.colors,
-                    eventName: $holder.data('event')
+                    eventName: $holder.data('event'),
+                    tooltip: options.tooltip
                   }).render());
                 });
               },

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -65,11 +65,13 @@ define([
     }
     $node.html(contents.join(''));
 
-    $node.find('.note-color-btn').tooltip({
-      container: 'body',
-      trigger: 'hover',
-      placement: 'bottom'
-    });
+    if (options.tooltip) {
+      $node.find('.note-color-btn').tooltip({
+        container: 'body',
+        trigger: 'hover',
+        placement: 'bottom'
+      });
+    }
   });
 
   var dialog = renderer.create('<div class="modal" aria-hidden="false" tabindex="-1"/>', function ($node, options) {


### PR DESCRIPTION
#### What does this PR do?

- Fixed tooltip shown at color picking dialog even when tooltip:false option set

#### Where should the reviewer start?

- Start on the src/bs3/ui.js

#### How should this be manually tested?

- Set summernote option tooltip: false
- Hover mouse pointer toolbar buttons and check tooltips are not shown
- Hover mouse pointer font/font-background color picker and check tooltips are not shown

#### Any background context you want to provide?

- Fixed issue 

#### What are the relevant tickets?

#2397

#### Screenshots (if for frontend)
![tooltip 2397](https://user-images.githubusercontent.com/1225082/29259160-5bbaab9c-80fb-11e7-8bad-225759306471.jpg)

### Checklist
- [x] added relevant tests
- [x] didn't break anything
