### PR TITLE
fix grunt-webfont error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: node_js
 sudo: false
-node_js: 7
+node_js: 8
 cache:
   directories:
     - node_modules
+before_install:
+- sudo add-apt-repository ppa:fontforge/fontforge -y
+- sudo apt-get update -q
+- sudo apt-get install fontforge ttfautohint -y
 before_script:
 - node --version
 - npm --version


### PR DESCRIPTION
`grunt webfont` in `grunt dist` occrrued an error on Travis CI. See [#2850 build](https://travis-ci.org/summernote/summernote/builds/273586238).

```
Running "webfont:icons" (webfont) task
Warning: fontforge not found. Please install fontforge and all other requirements: https://github.com/sapegin/grunt-webfont#installation Use --force to continue.
Aborted due to warnings.
```

As [the document](https://github.com/sapegin/grunt-webfont#linux) of `grunt-webfont`, fontforge is required.

It looks like [build webfonts correctly](https://travis-ci.org/outsideris/summernote/builds/283538595), but I can't check the less files yet. Also, I didn't know about the webfonts. Could you check it? @easylogic 