### PR TITLE
Do not propagate enter events on dialogs

### DIFF
--- a/src/js/base/module/ImageDialog.js
+++ b/src/js/base/module/ImageDialog.js
@@ -55,6 +55,7 @@ export default class ImageDialog {
   bindEnterKey($input, $btn) {
     $input.on('keypress', (event) => {
       if (event.keyCode === key.code.ENTER) {
+        event.preventDefault();
         $btn.trigger('click');
       }
     });

--- a/src/js/base/module/LinkDialog.js
+++ b/src/js/base/module/LinkDialog.js
@@ -56,6 +56,7 @@ export default class LinkDialog {
   bindEnterKey($input, $btn) {
     $input.on('keypress', (event) => {
       if (event.keyCode === key.code.ENTER) {
+        event.preventDefault();
         $btn.trigger('click');
       }
     });

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -41,6 +41,7 @@ export default class VideoDialog {
   bindEnterKey($input, $btn) {
     $input.on('keypress', (event) => {
       if (event.keyCode === key.code.ENTER) {
+        event.preventDefault();
         $btn.trigger('click');
       }
     });


### PR DESCRIPTION
#### What does this PR do?

- This patch prevents form submitting by hitting `enter` on dialogs.
- Previously, we use `event.preventDefault()` on clickings, not on pressing `enter`. So I fix them.

#### Where should the reviewer start?

- start on `src/js/base/module/\w+\.js`

#### How should this be manually tested?

- press `enter` on any dialog and see whether forms are submitted or not.

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/1561
- https://github.com/summernote/summernote/issues/1456