### PR TITLE
Add option to make Image Popover open at Mouse Position.

### DIFF
--- a/src/js/base/module/ImagePopover.js
+++ b/src/js/base/module/ImagePopover.js
@@ -40,14 +40,23 @@ export default class ImagePopover {
 
   update(target) {
     if (dom.isImg(target)) {
-      const pos = dom.posFromPlaceholder(target);
-      const posEditor = dom.posFromPlaceholder(this.editable);
+      if (options.popatmouse){
 
-      this.$popover.css({
-        display: 'block',
-        left: pos.left,
-        top: Math.min(pos.top, posEditor.top)
-      });
+        this.$popover.css({
+          display: 'block',
+          left: event.pageX-20,
+          top: event.pageY
+        });
+      }else{
+        const pos = dom.posFromPlaceholder(target);
+        const posEditor = dom.posFromPlaceholder(this.editable);
+
+        this.$popover.css({
+          display: 'block',
+          left: pos.left,
+          top: Math.min(pos.top, posEditor.top)
+        });
+      }
     } else {
       this.hide();
     }

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -78,6 +78,7 @@ $.summernote = $.extend($.summernote, {
     ],
 
     // popover
+    popatmouse: true, // true|false toggle if popover (image) opens at mouse position
     popover: {
       image: [
         ['imagesize', ['imageSize100', 'imageSize50', 'imageSize25']],

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -78,6 +78,7 @@ $.summernote = $.extend($.summernote, {
     ],
 
     // popover
+    popatmouse: true, // true|false toggle if popover (image) opens at mouse position
     popover: {
       image: [
         ['imagesize', ['imageSize100', 'imageSize50', 'imageSize25']],

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -77,6 +77,7 @@ $.summernote = $.extend($.summernote, {
     ],
 
     // popover
+    popatmouse: true, // true|false toggle if popover (image) opens at mouse position
     popover: {
       image: [
         ['imagesize', ['imageSize100', 'imageSize50', 'imageSize25']],


### PR DESCRIPTION
Adds an Option `popatmouse: true|false` to toggle if Popover (Image in this PR) opens at mouse position. Which was added so image larger than the editor open the popover without having to scroll to the end of the editor document.