### PR TITLE
Do not trigger focus events on mobile

### DIFF
--- a/src/js/base/module/ImageDialog.js
+++ b/src/js/base/module/ImageDialog.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import env from '../core/env';
 import key from '../core/key';
 
 export default class ImageDialog {
@@ -105,7 +106,11 @@ export default class ImageDialog {
         $imageUrl.on('keyup paste', () => {
           const url = $imageUrl.val();
           this.ui.toggleBtn($imageBtn, url);
-        }).val('').trigger('focus');
+        }).val('');
+
+        if (!env.isSupportTouch) {
+          $imageUrl.trigger('focus');
+        }
         this.bindEnterKey($imageUrl, $imageBtn);
       });
 

--- a/src/js/base/module/LinkDialog.js
+++ b/src/js/base/module/LinkDialog.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import env from '../core/env';
 import key from '../core/key';
 
 export default class LinkDialog {
@@ -112,7 +113,11 @@ export default class LinkDialog {
 
         $linkUrl.on('input', handleLinkUrlUpdate).on('paste', () => {
           setTimeout(handleLinkUrlUpdate, 0);
-        }).val(linkInfo.url).trigger('focus');
+        }).val(linkInfo.url);
+
+        if (!env.isSupportTouch) {
+          $linkUrl.trigger('focus');
+        }
 
         this.toggleLinkBtn($linkBtn, $linkText, $linkUrl);
         this.bindEnterKey($linkUrl, $linkBtn);

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import env from '../core/env';
 import key from '../core/key';
 
 export default class VideoDialog {
@@ -173,7 +174,11 @@ export default class VideoDialog {
 
         $videoUrl.val(text).on('input', () => {
           this.ui.toggleBtn($videoBtn, $videoUrl.val());
-        }).trigger('focus');
+        });
+
+        if (!env.isSupportTouch) {
+          $videoUrl.trigger('focus');
+        }
 
         $videoBtn.click((event) => {
           event.preventDefault();

--- a/src/js/base/summernote-en-US.js
+++ b/src/js/base/summernote-en-US.js
@@ -44,7 +44,7 @@ $.extend($.summernote.lang, {
       video: 'Video',
       videoLink: 'Video Link',
       insert: 'Insert Video',
-      url: 'Video URL?',
+      url: 'Video URL',
       providers: '(YouTube, Vimeo, Vine, Instagram, DailyMotion or Youku)'
     },
     link: {


### PR DESCRIPTION
#### What does this PR do?

- This patch prevents to trigger focus events on mobile devices. (determined by `env.isSupportTouch`)

#### Where should the reviewer start?

- Each dialog files.

#### How should this be manually tested?

- Run summernote on both a touchable device and a non-touchable device.

#### Any background context you want to provide?

- If we trigger `focus` event on input elements while dialogs are popping up on mobile devices, the keyboard UI pushes dialogs up and hard to recognize what to do.

#### What are the relevant tickets?

- #891 

#### Screenshot (if for frontend)

Now it displays the dialog properly. (without keyboard)
![img_4595](https://user-images.githubusercontent.com/579366/33647575-25132766-da99-11e7-9093-2757e905c0ce.PNG)

If a user selects the input box, the keyboard pops up in right way.
![img_4596](https://user-images.githubusercontent.com/579366/33647574-24e4298e-da99-11e7-8c39-171c8727b72f.PNG)
