### PR TITLE
Lite: Default modal target to 'body'

### DIFF
--- a/src/js/lite/ui/modal.js
+++ b/src/js/lite/ui/modal.js
@@ -4,7 +4,7 @@ var modal = (function() {
 
     this.init = function(options) {
       this.options = $.extend({}, {
-        target: options.container
+        target: options.container || 'body'
       }, options);
 
       this.$modal = $node;


### PR DESCRIPTION
Defaults `options.target` to `'body'` for modals in Summernote Lite.  Fixes #2521.

#### What does this PR do?

- Fixes #2521 

#### Where should the reviewer start?

- src/js/lite/ui/modal.js

#### How should this be manually tested?

1. Run `npm run dist` to build assets (JS + CSS)
2. Run `npm run start` to run the local development server
3. Visit http://localhost:3000/lite.html in your browser
4. Click on a button which should trigger a dialog (such as the Link button)

#### Any background context you want to provide?

- It would be great to get this into v0.8.9, so that a usable build of summernote-lite is available soon.

#### What are the relevant tickets?

#2521 #2522 #2510 
