### PR TITLE
Fix margin and padding of paragraph styles in the dropdown menu

### DIFF
--- a/src/less/summernote-bs4.less
+++ b/src/less/summernote-bs4.less
@@ -219,9 +219,16 @@
     }
   }
 
-  .note-style {
-    h1, h2, h3, h4, h5, h6, blockquote {
-      margin: 0;
+  .note-style { 
+    .dropdown-style {
+      blockquote, pre {
+          margin: 0;
+          padding: 5px 10px;
+      }
+      h1, h2, h3, h4, h5, h6, p {
+          margin: 0;
+          padding: 0;
+      }
     }
   }
 

--- a/src/less/summernote-bs4.scss
+++ b/src/less/summernote-bs4.scss
@@ -217,9 +217,16 @@ $img-margin-right: 10px;
     }
   }
 
-  .note-style {
-    h1, h2, h3, h4, h5, h6, blockquote {
-      margin: 0;
+  .note-style { 
+    .dropdown-style {
+      blockquote, pre {
+          margin: 0;
+          padding: 5px 10px;
+      }
+      h1, h2, h3, h4, h5, h6, p {
+          margin: 0;
+          padding: 0;
+      }
     }
   }
 

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -218,9 +218,16 @@
     }
   }
 
-  .note-style {
-    h1, h2, h3, h4, h5, h6, blockquote {
-      margin: 0;
+  .note-style { 
+    .dropdown-style {
+      blockquote, pre {
+          margin: 0;
+          padding: 5px 10px;
+      }
+      h1, h2, h3, h4, h5, h6, p {
+          margin: 0;
+          padding: 0;
+      }
     }
   }
 

--- a/src/less/summernote.scss
+++ b/src/less/summernote.scss
@@ -217,9 +217,16 @@ $img-margin-right: 10px;
     }
   }
 
-  .note-style {
-    h1, h2, h3, h4, h5, h6, blockquote {
-      margin: 0;
+  .note-style { 
+    .dropdown-style {
+      blockquote, pre {
+          margin: 0;
+          padding: 5px 10px;
+      }
+      h1, h2, h3, h4, h5, h6, p {
+          margin: 0;
+          padding: 0;
+      }
     }
   }
 


### PR DESCRIPTION
#### What does this PR do?

- Fix margin and padding of paragraph styles in the dropdown menu.

#### Where should the reviewer start?

- less and scss files in `src`

#### How should this be manually tested?

- Change paragraph styles by manually and open the style dropdown.

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/2471