### PR TITLE
add custom style for style dropdown

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -121,10 +121,7 @@ define([
         keys.push(keyName);
       }
 
-      console.log(keys);
-
       var eventName = keyMap[keys.join('+')];
-      console.log(eventName);
       if (eventName) {
         event.preventDefault();
         context.invoke(eventName);

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -121,7 +121,10 @@ define([
         keys.push(keyName);
       }
 
+      console.log(keys);
+
       var eventName = keyMap[keys.join('+')];
+      console.log(eventName);
       if (eventName) {
         event.preventDefault();
         context.invoke(eventName);
@@ -452,14 +455,26 @@ define([
       if (onApplyCustomStyle) {
         onApplyCustomStyle.call(this, $target, context, this.onFormatBlock);
       } else {
-        this.onFormatBlock(tagName);
+        this.onFormatBlock(tagName, $target);
       }
     });
 
-    this.onFormatBlock = function (tagName) {
+    this.onFormatBlock = function (tagName, $target) {
       // [workaround] for MSIE, IE need `<`
       tagName = agent.isMSIE ? '<' + tagName + '>' : tagName;
       document.execCommand('FormatBlock', false, tagName);
+
+      // support custom class 
+      if ($target && $target.length) {
+        var className = $target[0].className || '';
+        if (className) {
+          var currentRange = this.createRange();
+  
+          var $parent = $([currentRange.sc, currentRange.ec]).closest(tagName);
+          $parent.addClass(className);
+        }
+      }
+
     };
 
     this.formatPara = function () {

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -117,7 +117,11 @@ define([
       direction: null,
       tooltip: 'auto',
 
-      styleTags: ['p', { title: 'Blockquote', tag: 'blockquote', className: 'blockquote' }, 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+      styleTags: [
+        'p', 
+        { title: 'Blockquote', tag: 'blockquote', className: 'blockquote', value: 'blockquote' }, 
+        'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'
+      ],
 
       fontNames: [
         'Arial', 'Arial Black', 'Comic Sans MS', 'Courier New',

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -117,7 +117,7 @@ define([
       direction: null,
       tooltip: 'auto',
 
-      styleTags: ['p', 'blockquote', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
+      styleTags: ['p', { title: 'Blockquote', tag: 'blockquote', className: 'blockquote' }, 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
 
       fontNames: [
         'Arial', 'Arial Black', 'Comic Sans MS', 'Courier New',

--- a/test/unit/base/module/Editor.spec.js
+++ b/test/unit/base/module/Editor.spec.js
@@ -222,6 +222,60 @@ define([
         expectContents(context, '<blockquote>hello</blockquote>');
       });
 
+      it('should apply multi formatBlock', function () {
+
+        // set multi block html 
+        var codes = [
+          '<p><a href="http://summernote.org">hello world</a></p>',
+          '<p><a href="http://summernote.org">hello world</a></p>',
+          '<p><a href="http://summernote.org">hello world</a></p>'
+        ];
+
+        context.invoke('code', codes.join(''));
+
+        // append to body 
+        var editable = context.layoutInfo.editable;
+        editable.appendTo('body');
+
+        // run formatBlock 
+        editor.formatBlock('blockquote');
+
+        // check current range position in blockquote element 
+
+        var nodeName = editable.children()[0].nodeName;
+        expect(nodeName).to.equalsIgnoreCase('blockquote');
+
+      });      
+
+      it('should apply multi test 2 - formatBlock', function () {
+
+        var codes = [
+          '<p><a href="http://summernote.org">hello world</a></p>',
+          '<p><a href="http://summernote.org">hello world</a></p>',
+          '<p><a href="http://summernote.org">hello world</a></p>'
+        ];
+
+        context.invoke('code', codes.join(''));
+
+        var editable = context.layoutInfo.editable;
+        editable.appendTo('body');
+                
+        var startNode = editable.find('p').first()[0];
+        var endNode = editable.find('p').last()[0];
+
+        // all p tags is wrapped
+        range.create(startNode, 1, endNode, 1).normalize().select();
+
+        editor.formatBlock('blockquote');
+
+        var nodeName = editable.children()[0].nodeName;
+        expect(nodeName).to.equalsIgnoreCase('blockquote');
+
+        // p -> blockquote, p is none 
+        expect(editable.find('p').length).to.equals(0);
+
+      });      
+
       it('should apply custom className in formatBlock', function () {
         context.layoutInfo.editable.appendTo('body');
         var $target = $('<blockquote class="blockquote" />');

--- a/test/unit/base/module/Editor.spec.js
+++ b/test/unit/base/module/Editor.spec.js
@@ -213,6 +213,25 @@ define([
       });
     });
 
+    describe('formatBlock', function () {
+      it('should apply formatBlock', function () {
+        context.layoutInfo.editable.appendTo('body');
+        editor.formatBlock('blockquote');
+
+        // start <p>hello</p> => <blockquote>hello</blockquote>
+        expectContents(context, '<blockquote>hello</blockquote>');
+      });
+
+      it('should apply custom className in formatBlock', function () {
+        context.layoutInfo.editable.appendTo('body');
+        var $target = $('<blockquote class="blockquote" />');
+        editor.formatBlock('blockquote', $target);
+
+        // start <p>hello</p> => <blockquote class="blockquote">hello</blockquote>
+        expectContents(context, '<blockquote class="blockquote">hello</blockquote>');
+      });
+    });
+
     describe('createLink', function () {
       it('should create normal link', function () {
         var text = 'hello';


### PR DESCRIPTION
#### What does this PR do?

- modify style dropdown for bs4 
- apply custom className in formatBlock  command 

#### Where should the reviewer start?

- start on the src/js/base/module/Editorjs

#### How should this be manually tested?


#### Any background context you want to provide?

- Perhaps we need to add custom style features(onApplyCustomStyle) to the formatBlock command.
- because of  blockquote  in  bs4.
- blockquote has `blockquote` class name  in bs4
-  ```<blockquote class='blockquote'></blockquote>```

#### What are the relevant tickets?


#### Screenshots (if for frontend)


### Checklist
