### PR TITLE
Add Image popover enhancements.

### DIFF
--- a/src/js/base/module/Handle.js
+++ b/src/js/base/module/Handle.js
@@ -120,7 +120,7 @@ export default class Handle {
       const origImageObj = new Image();
       origImageObj.src = $image.attr("src");
 
-      const sizingText = imageSize.w + 'x' + imageSize.h + ' (Original: '+ origImageObj.width + 'x' + origImageObj.height +')';
+      const sizingText = imageSize.w + 'x' + imageSize.h + ' (Original: '+ origImageObj.width + 'x' + origImageObj.height + ')';
       this.context.invoke('editor.saveTarget', target);
     } else {
       this.hide();

--- a/src/js/base/module/Handle.js
+++ b/src/js/base/module/Handle.js
@@ -118,9 +118,10 @@ export default class Handle {
       }).data('target', $image); // save current image element.
 
       const origImageObj = new Image();
-      origImageObj.src = $image.attr("src");
+      origImageObj.src = $image.attr('src');
 
-      const sizingText = imageSize.w + 'x' + imageSize.h + ' (Original: '+ origImageObj.width + 'x' + origImageObj.height + ')';
+      const sizingText = imageSize.w + 'x' + imageSize.h + ' (Original: ' + origImageObj.width + 'x' + origImageObj.height + ')';
+      $selection.find('.note-control-selection-info').text(sizingText);
       this.context.invoke('editor.saveTarget', target);
     } else {
       this.hide();

--- a/src/js/base/module/Handle.js
+++ b/src/js/base/module/Handle.js
@@ -117,8 +117,10 @@ export default class Handle {
         height: imageSize.h
       }).data('target', $image); // save current image element.
 
-      const sizingText = imageSize.w + 'x' + imageSize.h;
-      $selection.find('.note-control-selection-info').text(sizingText);
+      const origImageObj = new Image();
+      origImageObj.src = $image.attr("src");
+
+      const sizingText = imageSize.w + 'x' + imageSize.h + ' (Original: '+ origImageObj.width + 'x' + origImageObj.height +')';
       this.context.invoke('editor.saveTarget', target);
     } else {
       this.hide();

--- a/src/js/base/module/ImagePopover.js
+++ b/src/js/base/module/ImagePopover.js
@@ -42,11 +42,10 @@ export default class ImagePopover {
     if (dom.isImg(target)) {
       const pos = dom.posFromPlaceholder(target);
       const posEditor = dom.posFromPlaceholder(this.editable);
-
       this.$popover.css({
         display: 'block',
-        left: pos.left,
-        top: Math.min(pos.top, posEditor.top)
+        left: this.options.popatmouse ? event.pageX - 20 : pos.left,
+        top: this.options.popatmouse ? event.pageY : Math.min(pos.top, posEditor.top)
       });
     } else {
       this.hide();

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -78,6 +78,7 @@ $.summernote = $.extend($.summernote, {
     ],
 
     // popover
+    popatmouse: true,
     popover: {
       image: [
         ['imagesize', ['imageSize100', 'imageSize50', 'imageSize25']],

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -78,6 +78,7 @@ $.summernote = $.extend($.summernote, {
     ],
 
     // popover
+    popatmouse: true,
     popover: {
       image: [
         ['imagesize', ['imageSize100', 'imageSize50', 'imageSize25']],

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -77,6 +77,7 @@ $.summernote = $.extend($.summernote, {
     ],
 
     // popover
+    popatmouse: true,
     popover: {
       image: [
         ['imagesize', ['imageSize100', 'imageSize50', 'imageSize25']],


### PR DESCRIPTION
#### What does this PR do?

- Adds `popatmouse` option for popovers.
- Enhance Image Popover to open at mouse position when `popatmouse` option is set to `true`
- Add actual image size to ([width] x [height]) display within image placeholder.

#### Any background context you want to provide?

- Just some enhancements to make image editing a little more easier. For e.g. large images that are outside the visible canvas area of the editor would require scrolling to find the image popover.
