### PR TITLE
Fix wrong command name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Once you run `npm test`, it will watch all javascript file. Therefore karma run 
 #### start local server for developing summernote.
 run local server with connect and watch.
 ```bash
-npm run server
+npm run start
 # Open a browser on http://localhost:3000.
 # If you change source code, automatically reload your page.
 ```


### PR DESCRIPTION
#### What does this PR do?

- Fix wrong command in `README.md`

#### Where should the reviewer start?

- See `README.md`

#### How should this be manually tested?

- Run `npm run start` instead of `npm run server`

#### Any background context you want to provide?

- Nope

#### What are the relevant tickets?

- `start` command was renamed at https://github.com/summernote/summernote/commit/611fffb6f7c67a67adb6353496410f8a47ccc832 but this PR didn't include a change for `README.md`
