### PR TITLE
Rollback default behavior of tab/untab by condition

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -123,8 +123,9 @@ define([
 
       var eventName = keyMap[keys.join('+')];
       if (eventName) {
-        event.preventDefault();
-        context.invoke(eventName);
+        if (context.invoke(eventName) !== false) {
+          event.preventDefault();
+        }
       } else if (key.isEdit(event.keyCode)) {
         this.afterCommand();
       }

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -277,6 +277,9 @@ define([
       if (rng.isCollapsed() && rng.isOnCell()) {
         table.tab(rng);
       } else {
+        if (options.tabSize === 0) {
+          return false;
+        }
         beforeCommand();
         typing.insertTab(rng, options.tabSize);
         afterCommand();
@@ -291,6 +294,10 @@ define([
       var rng = this.createRange();
       if (rng.isCollapsed() && rng.isOnCell()) {
         table.tab(rng, true);
+      } else {
+        if (options.tabSize === 0) {
+          return false;
+        }
       }
     };
     context.memo('help.untab', lang.help.untab);


### PR DESCRIPTION
#### What does this PR do?

- Rollback default behavior of tab/untab when `options.tabSize` is zero

#### Where should the reviewer start?

- I changed the calling order of `event.preventDefault()` and `context.invoke(eventName)` for this issue.

#### How should this be manually tested?

- Set `options.tabSize` as 0 and press `tab` and `shift+tab` again. The browser should move its focus to a previous/next element as like as default behavior.

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/615
