### PR TITLE
Fix minor tooltip issues

### DIFF
--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -69,7 +69,7 @@ define([
     }
     $node.html(contents.join(''));
 
-    if (options.tooltip) {
+    if (self.options.tooltip) {
       $node.find('.note-color-btn').tooltip({
         container: 'body',
         trigger: 'hover',

--- a/src/js/bs4/ui.js
+++ b/src/js/bs4/ui.js
@@ -69,7 +69,7 @@ define([
     }
     $node.html(contents.join(''));
 
-    if (options.tooltip) {
+    if (self.options.tooltip) {
       $node.find('.note-color-btn').tooltip({
         container: 'body',
         trigger: 'hover',

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -113,6 +113,7 @@ define([
       shortcuts: true,
       textareaAutoSync: true,
       direction: null,
+      tooltip: 'auto',
 
       styleTags: ['p', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
 

--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -25,7 +25,7 @@ define([
   var buttonGroup = renderer.create('<div class="note-btn-group">');
   var button = renderer.create('<button type="button" class="note-btn">', function ($node, options) {
     // set button type
-    if (options && options.tooltip) {
+    if (options && options.tooltip && self.options.tooltip) {
       TooltipUI.create($node, {
         title: options.tooltip
       });
@@ -260,10 +260,11 @@ define([
     }
     $node.html(contents.join(''));
 
-    $node.find('.note-color-btn').each(function () {
-      TooltipUI.create($(this));
-    });
-
+    if(self.options.tooltip) {
+      $node.find('.note-color-btn').each(function () {
+        TooltipUI.create($(this));
+      });
+    }
   });
 
   var colorDropdownButton = function (opt, type) {
@@ -570,6 +571,7 @@ define([
     },
 
     createLayout: function ($note, options) {
+      self.options = options;
       var $editor = (options.airMode ? ui.airEditor([
         ui.editingArea([
           ui.airEditable()


### PR DESCRIPTION
#### What does this PR do?

- Fix minor tooltip issues

#### Where should the reviewer start?

Below files had used `options.tooltip` to determine whether shows tooltip or not while creating palette UI. But `options.tooltip` is a string for it, not a proper option. I changed them into `self.options.tooltip` – the right one.
- `src/js/bs3/ui.js`
- `src/js/bs4/ui.js`

summernote-lite does not handle tooltip option as well as others. So I fixed it.
- `src/js/lite/settings.js`
- `src/js/lite/ui.js`

#### How should this be manually tested?

- Change `tooltip` value in settings through `true`, `false` and `'auto'`.