### PR TITLE
Add maxTextLength option for limiting text

### DIFF
--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -116,6 +116,7 @@ $.summernote = $.extend($.summernote, {
     direction: null,
     tooltip: 'auto',
     container: 'body',
+    maxTextLength: 0,
 
     styleTags: ['p', 'blockquote', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
 

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -116,6 +116,7 @@ $.summernote = $.extend($.summernote, {
     direction: null,
     tooltip: 'auto',
     container: 'body',
+    maxTextLength: 0,
 
     styleTags: [
       'p',

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -114,6 +114,7 @@ $.summernote = $.extend($.summernote, {
     direction: null,
     tooltip: 'auto',
     container: 'body',
+    maxTextLength: 0,
 
     styleTags: ['p', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
 

--- a/test/unit/base/module/Editor.spec.js
+++ b/test/unit/base/module/Editor.spec.js
@@ -147,12 +147,34 @@ describe('Editor', () => {
       editor.insertNode($('<span> world</span>')[0]);
       expectContents(context, '<p>hello<span> world</span></p>');
     });
+
+    it('should be limited', () => {
+      var options = $.extend({}, $.summernote.options);
+      options.langInfo = $.extend(true, {}, $.summernote.lang['en-US'], $.summernote.lang[options.lang]);
+      options.maxTextLength = 5;
+      context = new Context($('<div><p>hello</p></div>'), options);
+      editor = context.modules.editor;
+
+      editor.insertNode($('<span> world</span>')[0]);
+      expectContents(context, '<p>hello</p>');
+    });
   });
 
   describe('insertText', () => {
     it('should insert text', () => {
       editor.insertText(' world');
       expectContents(context, '<p>hello world</p>');
+    });
+
+    it('should be limited', () => {
+      var options = $.extend({}, $.summernote.options);
+      options.langInfo = $.extend(true, {}, $.summernote.lang['en-US'], $.summernote.lang[options.lang]);
+      options.maxTextLength = 5;
+      context = new Context($('<div><p>hello</p></div>'), options);
+      editor = context.modules.editor;
+
+      editor.insertText(' world');
+      expectContents(context, '<p>hello</p>');
     });
   });
 
@@ -177,6 +199,17 @@ describe('Editor', () => {
       var html = generateLargeHtml();
       editor.pasteHTML(html);
       expect(spy).to.have.been.called.once;
+    });
+
+    it('should be limited', () => {
+      var options = $.extend({}, $.summernote.options);
+      options.langInfo = $.extend(true, {}, $.summernote.lang['en-US'], $.summernote.lang[options.lang]);
+      options.maxTextLength = 5;
+      context = new Context($('<div><p>hello</p></div>'), options);
+      editor = context.modules.editor;
+
+      editor.pasteHTML('<span> world</span>');
+      expectContents(context, '<p>hello</p>');
     });
   });
 


### PR DESCRIPTION
#### What does this PR do?

- Add `options.maxTextLength` to limit the length of the text

#### Where should the reviewer start?

- start on the src/js/base/module/Editor.js

#### How should this be manually tested?

- set `maxTextLength` with a small value and try to `insertNode` / `insertText` / `pasteHTML`

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/118
- https://github.com/summernote/summernote/issues/1384
- https://github.com/summernote/summernote/issues/1957