### PR TITLE
Rename UI components for Lite

### DIFF
--- a/src/js/lite/ui/dropdown.js
+++ b/src/js/lite/ui/dropdown.js
@@ -1,4 +1,4 @@
-var dropdown = (function() {
+var DropdownUI = (function() {
   var Dropdown = function($node, options) {
     var self = this;
 
@@ -77,4 +77,4 @@ $(document).on('click.note-dropdown-menu', function(e) {
   $(e.target).closest('.note-dropdown-menu').parent().removeClass('open');
 });
 
-export default dropdown;
+export default DropdownUI;

--- a/src/js/lite/ui/modal.js
+++ b/src/js/lite/ui/modal.js
@@ -1,4 +1,4 @@
-var modal = (function() {
+var ModalUI = (function() {
   var Modal = function($node, options) {
     var self = this;
 
@@ -45,4 +45,4 @@ var modal = (function() {
   };
 })();
 
-export default modal;
+export default ModalUI;

--- a/src/js/lite/ui/popover.js
+++ b/src/js/lite/ui/popover.js
@@ -1,4 +1,4 @@
-var popover = (function() {
+var PopoverUI = (function() {
   var Popover = function($node, options) {
     var self = this;
 
@@ -109,4 +109,4 @@ var popover = (function() {
   };
 })();
 
-export default popover;
+export default PopoverUI;

--- a/src/js/lite/ui/tooltip.js
+++ b/src/js/lite/ui/tooltip.js
@@ -1,4 +1,4 @@
-var tooltip = (function() {
+var TooltipUI = (function() {
   var Tooltip = function($node, options) {
     var self = this;
 
@@ -106,4 +106,4 @@ var tooltip = (function() {
     }
   };
 })();
-export default tooltip;
+export default TooltipUI;


### PR DESCRIPTION
The build process seems to include the UI components as-is rather than using the name they're imported as.  Renaming the components from `component` to `ComponentUI` in their source files results in a working build.  Closes #2510.

#### What does this PR do?

- Results in a working version of summernote-lite.js

#### Where should the reviewer start?

- Build and test summernote-lite

#### What are the relevant tickets?

#2510 

### Checklist
- [X] added relevant tests (N/A)
- [X] didn't break anything
