### PR TITLE
Set word-wrap as break-word for note-editable

### DIFF
--- a/src/less/summernote-bs4.less
+++ b/src/less/summernote-bs4.less
@@ -96,6 +96,7 @@
 
       &[contenteditable="false"] {
         background-color: #e5e5e5;
+        word-wrap: break-word;
       }
     }
 

--- a/src/less/summernote-bs4.less
+++ b/src/less/summernote-bs4.less
@@ -93,10 +93,10 @@
       color: #000;
       padding: 10px;
       overflow: auto;
+      word-wrap: break-word;
 
       &[contenteditable="false"] {
         background-color: #e5e5e5;
-        word-wrap: break-word;
       }
     }
 

--- a/src/less/summernote-bs4.scss
+++ b/src/less/summernote-bs4.scss
@@ -92,10 +92,10 @@ $img-margin-right: 10px;
       color: #000;
       padding: 10px;
       overflow: auto;
+      word-wrap: break-word;
 
       &[contenteditable="false"] {
         background-color: #e5e5e5;
-        word-wrap: break-word;
       }
     }
 

--- a/src/less/summernote-bs4.scss
+++ b/src/less/summernote-bs4.scss
@@ -95,6 +95,7 @@ $img-margin-right: 10px;
 
       &[contenteditable="false"] {
         background-color: #e5e5e5;
+        word-wrap: break-word;
       }
     }
 

--- a/src/less/summernote-lite.less
+++ b/src/less/summernote-lite.less
@@ -97,10 +97,10 @@
       color: #000;
       padding: 10px;
       overflow: auto;
+      word-wrap: break-word;
 
       &[contenteditable="false"] {
         background-color: #e5e5e5;
-        word-wrap: break-word;
       }
     }
 

--- a/src/less/summernote-lite.less
+++ b/src/less/summernote-lite.less
@@ -100,6 +100,7 @@
 
       &[contenteditable="false"] {
         background-color: #e5e5e5;
+        word-wrap: break-word;
       }
     }
 

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -96,6 +96,7 @@
 
       &[contenteditable="false"] {
         background-color: #e5e5e5;
+        word-wrap: break-word;
       }
     }
 

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -93,10 +93,10 @@
       color: #000;
       padding: 10px;
       overflow: auto;
+      word-wrap: break-word;
 
       &[contenteditable="false"] {
         background-color: #e5e5e5;
-        word-wrap: break-word;
       }
     }
 

--- a/src/less/summernote.scss
+++ b/src/less/summernote.scss
@@ -92,10 +92,10 @@ $img-margin-right: 10px;
       color: #000;
       padding: 10px;
       overflow: auto;
+      word-wrap: break-word;
 
       &[contenteditable="false"] {
         background-color: #e5e5e5;
-        word-wrap: break-word;
       }
     }
 

--- a/src/less/summernote.scss
+++ b/src/less/summernote.scss
@@ -95,6 +95,7 @@ $img-margin-right: 10px;
 
       &[contenteditable="false"] {
         background-color: #e5e5e5;
+        word-wrap: break-word;
       }
     }
 


### PR DESCRIPTION
#### What does this PR do?

- Set `word-wrap: break-word;` for disabled contenteditables.

#### Where should the reviewer start?

- start on less/scss files

#### How should this be manually tested?

- write a long text in summernote and disabled it

#### Any background context you want to provide?

- `contenteidtable="true"` div gives `word-wrap: break-word;` by default, but `"false"` does not. So I added it by manually.

#### What are the relevant tickets?

- #2553 
