### PR TITLE
Exclude test/coverage folder from eslint

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,6 +83,7 @@ module.exports = function(grunt) {
         'Gruntfile.js',
         'test/**/*.js',
         '!coverage/**/*.js',
+        '!test/coverage/**/*.js',
         'build/*.js'
       ]
     },


### PR DESCRIPTION
#### What does this PR do?

- I sometimes got errors by external sources in `test/coverage/<some-phantomjs>/lcov-report/*.js`.
- Exclude test/coverage folder to prevent lint errors by external sources

#### Where should the reviewer start?

- Gruntfile.js

#### How should this be manually tested?

- Just build it
