### PR TITLE
support formatter for execCommand

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -262,6 +262,8 @@ define([
         return function (value) {
           beforeCommand();
           document.execCommand(sCmd, false, value);
+          // support formatter for execCommand   
+          context.invoke('formatter.'+sCmd);
           afterCommand(true);
         };
       })(commands[idx]);

--- a/src/js/base/module/Formatter.js
+++ b/src/js/base/module/Formatter.js
@@ -1,0 +1,60 @@
+define([
+  'jquery',
+  'summernote/base/core/range'
+], function ($, range) {
+  /**
+   * Command Formatter
+   */
+  var Formatter = function (context) {
+
+    this.shouldInitialize = function () {
+      return true; 
+    };
+
+    /**
+     * run after execCommand('fontName')
+     */
+    this.fontName = function () {
+      var currentRange = context.invoke('createRange');
+      var sc = currentRange.sc;
+      var ec = currentRange.ec;
+      var so = currentRange.so;
+      var eo = currentRange.eo; 
+
+      var $fontAll = context.layoutInfo.editable.find('font');
+      $fontAll.each(function() {
+        var $font = $(this);
+        var $span = $('<span />');
+        
+        if ($font.attr('face')) {
+          $span.css('font-family', $font.attr('face'));
+        }
+
+        $font.after($span);
+
+        var node = $font[0].firstChild;
+        while (node) {
+          var hasStart = false, hasEnd = false; 
+          if (node === sc) { hasStart = true; } 
+          if (node === ec) { hasEnd = true; }
+
+          var aChild = $span[0].appendChild(node);
+
+          if (hasStart) { sc = aChild; }
+          if (hasEnd) { ec = aChild; }
+          
+          node = node.nextSibling;
+        }
+
+        $font.remove();
+      });
+
+      // recover range selection 
+      range.create(sc, so, ec, eo).select(); 
+
+    };
+
+  };
+
+  return Formatter;
+});

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -4,6 +4,7 @@ define([
   'summernote/base/summernote-en-US',
   'summernote/base/module/Editor',
   'summernote/base/module/Clipboard',
+  'summernote/base/module/Formatter',
   'summernote/base/module/Dropzone',
   'summernote/base/module/Codeview',
   'summernote/base/module/Statusbar',
@@ -25,7 +26,7 @@ define([
   'summernote/base/module/HintPopover'
 ], function (
   ui, dom, lang,
-  Editor, Clipboard, Dropzone, Codeview, Statusbar, Fullscreen, Handle, AutoLink, AutoSync, Placeholder,
+  Editor, Clipboard, Formatter, Dropzone, Codeview,  Statusbar, Fullscreen, Handle, AutoLink, AutoSync, Placeholder,
   Buttons, Toolbar, LinkDialog, LinkPopover, ImageDialog, ImagePopover, TablePopover, VideoDialog, HelpDialog, AirPopover, HintPopover
 ) {
 
@@ -40,6 +41,7 @@ define([
       modules: {
         'editor': Editor,
         'clipboard': Clipboard,
+        'formatter': Formatter,
         'dropzone': Dropzone,
         'codeview': Codeview,
         'statusbar': Statusbar,

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -4,6 +4,7 @@ define([
   'summernote/base/summernote-en-US',
   'summernote/base/module/Editor',
   'summernote/base/module/Clipboard',
+  'summernote/base/module/Formatter',  
   'summernote/base/module/Dropzone',
   'summernote/base/module/Codeview',
   'summernote/base/module/Statusbar',
@@ -25,7 +26,7 @@ define([
   'summernote/base/module/HintPopover'
 ], function (
   ui, dom, lang,
-  Editor, Clipboard, Dropzone, Codeview, Statusbar, Fullscreen, Handle, AutoLink, AutoSync, Placeholder,
+  Editor, Clipboard, Formatter, Dropzone, Codeview, Statusbar, Fullscreen, Handle, AutoLink, AutoSync, Placeholder,
   Buttons, Toolbar, LinkDialog, LinkPopover, ImageDialog, ImagePopover, TablePopover, VideoDialog, HelpDialog, AirPopover, HintPopover
 ) {
 
@@ -40,6 +41,7 @@ define([
       modules: {
         'editor': Editor,
         'clipboard': Clipboard,
+        'formatter': Formatter,        
         'dropzone': Dropzone,
         'codeview': Codeview,
         'statusbar': Statusbar,

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -3,6 +3,7 @@ define([
   'summernote/base/summernote-en-US',
   'summernote/base/module/Editor',
   'summernote/base/module/Clipboard',
+  'summernote/base/module/Formatter',  
   'summernote/base/module/Dropzone',
   'summernote/base/module/Codeview',
   'summernote/base/module/Statusbar',
@@ -24,7 +25,7 @@ define([
   'summernote/base/module/HintPopover'
 ], function (
   ui, lang,
-  Editor, Clipboard, Dropzone, Codeview, Statusbar, Fullscreen, Handle, AutoLink, AutoSync, Placeholder,
+  Editor, Clipboard, Formatter, Dropzone, Codeview, Statusbar, Fullscreen, Handle, AutoLink, AutoSync, Placeholder,
   Buttons, Toolbar, LinkDialog, LinkPopover, ImageDialog, ImagePopover, TablePopover, VideoDialog, HelpDialog, AirPopover, HintPopover
 ) {
 
@@ -38,6 +39,7 @@ define([
       modules: {
         'editor': Editor,
         'clipboard': Clipboard,
+        'formatter': Formatter,
         'dropzone': Dropzone,
         'codeview': Codeview,
         'statusbar': Statusbar,

--- a/test/unit/base/module/Formatter.spec.js
+++ b/test/unit/base/module/Formatter.spec.js
@@ -1,0 +1,124 @@
+/**
+ * Formatter.spec.js
+ * (c) 2015~ Summernote Team
+ * summernote may be freely distributed under the MIT license./
+ */
+define([
+  'chai',
+  'summernote/base/core/range',
+  'summernote/base/Context',
+  'summernote/base/module/Formatter'
+], function (chai, range, Context, Formatter) {
+  'use strict';
+
+  var expect = chai.expect;
+
+  var expectContents = function (context, markup) {
+    expect(context.layoutInfo.editable.html()).to.equalsIgnoreCase(markup);
+  };
+
+  describe('Formatter', function () {
+    var formatter, context;
+
+    beforeEach(function () {
+      var options = $.extend({}, $.summernote.options);
+      options.langInfo = $.extend(true, {
+      }, $.summernote.lang['en-US'], $.summernote.lang[options.lang]);
+      context = new Context($('<div><p>hello</p></div>'), options);
+      formatter = new Formatter(context);
+
+      // append to body 
+      context.layoutInfo.editable.appendTo('body');
+      
+    });
+
+    it('check single range for fontName execCommand  ', function () {
+
+      var $p = context.layoutInfo.editable.find('p');
+      var textNode = $p[0].firstChild;
+
+      range.create(textNode, 0, textNode, 2).select();
+      document.execCommand('fontName', false, 'Arial');
+      formatter.fontName();
+      
+      var $span = $p.find('span');
+      expect($span.length).to.equals(1);
+      expect($span.css('font-family')).to.equals('Arial');
+      expectContents(context, '<p><span style="font-family: Arial;">he</span>llo</p>');
+    });
+
+    it('check multi range for fontName execCommand  ', function () {
+      var sampleText = [
+        '<p>hello</p>',
+        '<p>World</p>',
+        '<p>Wow</p>',
+        '<p>Show me the money</p>',
+        '<p>ChuChu</p>'
+      ].join('');
+      context.invoke('code', sampleText);
+
+      var $p = context.layoutInfo.editable.find('p');
+
+      var $startP = $p.first();
+      var startTextNode = $startP[0].firstChild;
+
+      var $lastP = $p.last();
+      var lastTextNode = $lastP[0].firstChild;      
+
+      range.create(startTextNode, 0, lastTextNode, 3).select();
+      document.execCommand('fontName', false, 'Arial');
+      formatter.fontName();
+      
+      var $span = $p.find('span');
+      expect($span.length).to.equals(5);
+      expect($span.first().css('font-family')).to.equals('Arial');
+
+      var testText = [
+        '<p><span style="font-family: Arial;">hello</span></p>',
+        '<p><span style="font-family: Arial;">World</span></p>',
+        '<p><span style="font-family: Arial;">Wow</span></p>',
+        '<p><span style="font-family: Arial;">Show me the money</span></p>',
+        '<p><span style="font-family: Arial;">Chu</span>Chu</p>'
+      ].join('');
+
+      expectContents(context, testText);
+    });
+
+    it('test multi range 2 for fontName execCommand  ', function () {
+      var sampleText = [
+        '<p>he <span>yollo</span>llo</p>',
+        '<p>World</p>',
+        '<p>Wow</p>',
+        '<p>Show me the money</p>',
+        '<p>ChuChu</p>'
+      ].join('');
+      context.invoke('code', sampleText);
+
+      var $p = context.layoutInfo.editable.find('p');
+
+      var $startElement = $p.first().find('span');
+      var startTextNode = $startElement[0].firstChild;
+
+      var $lastP = $p.last();
+      var lastTextNode = $lastP[0].firstChild;      
+
+      range.create(startTextNode, 0, lastTextNode, 3).select();
+      document.execCommand('fontName', false, 'Arial');
+      formatter.fontName();
+      
+      var $span = $p.find('span');
+      expect($span.length).to.equals(6);
+      expect($span.first().css('font-family')).to.equals('Arial');
+
+      var testText = [
+        '<p>he <span style="font-family: Arial;"><span>yollo</span>llo</span></p>',
+        '<p><span style="font-family: Arial;">World</span></p>',
+        '<p><span style="font-family: Arial;">Wow</span></p>',
+        '<p><span style="font-family: Arial;">Show me the money</span></p>',
+        '<p><span style="font-family: Arial;">Chu</span>Chu</p>'
+      ].join('');
+
+      expectContents(context, testText);
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?

- support formatter for execCommand
- when execCommand is run ,  Formatter module is called and then  run method like command's name 

#### Where should the reviewer start?

- start on the src/js/base/module/Editor.js , search fontName execCommand 
- src/js/base/module/Formatter.js

#### How should this be manually tested?


#### Any background context you want to provide?

- execCommand is diffrent by browser 
- This is one way to do the same thing for Cross Browser.

#### What are the relevant tickets?

#2005

#### Screenshots (if for frontend)


### Checklist
- [X] added test units for Formatter module 

