### PR TITLE
Remove explicit dependencie to JQuery 2.2.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "dist": "grunt dist"
   },
   "dependencies": {
-    "jquery": "^2.2.4",
     "bootstrap": "^3.3.7"
   },
   "devDependencies": {


### PR DESCRIPTION
finish logic of https://github.com/summernote/summernote/commit/194cbf75bed567be7c485894854cb4ba8c89c1c4
see general compatibility issue - was fixed in 0.8.2: https://github.com/summernote/summernote/issues/2087

