### PR TITLE
Add a callback for blurring on codeview

### DIFF
--- a/src/js/base/module/Codeview.js
+++ b/src/js/base/module/Codeview.js
@@ -74,9 +74,17 @@ export default class CodeView {
         });
       }
 
+      cmEditor.on('blur', (event) => {
+        this.context.triggerEvent('blur.codeview', cmEditor.getValue(), event);
+      });
+
       // CodeMirror hasn't Padding.
       cmEditor.setSize(null, this.$editable.outerHeight());
       this.$codable.data('cmEditor', cmEditor);
+    } else {
+      this.$codable.on('blur', (event) => {
+        this.context.triggerEvent('blur.codeview', this.$codable.val(), event);
+      });
     }
   }
 

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -158,6 +158,7 @@ $.summernote = $.extend($.summernote, {
       onInit: null,
       onFocus: null,
       onBlur: null,
+      onBlurCodeview: null,
       onEnter: null,
       onKeyup: null,
       onKeydown: null,

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -162,6 +162,7 @@ $.summernote = $.extend($.summernote, {
       onInit: null,
       onFocus: null,
       onBlur: null,
+      onBlurCodeview: null,
       onEnter: null,
       onKeyup: null,
       onKeydown: null,

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -156,6 +156,7 @@ $.summernote = $.extend($.summernote, {
       onInit: null,
       onFocus: null,
       onBlur: null,
+      onBlurCodeview: null,
       onEnter: null,
       onKeyup: null,
       onKeydown: null,


### PR DESCRIPTION
#### What does this PR do?

- Add a callback for blurring on Codeview

#### Where should the reviewer start?

- start on the src/js/base/module/Codeview.js

#### How should this be manually tested?

- Add a callback named `OnBlurCodeview`.

#### Any background context you want to provide?

- At django-summernote, it had to catch a blurring event on Codeview to copy values from it. But this also needed in other connectors.

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/758
