### PR TITLE
Update font name to appear in the selected font

### DIFF
--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -701,7 +701,7 @@ export default class Buttons {
         const isChecked = ($item.data('value') + '') === (fontName + '');
         $item.toggleClass('checked', isChecked);
       });
-      $cont.find('.note-current-fontname').text(fontName);
+      $cont.find('.note-current-fontname').text(fontName).css('font-family', fontName);
     }
 
     if (styleInfo['font-size']) {


### PR DESCRIPTION
#### What does this PR do?

- Make the current font name appear in the selected font

#### Any background context you want to provide?

- The font names dropdown already displays in the list of fonts however the when you select one, the item in the toolbar always used the inherited font.
- This makes it match the dropdown.