### PR TITLE
Make the toolbar simpler again

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "grunt test",
     "download:selenium": "if [ ! -e test/libs/selenium-server-standalone.jar ]; then wget http://selenium-release.storage.googleapis.com/3.6/selenium-server-standalone-3.6.0.jar -O test/libs/selenium-server-standalone.jar; fi",
     "test:e2e": "npm run download:selenium && concurrently --kill-others 'node test/e2e/static-server.js' 'nightwatch --config test/nightwatch.conf.js'",
-    "test:e2e-saucelabs": "npx bower install && npm run dist && npm run download:selenium && nightwatch --config test/nightwatch.conf.js --env ie9,ie10,ie11,chrome,firefox",
+    "test:e2e-saucelabs": "npm run dist && npm run download:selenium && nightwatch --config test/nightwatch.conf.js --env ie9,ie10,ie11,chrome,firefox",
     "build": "grunt build",
     "dist": "grunt dist",
     "test-travis": "grunt test-travis --verbose",

--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -95,6 +95,19 @@ export default class Buttons {
       ]).render();
     });
 
+    for (let styleIdx = 0, styleLen = this.options.styleTags.length; styleIdx < styleLen; styleIdx++) {
+      const item = this.options.styleTags[styleIdx];
+
+      this.context.memo('button.style.' + item, () => {
+        return this.button({
+          className: 'note-btn-style-' + item,
+          contents: '<div data-value="' + item + '">' + item.toUpperCase() + '</div>',
+          tooltip: item.toUpperCase(),
+          click: this.context.createInvokeHandler('editor.formatBlock')
+        }).render();
+      });
+    }
+
     this.context.memo('button.bold', () => {
       return this.button({
         className: 'note-btn-bold',

--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -643,7 +643,7 @@ export default class Buttons {
     for (let groupIdx = 0, groupLen = groups.length; groupIdx < groupLen; groupIdx++) {
       const group = groups[groupIdx];
       const groupName = group[0];
-      const buttons = group[1];
+      const buttons = (group.length === 1) ? [group[0]] : group[1];
 
       const $group = this.ui.buttonGroup({
         className: 'note-' + groupName

--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -655,8 +655,8 @@ export default class Buttons {
   build($container, groups) {
     for (let groupIdx = 0, groupLen = groups.length; groupIdx < groupLen; groupIdx++) {
       const group = groups[groupIdx];
-      const groupName = group[0];
-      const buttons = (group.length === 1) ? [group[0]] : group[1];
+      const groupName = $.isArray(group) ? group[0] : group;
+      const buttons = $.isArray(group) ? ((group.length === 1) ? [group[0]] : group[1]) : [group];
 
       const $group = this.ui.buttonGroup({
         className: 'note-' + groupName


### PR DESCRIPTION
#### What does this PR do?

- Allow the simplest way to define buttons in the toolbar.
- If there is only one button in a button group, then it could be `['style']` or just `style`, not `['style', ['style']]`. We currently only accept the last - verbose - way.
- Also provides buttons for each style. They can be defined as like `style.h1`, `style.pre`.

Example:
```
toolbar: [                                                                                  
  ['style', ['style.p', 'style.h1', 'style.h2', 'style.h3', 'style.pre']],
  'height',                                                                                 
  'codeview'                                                                                
]
```

#### Where should the reviewer start?

- start on the `src/js/base/module/Buttons.js`

#### How should this be manually tested?

- click here and here

#### Any background context you want to provide?

- No

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/2417

#### Screenshot (if for frontend)

![screen shot 2017-11-29 at 9 10 52 pm](https://user-images.githubusercontent.com/579366/33374545-f617d76c-d549-11e7-90fc-a5971560bbc4.png)