### PR TITLE
Allow user set the container of tooltip and container instead of default 'body'

### DIFF
--- a/src/js/base/module/AirPopover.js
+++ b/src/js/base/module/AirPopover.js
@@ -39,7 +39,7 @@ define([
     this.initialize = function () {
       this.$popover = ui.popover({
         className: 'note-air-popover'
-      }).render().appendTo('body');
+      }).render().appendTo(options.container);
       var $content = this.$popover.find('.popover-content');
 
       context.invoke('buttons.build', $content, options.popover.air);

--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -36,6 +36,7 @@ define([
       if (!options.tooltip && o.tooltip) {
         delete o.tooltip;
       }
+      o.container = options.container;
       return ui.button(o);
     };
 
@@ -251,6 +252,7 @@ define([
                   $holder.append(ui.palette({
                     colors: options.colors,
                     eventName: $holder.data('event'),
+                    container: options.container,
                     tooltip: options.tooltip
                   }).render());
                 });

--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -646,9 +646,9 @@ define([
         }).render();
 
         for (var idx = 0, len = buttons.length; idx < len; idx++) {
-          var button = context.memo('button.' + buttons[idx]);
-          if (button) {
-            $group.append(typeof button === 'function' ? button(context) : button);
+          var btn = context.memo('button.' + buttons[idx]);
+          if (btn) {
+            $group.append(typeof btn === 'function' ? btn(context) : btn);
           }
         }
         $group.appendTo($container);

--- a/src/js/base/module/HintPopover.js
+++ b/src/js/base/module/HintPopover.js
@@ -10,8 +10,9 @@ define([
     var ui = $.summernote.ui;
 
     var POPOVER_DIST = 5;
-    var hint = context.options.hint || [];
-    var direction = context.options.hintDirection || 'bottom';
+    var options = context.options;
+    var hint = options.hint || [];
+    var direction = options.hintDirection || 'bottom';
     var hints = $.isArray(hint) ? hint : [hint];
 
     this.events = {
@@ -38,7 +39,7 @@ define([
         className: 'note-hint-popover',
         hideArrow: true,
         direction: ''
-      }).render().appendTo('body');
+      }).render().appendTo(options.container);
 
       this.$popover.hide();
 

--- a/src/js/base/module/ImagePopover.js
+++ b/src/js/base/module/ImagePopover.js
@@ -30,7 +30,7 @@ define([
     this.initialize = function () {
       this.$popover = ui.popover({
         className: 'note-image-popover'
-      }).render().appendTo('body');
+      }).render().appendTo(options.container);
       var $content = this.$popover.find('.popover-content,.note-popover-content');
 
       context.invoke('buttons.build', $content, options.popover.image);

--- a/src/js/base/module/LinkPopover.js
+++ b/src/js/base/module/LinkPopover.js
@@ -29,7 +29,7 @@ define([
           var $content = $node.find('.popover-content,.note-popover-content');
           $content.prepend('<span><a target="_blank"></a>&nbsp;</span>');
         }
-      }).render().appendTo('body');
+      }).render().appendTo(options.container);
       var $content = this.$popover.find('.popover-content,.note-popover-content');
 
       context.invoke('buttons.build', $content, options.popover.link);

--- a/src/js/base/module/TablePopover.js
+++ b/src/js/base/module/TablePopover.js
@@ -29,7 +29,7 @@ define([
     this.initialize = function () {
       this.$popover = ui.popover({
         className: 'note-table-popover'
-      }).render().appendTo('body');
+      }).render().appendTo(options.container);
       var $content = this.$popover.find('.popover-content,.note-popover-content');
 
       context.invoke('buttons.build', $content, options.popover.table);

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -116,6 +116,7 @@ define([
       textareaAutoSync: true,
       direction: null,
       tooltip: 'auto',
+      container: 'body',
 
       styleTags: ['p', 'blockquote', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
 

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -71,7 +71,7 @@ define([
 
     if (options.tooltip) {
       $node.find('.note-color-btn').tooltip({
-        container: 'body',
+        container: options.container,
         trigger: 'hover',
         placement: 'bottom'
       });
@@ -156,7 +156,7 @@ define([
           $node.attr({
             title: options.tooltip
           }).tooltip({
-            container: 'body',
+            container: options.container,
             trigger: 'hover',
             placement: 'bottom'
           });

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -116,6 +116,7 @@ define([
       textareaAutoSync: true,
       direction: null,
       tooltip: 'auto',
+      container: 'body',
 
       styleTags: ['p', 'blockquote', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
 

--- a/src/js/bs4/ui.js
+++ b/src/js/bs4/ui.js
@@ -71,7 +71,7 @@ define([
 
     if (options.tooltip) {
       $node.find('.note-color-btn').tooltip({
-        container: 'body',
+        container: options.container,
         trigger: 'hover',
         placement: 'bottom'
       });
@@ -159,7 +159,7 @@ define([
           $node.attr({
             title: options.tooltip
           }).tooltip({
-            container: 'body',
+            container: options.container,
             trigger: 'hover',
             placement: 'bottom'
           });

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -114,6 +114,7 @@ define([
       textareaAutoSync: true,
       direction: null,
       tooltip: 'auto',
+      container: 'body',
 
       styleTags: ['p', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
 

--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -27,7 +27,8 @@ define([
     // set button type
     if (options && options.tooltip) {
       TooltipUI.create($node, {
-        title: options.tooltip
+        title: options.tooltip,
+        container: options.container
       });
     }
     if (options.contents) {
@@ -35,7 +36,9 @@ define([
     }
     
     if (options && options.data && options.data.toggle === 'dropdown') {
-      DropdownUI.create($node);
+      DropdownUI.create($node, {
+        container: options.container
+      });
     }
   });
 
@@ -261,7 +264,9 @@ define([
     $node.html(contents.join(''));
 
     $node.find('.note-color-btn').each(function () {
-      TooltipUI.create($(this));
+      TooltipUI.create($(this), {
+        container: options.container
+      });
     });
 
   });

--- a/src/js/lite/ui/dropdown.js
+++ b/src/js/lite/ui/dropdown.js
@@ -5,7 +5,11 @@ define(function () {
     var Dropdown = function ($node, options) {
       var self = this;
 
-      this.init = function () {
+      this.init = function (options) {
+        this.options = $.extend({}, {
+          target: options.container
+        }, options);
+
         this.$button = $node;
         this.setEvent();
       };
@@ -30,10 +34,10 @@ define(function () {
         var offset = $dropdown.offset();
         var width = $dropdown.outerWidth();
         var windowWidth = $(window).width();
-        var bodyMarginRight = parseFloat($('body').css('margin-right'));
+        var targetMarginRight = parseFloat($(this.options.target).css('margin-right'));
 
-        if (offset.left + width > windowWidth - bodyMarginRight) {
-          $dropdown.css('margin-left', windowWidth - bodyMarginRight - (offset.left + width));
+        if (offset.left + width > windowWidth - targetMarginRight) {
+          $dropdown.css('margin-left', windowWidth - targetMarginRight - (offset.left + width));
         } else {
           $dropdown.css('margin-left', '');
         }

--- a/src/js/lite/ui/modal.js
+++ b/src/js/lite/ui/modal.js
@@ -6,7 +6,7 @@ define(function () {
 
       this.init = function (options) {
         this.options = $.extend({}, {
-          target: 'body'
+          target: options.container
         }, options);
 
         this.$modal = $node;

--- a/src/js/lite/ui/popover.js
+++ b/src/js/lite/ui/popover.js
@@ -9,7 +9,7 @@ define(function () {
         this.options = $.extend({}, {
           title: '',
           content: '',
-          target: 'body',
+          target: options.container,
           trigger: 'hover focus',
           placement: 'bottom'
         }, options);

--- a/src/js/lite/ui/tooltip.js
+++ b/src/js/lite/ui/tooltip.js
@@ -6,7 +6,7 @@ define(function () {
       this.init = function (options) {
         this.options = $.extend({}, {
           title: '',
-          target: 'body',
+          target: options.container,
           trigger: 'hover focus',
           placement: 'bottom'
         }, options);


### PR DESCRIPTION
#### What does this PR do?

- Allow user can set the container of tooltip and container.

#### Where should the reviewer start?

- `ui.js` in each theme

#### How should this be manually tested?

- Change `container` in each `settings.js` file and test it on the browser.

#### What are the relevant tickets?

- https://github.com/summernote/summernote/pull/2036, but it is pretty outdated.