### PR TITLE
Do not remove statusbar by reset

### DIFF
--- a/src/js/base/Context.js
+++ b/src/js/base/Context.js
@@ -195,7 +195,7 @@ export default class Context {
   }
 
   /**
-   *Some buttons need to change their visual style immediately once they get pressed
+   * Some buttons need to change their visual style immediately once they get pressed
    */
   createInvokeHandlerAndUpdateState(namespace, value) {
     return (event) => {

--- a/src/js/base/module/Statusbar.js
+++ b/src/js/base/module/Statusbar.js
@@ -37,6 +37,5 @@ export default class Statusbar {
 
   destroy() {
     this.$statusbar.off();
-    this.$statusbar.remove();
   }
 }


### PR DESCRIPTION
#### What does this PR do?

- Currently, calling `reset` also removes the `Statusbar`. Module `Statusbar` is not a constructor of `Statusbar` so `Statusbar` should not be removed by the module `Statusbar`.

#### Where should the reviewer start?

- start on the `src/js/base/module/Statusbar.js`

#### How should this be manually tested?

- call `reset` and see whether the Statusbar disappears or not.

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/2586