### PR TITLE
Remove useless direction option and add omitted hintDirection option

### DIFF
--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -113,7 +113,7 @@ $.summernote = $.extend($.summernote, {
     styleWithSpan: true,
     shortcuts: true,
     textareaAutoSync: true,
-    direction: null,
+    hintDirection: 'bottom',
     tooltip: 'auto',
     container: 'body',
 

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -113,7 +113,7 @@ $.summernote = $.extend($.summernote, {
     styleWithSpan: true,
     shortcuts: true,
     textareaAutoSync: true,
-    direction: null,
+    hintDirection: 'bottom',
     tooltip: 'auto',
     container: 'body',
 

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -111,7 +111,7 @@ $.summernote = $.extend($.summernote, {
     styleWithSpan: true,
     shortcuts: true,
     textareaAutoSync: true,
-    direction: null,
+    hintDirection: 'bottom',
     tooltip: 'auto',
     container: 'body',
 


### PR DESCRIPTION
#### What does this PR do?

- Remove useless `direction` option.
- Add omitted `hintDirection` option.

#### Where should the reviewer start?

- Each `settings.js` file.

#### How should this be manually tested?

- Change `hintDirection` to `top` and check whether it displays hint popovers properly.

#### Any background context you want to provide?

- There was a `direction` option for choosing LTR/RTL direction. But we lost it while we're refactoring code structures. And it was not a full-featured RTL support. It just added `direction: rtl` to its CSS style.

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/563
- https://github.com/summernote/summernote/issues/1746
