### PR TITLE
[WIP] Add default fonts and a fix for styling

### DIFF
--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -62,6 +62,13 @@ export default class Buttons {
     return this.fontInstalledMap[name];
   }
 
+  isFontDeservedToAdd(name) {
+    const genericFamilies = ['sans-serif', 'serif', 'monospace', 'cursive', 'fantasy'];
+    name = name.toLowerCase();
+
+    return ((name !== '') && this.isFontInstalled(name) && ($.inArray(name, genericFamilies) === -1));
+  }
+
   addToolbarButtons() {
     this.context.memo('button.style', () => {
       return this.ui.buttonGroup([
@@ -171,6 +178,18 @@ export default class Buttons {
     });
 
     this.context.memo('button.fontname', () => {
+      const styleInfo = this.context.invoke('editor.currentStyle');
+
+      // Add 'default' fonts into the fontnames array if not exist
+      $.each(styleInfo['font-family'].split(','), (idx, fontname) => {
+        fontname = fontname.trim().replace(/['"]+/g, '');
+        if (this.isFontDeservedToAdd(fontname)) {
+          if ($.inArray(fontname, this.options.fontNames) === -1) {
+            this.options.fontNames.push(fontname);
+          }
+        }
+      });
+
       return this.ui.buttonGroup([
         this.button({
           className: 'dropdown-toggle',
@@ -187,7 +206,7 @@ export default class Buttons {
           checkClassName: this.options.icons.menuCheck,
           items: this.options.fontNames.filter(this.isFontInstalled.bind(this)),
           template: (item) => {
-            return '<span style="font-family:' + item + '">' + item + '</span>';
+            return '<span style="font-family: \'' + item + '\'">' + item + '</span>';
           },
           click: this.context.createInvokeHandlerAndUpdateState('editor.fontName')
         })

--- a/test/unit/bs/module/Buttons.spec.js
+++ b/test/unit/bs/module/Buttons.spec.js
@@ -217,8 +217,8 @@ describe('Buttons', () => {
     });
   });
 
-  describe('font size button', () => {
-    it('should update font size button value when changing font size with empty content', () => {
+  describe('font size button with empty content', () => {
+    it('should update font size button value when changing font size', () => {
       var $fontSizeDropdown = $toolbar.find('.dropdown-fontsize');
       var $fontSizeButton = $fontSizeDropdown.siblings('button');
       var $fontSizeList = $fontSizeDropdown.find('a');


### PR DESCRIPTION
#### What does this PR do?

- If a page has a global style like `* { font-family: blahblah }` then it affects the fontname dropdown.
- This patch adds default fonts into the dropdown even settings does not have them.
- I made `Editor.js` to use similar function `editor.fontStyling` to prevent creating empty `<span>`. Currently, summernote creates an empty `<span>` with an empty range selection.

#### Where should the reviewer start?

- start on the `src/js/base/module/Editor.js`

#### How should this be manually tested?

- Set global `font-family` style and click the fontname dropdown.

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/2176
