### PR TITLE
created AutoReplace module

### DIFF
--- a/src/js/base/core/key.js
+++ b/src/js/base/core/key.js
@@ -2,6 +2,11 @@ import lists from './lists';
 import func from './func';
 
 const KEY_MAP = {
+  //punctuation characters
+  'PERIOD': 190,
+  'COMMA': 188,
+  'SEMICOLON': 186,
+
   'BACKSPACE': 8,
   'TAB': 9,
   'ENTER': 13,

--- a/src/js/base/module/AutoReplace.js
+++ b/src/js/base/module/AutoReplace.js
@@ -1,0 +1,67 @@
+import $ from 'jquery';
+import func from '../core/func';
+import lists from '../core/lists';
+import dom from '../core/dom';
+import range from '../core/range';
+import key from '../core/key';
+
+
+export default class AutoReplace {
+  constructor(context) {
+    this.context = context;
+    this.options = context.options.replace || {};
+
+    this.events = {
+      'summernote.keyup': (we, e) => {
+        if (!e.isDefaultPrevented()) {
+          this.handleKeyup(e);
+        }
+      },
+      'summernote.keydown': (we, e) => {
+        this.handleKeydown(e);
+      },
+    };
+  }
+
+  shouldInitialize() {
+    return !$.isEmptyObject(this.options);
+  }
+
+  initialize() {
+    this.lastWordRange = null;
+  }
+
+  destroy() {
+    this.lastWordRange = null;
+  }
+
+  replace() {
+    if (!this.lastWordRange) {
+      return;
+    }
+
+    const keyword = this.lastWordRange.toString();
+    const match = this.options.match(keyword);
+
+    if (match) {
+      const node = dom.createText(match);
+
+      this.lastWordRange.insertNode(node);
+      this.lastWordRange = null;
+      this.context.invoke('editor.focus');
+    }
+  }
+
+  handleKeydown(e) {
+    if (lists.contains([key.code.ENTER, key.code.SPACE, 190], e.keyCode)) {
+      const wordRange = this.context.invoke('editor.createRange').getWordRange();
+      this.lastWordRange = wordRange;
+    }
+  }
+
+  handleKeyup(e) {
+    if (lists.contains([key.code.ENTER, key.code.SPACE, 190], e.keyCode)) {
+      this.replace();
+    }
+  }
+}

--- a/src/js/base/module/AutoReplace.js
+++ b/src/js/base/module/AutoReplace.js
@@ -11,6 +11,9 @@ export default class AutoReplace {
     this.context = context;
     this.options = context.options.replace || {};
 
+    this.keys = [key.code.ENTER, key.code.SPACE, key.code.PERIOD, key.code.COMMA, key.code.SEMICOLON, key.code.SLASH];
+    this.previousKeydownCode = null;
+
     this.events = {
       'summernote.keyup': (we, e) => {
         if (!e.isDefaultPrevented()) {
@@ -28,40 +31,50 @@ export default class AutoReplace {
   }
 
   initialize() {
-    this.lastWordRange = null;
+    this.lastWord = null;
   }
 
   destroy() {
-    this.lastWordRange = null;
+    this.lastWord = null;
   }
 
   replace() {
-    if (!this.lastWordRange) {
+    if (!this.lastWord) {
       return;
     }
 
-    const keyword = this.lastWordRange.toString();
+    const keyword = this.lastWord.toString();
     const match = this.options.match(keyword);
 
     if (match) {
       const node = dom.createText(match);
 
-      this.lastWordRange.insertNode(node);
-      this.lastWordRange = null;
+      this.lastWord.insertNode(node);
+      this.lastWord = null;
       this.context.invoke('editor.focus');
     }
   }
 
   handleKeydown(e) {
-    if (lists.contains([key.code.ENTER, key.code.SPACE, 190], e.keyCode)) {
-      const wordRange = this.context.invoke('editor.createRange').getWordRange();
-      this.lastWordRange = wordRange;
+
+    //this forces it to remember the last whole word, even if multiple termination keys are pressed
+    //before the previous key is let go.
+    if(this.previousKeydownCode && lists.contains(this.keys, this.previousKeydownCode)){
+      this.previousKeydownCode = e.keyCode;
+      return;
     }
+
+    if (lists.contains(this.keys, e.keyCode)) {
+      const wordRange = this.context.invoke('editor.createRange').getWordRange();
+      this.lastWord = wordRange;
+    }
+    this.previousKeydownCode = e.keyCode;
+
+    
   }
 
   handleKeyup(e) {
-    if (lists.contains([key.code.ENTER, key.code.SPACE, 190], e.keyCode)) {
+    if (lists.contains(this.keys, e.keyCode)) 
       this.replace();
-    }
   }
 }

--- a/src/js/base/module/HintPopover.js
+++ b/src/js/base/module/HintPopover.js
@@ -146,7 +146,7 @@ export default class HintPopover {
     if (!this.$popover.is(':visible')) {
       return;
     }
-
+    
     if (e.keyCode === key.code.ENTER) {
       e.preventDefault();
       this.replace();

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -10,6 +10,7 @@ import Statusbar from '../base/module/Statusbar';
 import Fullscreen from '../base/module/Fullscreen';
 import Handle from '../base/module/Handle';
 import AutoLink from '../base/module/AutoLink';
+import AutoReplace from '../base/module/AutoReplace';
 import AutoSync from '../base/module/AutoSync';
 import Placeholder from '../base/module/Placeholder';
 import Buttons from '../base/module/Buttons';
@@ -44,6 +45,7 @@ $.summernote = $.extend($.summernote, {
       //  - Script error about range when Enter key is pressed on hint popover
       'hintPopover': HintPopover,
       'autoLink': AutoLink,
+      'autoReplace': AutoReplace,
       'autoSync': AutoSync,
       'placeholder': Placeholder,
       'buttons': Buttons,

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -10,6 +10,7 @@ import Statusbar from '../base/module/Statusbar';
 import Fullscreen from '../base/module/Fullscreen';
 import Handle from '../base/module/Handle';
 import AutoLink from '../base/module/AutoLink';
+import AutoReplace from '../base/module/AutoReplace';
 import AutoSync from '../base/module/AutoSync';
 import Placeholder from '../base/module/Placeholder';
 import Buttons from '../base/module/Buttons';
@@ -44,6 +45,7 @@ $.summernote = $.extend($.summernote, {
       //  - Script error about range when Enter key is pressed on hint popover
       'hintPopover': HintPopover,
       'autoLink': AutoLink,
+      'autoReplace': AutoReplace,
       'autoSync': AutoSync,
       'placeholder': Placeholder,
       'buttons': Buttons,

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -9,6 +9,7 @@ import Statusbar from '../base/module/Statusbar';
 import Fullscreen from '../base/module/Fullscreen';
 import Handle from '../base/module/Handle';
 import AutoLink from '../base/module/AutoLink';
+import AutoReplace from '../base/module/AutoReplace';
 import AutoSync from '../base/module/AutoSync';
 import Placeholder from '../base/module/Placeholder';
 import Buttons from '../base/module/Buttons';
@@ -42,6 +43,7 @@ $.summernote = $.extend($.summernote, {
       //  - Script error about range when Enter key is pressed on hint popover
       'hintPopover': HintPopover,
       'autoLink': AutoLink,
+      'autoReplace': AutoReplace,
       'autoSync': AutoSync,
       'placeholder': Placeholder,
       'buttons': Buttons,


### PR DESCRIPTION
#### What does this PR do?

A new "AutoReplace" module so that words can be replaced.

#### Where should the reviewer start?

src/base/module/AutoReplace

#### How should this be manually tested?

create a new summernote with the replace match function set, eg:
`options.replace.match = function(word){
   if(word=='this') 
       return 'that';
   return null;
`
Anytime 'this' is typed it will be replaced with that.
You can provide any function to replace words.  This could be useful for splel check.

#### Any background context you want to provide?
I am using it for shortcuts, in conjunction with  "hints" but you don't have to select the hint if it is an exact match.  It is replaced once you enter a space or '.' or 'enter' after the word.

#### What are the relevant tickets?
none?

#### Screenshot (if for frontend)


### Checklist
- [ ] added relevant tests
- [x ] didn't break anything
- [ ] ...
