### PR TITLE
Update summernote css to reflect Notification area styles and fix notification area markup.

### DIFF
--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -7,8 +7,8 @@ const editingArea = renderer.create('<div class="note-editing-area"/>');
 const codable = renderer.create('<textarea class="note-codable" role="textbox" aria-multiline="true"/>');
 const editable = renderer.create('<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>');
 const statusbar = renderer.create([
+  '<output class="note-status-output" aria-live="polite"/>',
   '<div class="note-statusbar" role="status">',
-  '  <output class="note-status-output" aria-live="polite"></output>',
   '  <div class="note-resizebar" role="seperator" aria-orientation="horizontal" aria-label="Resize">',
   '    <div class="note-icon-bar"/>',
   '    <div class="note-icon-bar"/>',
@@ -18,7 +18,10 @@ const statusbar = renderer.create([
 ].join(''));
 
 const airEditor = renderer.create('<div class="note-editor"/>');
-const airEditable = renderer.create('<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>');
+const airEditable = renderer.create([
+  '  <output class="note-status-output" aria-live="polite"/>',
+  '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>'
+].join(''));
 
 const buttonGroup = renderer.create('<div class="note-btn-group btn-group">');
 

--- a/src/js/bs4/ui.js
+++ b/src/js/bs4/ui.js
@@ -7,6 +7,7 @@ const editingArea = renderer.create('<div class="note-editing-area"/>');
 const codable = renderer.create('<textarea class="note-codable" role="textbox" aria-multiline="true"/>');
 const editable = renderer.create('<div class="note-editable card-block" contentEditable="true" role="textbox" aria-multiline="true"/>');
 const statusbar = renderer.create([
+  '<output class="note-status-output" aria-live="polite"/>',
   '<div class="note-statusbar" role="status">',
   '  <output class="note-status-output" aria-live="polite"></output>',
   '  <div class="note-resizebar" role="seperator" aria-orientation="horizontal" aria-label="Resize">',
@@ -18,7 +19,10 @@ const statusbar = renderer.create([
 ].join(''));
 
 const airEditor = renderer.create('<div class="note-editor"/>');
-const airEditable = renderer.create('<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>');
+const airEditable = renderer.create([
+  '<output class="note-status-output" aria-live="polite"/>',
+  '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>'
+].join(''));
 
 const buttonGroup = renderer.create('<div class="note-btn-group btn-group">');
 

--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -9,8 +9,8 @@ const editingArea = renderer.create('<div class="note-editing-area"/>');
 const codable = renderer.create('<textarea class="note-codable" role="textbox" aria-multiline="true"/>');
 const editable = renderer.create('<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>');
 const statusbar = renderer.create([
-  '<div class="note-statusbar" role="status">',
-  '  <output class="note-status-output" aria-live="polite"></output>',
+  '<output class="note-status-output" role="status" aria-live="polite"/>',
+  '<div class="note-statusbar" role="resize">',
   '  <div class="note-resizebar" role="seperator" aria-orientation="horizontal" aria-label="resize">',
   '    <div class="note-icon-bar"/>',
   '    <div class="note-icon-bar"/>',
@@ -20,7 +20,10 @@ const statusbar = renderer.create([
 ].join(''));
 
 const airEditor = renderer.create('<div class="note-editor"/>');
-const airEditable = renderer.create('<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>');
+const airEditable = renderer.create([
+  '<output class="note-status-output" role="status" aria-live="polite"/>',
+  '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>'
+].join(''));
 
 const buttonGroup = renderer.create('<div class="note-btn-group">');
 const button = renderer.create('<button type="button" class="note-btn" role="button" tabindex="-1">', function($node, options) {

--- a/src/less/lite-ui/btn-group.less
+++ b/src/less/lite-ui/btn-group.less
@@ -4,22 +4,22 @@
   margin-right: 8px;
 
   > .note-btn-group {
-    margin-right:0px;
+    margin-right: 0;
   }
 
   > .note-btn,
   > .note-btn-group {
     margin-left: -4px;
-    border-radius: 0px;
+    border-radius: 0;
 
     &.focus,
     &.active {
-      border-radius:0px;
+      border-radius:0;
     }
 
 
     &:first-child {
-      margin-left: 0px;
+      margin-left: 0;
       border-top-left-radius: 1px;
       border-bottom-left-radius: 1px;
 
@@ -44,7 +44,7 @@
 
   &.open {
     > .note-dropdown {
-      display:block;
+      display: block;
     }
 
   }

--- a/src/less/lite-ui/buttons.less
+++ b/src/less/lite-ui/buttons.less
@@ -1,11 +1,12 @@
 .note-btn {
-  display:inline-block;
-  font-weight: normal;
-  margin-bottom:0px;
-  text-align:center;
+  display: inline-block;
+  font-weight: 400;
+  margin-bottom: 0;
+  text-align: center;
   vertical-align: middle;
   touch-action: manipulation;
   cursor: pointer;
+  background-color: #fff;
   background-image: none;
   border: 1px solid @btn-default-border;
   white-space: nowrap;
@@ -17,10 +18,10 @@
   &:hover,
   &:focus,
   &.focus {
-    color: @btn-default-color;
+    color: #333;
     text-decoration: none;
-    border: 1px solid @btn-default-border;
-    background-color: @btn-default-hover-bg; 
+    border: 1px solid #fff;
+    background-color: #f4f4f4; 
     outline: 0;
     .rounded(1px);
   }
@@ -45,28 +46,23 @@
 
 .note-btn-primary {
   background: #fa6362;
-  color: white;
+  color: #fff;
 
   &:hover,
   &:focus,
   &.focus {
-    color: white;
+    color: #fff;
     text-decoration: none;
-    border: 1px solid @btn-default-border;
+    border: 1px solid #fff;
     background-color: #fa6362;
     .rounded(1px);
   }
 
 }
 
-.note-btn-large {
-  font-size:16px;
-  padding: 8px 34px;
-}
-
 .note-btn-block {
   display: block;
-  width:100%;
+  width: 100%;
 }
 
 .note-btn-block + .note-btn-block {
@@ -83,10 +79,10 @@ input[type="button"] {
 }
 
 button.close {
-  padding:0px;
-  cursor:pointer;
-  background:transparent;
-  border: 0px;
+  padding: 0;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
   -webkit-appearance: none;
 }
 
@@ -96,4 +92,13 @@ button.close {
   line-height: 1;
   color: #000;
   opacity: .2;
+}
+
+.close:hover {
+  -webkit-opacity: 1;
+   -khtml-opacity: 1;
+     -moz-opacity: 1;
+       -ms-filter: alpha(opacity=100);
+           filter: alpha(opacity=100);
+          opacity: 1
 }

--- a/src/less/lite-ui/buttons.less
+++ b/src/less/lite-ui/buttons.less
@@ -6,7 +6,6 @@
   vertical-align: middle;
   touch-action: manipulation;
   cursor: pointer;
-  background-color: #fff;
   background-image: none;
   border: 1px solid @btn-default-border;
   white-space: nowrap;
@@ -18,10 +17,10 @@
   &:hover,
   &:focus,
   &.focus {
-    color: #333;
+    color: @btn-default-color;
     text-decoration: none;
-    border: 1px solid #fff;
-    background-color: #f4f4f4; 
+    border: 1px solid @btn-default-border;
+    background-color: @btn-default-hover-bg;
     outline: 0;
     .rounded(1px);
   }
@@ -41,7 +40,6 @@
     .box-shadow(none);
   }
 
-
 }
 
 .note-btn-primary {
@@ -53,7 +51,7 @@
   &.focus {
     color: #fff;
     text-decoration: none;
-    border: 1px solid #fff;
+    border: 1px solid @btn-default-border;
     background-color: #fa6362;
     .rounded(1px);
   }

--- a/src/less/lite-ui/common.less
+++ b/src/less/lite-ui/common.less
@@ -1,6 +1,8 @@
-.summernote-ui * {
-  color: black;
-  .box-sizing();
+.note-frame * {
+  -webkit-box-sizing: border-box;
+     -moz-box-sizing: border-box;
+          box-sizing: border-box;
+  color: #000;
 }
 
 p {
@@ -9,10 +11,10 @@ p {
 
 // shortcut text style
 kbd {
-  border-radius:2px;
-  background-color:black;
-  color:white;
-  padding:3px 5px;
-  font-weight:bold;
+  border-radius: 2px;
+  background-color: #000;
+  color: #fff;
+  padding: 3px 5px;
+  font-weight: 700;
   .box-sizing();
 }

--- a/src/less/lite-ui/dropdown.less
+++ b/src/less/lite-ui/dropdown.less
@@ -31,10 +31,8 @@
   }
 }
 
-
-
-
-a.note-dropdown-item {
+a.note-dropdown-item,
+a.note-dropdown-item:hover {
   margin: 2px 0;
   color: #000;
   text-decoration: none;

--- a/src/less/lite-ui/dropdown.less
+++ b/src/less/lite-ui/dropdown.less
@@ -4,11 +4,11 @@
 }
 
 .note-dropdown-menu {
-  display:none;
-  min-width:100px;
+  display: none;
+  min-width: 100px;
   position: absolute;
   top: 100%;
-  left: 0px;
+  left: 0;
   z-index : @zindex-dropdown;
   float: left;
   text-align:left;
@@ -20,14 +20,14 @@
 }
 
 .note-btn-group.open .note-dropdown-menu {
-  display:block;
+  display: block;
 }
 
 .note-dropdown-item {
-  display:block;
+  display: block;
 
   &:hover {
-    background-color:@btn-default-hover-bg;
+    background-color: @btn-default-hover-bg;
   }
 }
 

--- a/src/less/lite-ui/dropdown.less
+++ b/src/less/lite-ui/dropdown.less
@@ -35,6 +35,7 @@
 
 
 a.note-dropdown-item {
-  color:black;
+  margin: 2px 0;
+  color: #000;
   text-decoration: none;
 }

--- a/src/less/lite-ui/form.less
+++ b/src/less/lite-ui/form.less
@@ -3,7 +3,7 @@
 }
 
 .note-form-group:last-child {
-  padding-bottom: 0px;
+  padding-bottom: 0;
 }
 
 .note-form-label {

--- a/src/less/lite-ui/form.less
+++ b/src/less/lite-ui/form.less
@@ -11,14 +11,14 @@
   font-size: 16px;
   color: #42515f;
   margin-bottom: 10px;
-  font-weight:bold;
+  font-weight: 700;
 }
 
 .note-input {
-  width:100%;
+  width: 100%;
   display: block;
   border: 1px solid #ededef;
-  background: white;
+  background: #fff;
   outline: 0;
   padding: 6px 4px; 
   font-size: 14px;

--- a/src/less/lite-ui/modal.less
+++ b/src/less/lite-ui/modal.less
@@ -72,18 +72,18 @@
 }
 
 .note-modal-backdrop {
-  position:absolute;
-  left:0px;
-  right:0px;
-  bottom:0px;
-  top:0px;
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
   z-index: @zindex-modal-background;
   background: @modal-backdrop-bg;
   .opacity(0.5);
-  display:none;
+  display: none;
 
   &.open {
-    display:block;
+    display: block;
   }
 }
 

--- a/src/less/lite-ui/modal.less
+++ b/src/less/lite-ui/modal.less
@@ -1,13 +1,13 @@
 .note-modal {
-  position:absolute;
-  left:0px;
-  right:0px;
-  top:0px;
-  bottom:0px;
-  overflow:hidden;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  overflow: hidden;
   z-index: @zindex-modal;
   .opacity(1);
-  display:none;
+  display: none;
 
   &.open {
     display:block;
@@ -28,37 +28,46 @@
 }
 
 .note-modal-header {
-  padding-top: 30px;
-  padding-bottom:20px;
-  padding-right:20px;
-  padding-left:20px;
+  padding: 30px 20px 20px 20px;
   border: 1px solid #ededef;
 
   .close {
-    margin-top:-10px;
+    margin-top: -10px;
   }
 
 }
 
 .note-modal-body {
-  position:relative;
+  position: relative;
   padding: 20px 30px;
 }
 
 .note-modal-footer {
-  padding-top: 10px;
-  padding-bottom: 10px;
-  padding-right: 10px;
-  padding-left: 10px;
-  text-align:center;
+  height: 40px;
+  padding: 10px;
+  text-align: center;
 
 }
 
+.note-modal-footer a {
+  color: #337ab7;
+  text-decoration: none
+}
+
+.note-modal-footer a:hover,
+.note-modal-footer a:focus {
+  color: #23527c;
+  text-decoration: underline
+}
+
+.note-modal-footer .note-btn {
+  float: right
+}
+
 .note-modal-title {
-  text-align: center;
   font-size: 26px;
   color: #42515f;
-  margin: 0px;
+  margin: 0;
   line-height: 1.4;
 }
 

--- a/src/less/lite-ui/popover.less
+++ b/src/less/lite-ui/popover.less
@@ -6,12 +6,12 @@
   // So reset our font and text properties to avoid inheriting weird values.
   font-size: 13px;
 
-  display:none;
+  display: none;
   background: @popover-bg;
   border: 1px solid @popover-border-color;
   border: 1px solid @popover-fallback-border-color;
 
-  &.in     { display:block; }
+  &.in     { display: block; }
   &.top    { margin-top:  -3px; padding: 5 0; }
   &.right  { margin-left:  3px; padding: 0 5; }
   &.bottom { margin-top:   3px; padding: 5 0; }

--- a/src/less/lite-ui/popover.less
+++ b/src/less/lite-ui/popover.less
@@ -23,7 +23,7 @@
     top: -11px;
     left: 50%;
     margin-left: -@popover-arrow-width;
-    border-top-width: 0 ;
+    border-top-width: 0;
     border-bottom-color: @popover-arrow-outer-fallback-color;
     border-bottom-color: @popover-arrow-outer-color;
 
@@ -93,9 +93,7 @@
   position: absolute;
   width: 0;
   height: 0;
-  border-color: transparent;
-  border-style: solid;
-  border-width: 11px;
+  border: 11px solid transparent;
 
   &::after {
     position: absolute;

--- a/src/less/lite-ui/tooltip.less
+++ b/src/less/lite-ui/tooltip.less
@@ -21,7 +21,7 @@
     left: 50%;
     margin-left: -@tooltip-arrow-width;
     border-width: 0 @tooltip-arrow-width @tooltip-arrow-width;
-    border-bottom-color: @tooltip-arrow-color;
+    border-bottom-color: #000;
   }
 
   &.top .note-tooltip-arrow {
@@ -29,7 +29,7 @@
     left: 50%;
     margin-left: -@tooltip-arrow-width;
     border-width: @tooltip-arrow-width @tooltip-arrow-width 0;
-    border-top-color: @tooltip-arrow-color;
+    border-top-color: #000;
   }
 
   &.right .note-tooltip-arrow {
@@ -37,14 +37,14 @@
     left: 0;
     margin-top: -@tooltip-arrow-width;
     border-width: @tooltip-arrow-width @tooltip-arrow-width @tooltip-arrow-width 0;
-    border-right-color: @tooltip-arrow-color;
+    border-right-color: #000;
   }
   &.left .note-tooltip-arrow {
     top: 50%;
     right: 0;
     margin-top: -@tooltip-arrow-width;
     border-width: @tooltip-arrow-width 0 @tooltip-arrow-width @tooltip-arrow-width;
-    border-left-color: @tooltip-arrow-color;
+    border-left-color: #000;
   }
 }
 
@@ -62,5 +62,5 @@
   padding: 3px 8px;
   color: @tooltip-color;
   text-align: center;
-  background-color: @tooltip-bg;
+  background-color: #000;
 }

--- a/src/less/lite-ui/tooltip.less
+++ b/src/less/lite-ui/tooltip.less
@@ -21,7 +21,7 @@
     left: 50%;
     margin-left: -@tooltip-arrow-width;
     border-width: 0 @tooltip-arrow-width @tooltip-arrow-width;
-    border-bottom-color: #000;
+    border-bottom-color: @tooltip-arrow-color;
   }
 
   &.top .note-tooltip-arrow {
@@ -29,7 +29,7 @@
     left: 50%;
     margin-left: -@tooltip-arrow-width;
     border-width: @tooltip-arrow-width @tooltip-arrow-width 0;
-    border-top-color: #000;
+    border-top-color: @tooltip-arrow-color;
   }
 
   &.right .note-tooltip-arrow {
@@ -37,14 +37,14 @@
     left: 0;
     margin-top: -@tooltip-arrow-width;
     border-width: @tooltip-arrow-width @tooltip-arrow-width @tooltip-arrow-width 0;
-    border-right-color: #000;
+    border-right-color: @tooltip-arrow-color;
   }
   &.left .note-tooltip-arrow {
     top: 50%;
     right: 0;
     margin-top: -@tooltip-arrow-width;
     border-width: @tooltip-arrow-width 0 @tooltip-arrow-width @tooltip-arrow-width;
-    border-left-color: #000;
+    border-left-color: @tooltip-arrow-color;
   }
 }
 
@@ -62,5 +62,5 @@
   padding: 3px 8px;
   color: @tooltip-color;
   text-align: center;
-  background-color: #000;
+  background-color: @tooltip-bg;
 }

--- a/src/less/lite-ui/variables.less
+++ b/src/less/lite-ui/variables.less
@@ -51,7 +51,7 @@
 
 @tooltip-max-width:200px;
 @tooltip-color:    #fff;
-@tooltip-bg:       #47c8f7;
+@tooltip-bg:       #000;
 @tooltip-opacity:  .9;
 @tooltip-arrow-width:         5px;
 @tooltip-arrow-color:         @tooltip-bg;

--- a/src/less/summernote-bs4.less
+++ b/src/less/summernote-bs4.less
@@ -135,6 +135,84 @@
     }
   }
 
+/* Notifications */
+  .note-status-output {
+    display: block;
+    width: 100%;
+    font-size: 14px;
+    line-height: 1.42857143;
+    height: 20px;
+    margin-bottom: 0;
+    color: #000;
+    border: 0;
+    border-top: 1px solid #e2e2e2
+  }
+
+  .note-status-output:empty {
+    height: 0;
+    border-top:0 solid transparent
+  }
+
+  .note-status-output .pull-right {
+    float: right !important
+  }
+
+  .note-status-output .text-muted {
+    color: #777
+  }
+
+  .note-status-output .text-primary {
+    color: #286090
+  }
+
+  .note-status-output .text-success {
+    color: #3c763d
+  }
+
+  .note-status-output .text-info {
+    color: #31708f
+  }
+
+  .note-status-output .text-warning {
+    color: #8a6d3b
+  }
+
+  .note-status-output .text-danger {
+    color:#a94442
+  }
+
+  .note-status-output .alert {
+    margin: -7px 0 0 0;
+    padding: 7px 10px 2px 10px;
+    border-radius: 0;
+    color: #000;
+    background-color: #f5f5f5;
+  }
+
+  .note-status-output .alert .note-icon{
+    margin-right:5px
+  }
+
+  .note-status-output .alert-success {
+    color: #3c763d !important;
+    background-color: #dff0d8 !important;
+  }
+
+  .note-status-output .alert-info {
+    color: #31708f !important;
+    background-color: #d9edf7 !important;
+  }
+
+  .note-status-output .alert-warning {
+    color: #8a6d3b !important;
+    background-color: #fcf8e3 !important;
+  }
+
+  .note-status-output .alert-danger {
+    color: #a94442 !important;
+    background-color: #f2dede !important;
+  }
+
   /* statusbar */
   .note-statusbar {
     background-color: @background-color;

--- a/src/less/summernote-bs4.less
+++ b/src/less/summernote-bs4.less
@@ -22,7 +22,7 @@
     display: none;
     z-index: 100;
     color: @dropzone-color;
-    background-color: white;
+    background-color: #fff;
     opacity: 0.95;
 
     .note-dropzone-message {
@@ -30,7 +30,7 @@
       vertical-align: middle;
       text-align: center;
       font-size: 28px;
-      font-weight: bold;
+      font-weight: 700;
     }
 
     &.hover {
@@ -128,7 +128,7 @@
     width: 100% !important;
     z-index: 1050; /* bs3 modal-backdrop: 1030, bs2: 1040 */
     .note-editable {
-      background-color: white;
+      background-color: #fff;
     }
     .note-resizebar {
       display: none;
@@ -190,7 +190,7 @@
   }
 
   .note-status-output .alert .note-icon{
-    margin-right:5px
+    margin-right: 5px
   }
 
   .note-status-output .alert-success {
@@ -229,40 +229,6 @@
         margin: 1px auto;
         border-top: 1px solid @border-color;
       }
-    }
-    .note-status-output {
-      display: inline;
-      font-size: 12px;
-      height: 25px;
-    }
-    .note-status-output .alert {
-      margin:-7px 0 0 0;
-      padding: 2px 10px;
-      border: 1px solid transparent;
-      border-radius: 0;
-    }
-    .note-status-output .alert .note-icon {
-      margin-right: 5px;
-    }
-    .note-status-output .alert .alert-success {
-      color: #3c763d;
-      background-color: #dff0d8;
-      border-color: #d6e9c6;
-    }
-    .note-status-output .alert .alert-info {
-      color: #31708f;
-      background-color: #d9edf7;
-      border-color: #bce8f1;
-    }
-    .note-status-output .alert .alert-warning {
-      color: #8a6d3b;
-      background-color: #fcf8e3;
-      border-color: #faebcc;
-    }
-    .note-status-output .alert .alert-danger {
-      color: #a94442;
-      background-color: #f2dede;
-      border-color: #ebccd1;
     }
   }
   .note-placeholder {
@@ -561,8 +527,8 @@
       bottom: 0;
       padding: 5px;
       margin: 5px;
-      color: white;
-      background-color: black;
+      color: #fff;
+      background-color: #000;
       font-size: 12px;
       .rounded(5px);
       .opacity(0.7);
@@ -589,7 +555,7 @@
           clear: both;
           font-weight: 400;
           line-height: 1.4;
-          color: white;
+          color: #fff;
           white-space: nowrap;
           text-decoration: none;
           background-color: #428bca;

--- a/src/less/summernote-bs4.scss
+++ b/src/less/summernote-bs4.scss
@@ -134,6 +134,84 @@ $img-margin-right: 10px;
     }
   }
 
+/* Notifications */
+  .note-status-output {
+    display: block;
+    width: 100%;
+    font-size: 14px;
+    line-height: 1.42857143;
+    height: 20px;
+    margin-bottom: 0;
+    color: #000;
+    border: 0;
+    border-top: 1px solid #e2e2e2
+  }
+
+  .note-status-output:empty {
+    height: 0;
+    border-top:0 solid transparent
+  }
+
+  .note-status-output .pull-right {
+    float: right !important
+  }
+
+  .note-status-output .text-muted {
+    color: #777
+  }
+
+  .note-status-output .text-primary {
+    color: #286090
+  }
+
+  .note-status-output .text-success {
+    color: #3c763d
+  }
+
+  .note-status-output .text-info {
+    color: #31708f
+  }
+
+  .note-status-output .text-warning {
+    color: #8a6d3b
+  }
+
+  .note-status-output .text-danger {
+    color:#a94442
+  }
+
+  .note-status-output .alert {
+    margin: -7px 0 0 0;
+    padding: 7px 10px 2px 10px;
+    border-radius: 0;
+    color: #000;
+    background-color: #f5f5f5;
+  }
+
+  .note-status-output .alert .note-icon{
+    margin-right:5px
+  }
+
+  .note-status-output .alert-success {
+    color: #3c763d !important;
+    background-color: #dff0d8 !important;
+  }
+
+  .note-status-output .alert-info {
+    color: #31708f !important;
+    background-color: #d9edf7 !important;
+  }
+
+  .note-status-output .alert-warning {
+    color: #8a6d3b !important;
+    background-color: #fcf8e3 !important;
+  }
+
+  .note-status-output .alert-danger {
+    color: #a94442 !important;
+    background-color: #f2dede !important;
+  }
+
   /* statusbar */
   .note-statusbar {
     background-color: $background-color;

--- a/src/less/summernote-bs4.scss
+++ b/src/less/summernote-bs4.scss
@@ -21,7 +21,7 @@ $img-margin-right: 10px;
     display: none;
     z-index: 100;
     color: $dropzone-color;
-    background-color: white;
+    background-color: #fff;
     opacity: 0.95;
 
     .note-dropzone-message {
@@ -29,7 +29,7 @@ $img-margin-right: 10px;
       vertical-align: middle;
       text-align: center;
       font-size: 28px;
-      font-weight: bold;
+      font-weight: 700;
     }
 
     &.hover {
@@ -127,7 +127,7 @@ $img-margin-right: 10px;
     width: 100% !important;
     z-index: 1050; /* bs3 modal-backdrop: 1030, bs2: 1040 */
     .note-editable {
-      background-color: white;
+      background-color: #fff;
     }
     .note-resizebar {
       display: none;
@@ -149,7 +149,7 @@ $img-margin-right: 10px;
 
   .note-status-output:empty {
     height: 0;
-    border-top:0 solid transparent
+    border-top: 0 solid transparent
   }
 
   .note-status-output .pull-right {
@@ -189,7 +189,7 @@ $img-margin-right: 10px;
   }
 
   .note-status-output .alert .note-icon{
-    margin-right:5px
+    margin-right: 5px
   }
 
   .note-status-output .alert-success {
@@ -228,40 +228,6 @@ $img-margin-right: 10px;
         margin: 1px auto;
         border-top: 1px solid $border-color;
       }
-    }
-    .note-status-output {
-      display: inline;
-      font-size: 12px;
-      height: 25px;
-    }
-    .note-status-output .alert {
-      margin:-7px 0 0 0;
-      padding: 2px 10px;
-      border: 1px solid transparent;
-      border-radius: 0;
-    }
-    .note-status-output .alert .note-icon {
-      margin-right: 5px;
-    }
-    .note-status-output .alert .alert-success {
-      color: #3c763d;
-      background-color: #dff0d8;
-      border-color: #d6e9c6;
-    }
-    .note-status-output .alert .alert-info {
-      color: #31708f;
-      background-color: #d9edf7;
-      border-color: #bce8f1;
-    }
-    .note-status-output .alert .alert-warning {
-      color: #8a6d3b;
-      background-color: #fcf8e3;
-      border-color: #faebcc;
-    }
-    .note-status-output .alert .alert-danger {
-      color: #a94442;
-      background-color: #f2dede;
-      border-color: #ebccd1;
     }
   }
   .note-placeholder {
@@ -487,14 +453,14 @@ $img-margin-right: 10px;
     .note-control-selection-bg {
       width: 100%;
       height: 100%;
-      background-color: black;
+      background-color: #000;
       @include opacity(0.3);
     }
 
     .note-control-handle {
       width: 7px;
       height: 7px;
-      border: 1px solid black;
+      border: 1px solid #000;
     }
 
     .note-control-holder {
@@ -503,7 +469,7 @@ $img-margin-right: 10px;
 
     .note-control-sizing {
       @extend .note-control-handle;
-      background-color: white;
+      background-color: #fff;
     }
 
     .note-control-nw {
@@ -544,8 +510,8 @@ $img-margin-right: 10px;
       bottom: 0;
       padding: 5px;
       margin: 5px;
-      color: white;
-      background-color: black;
+      color: #fff;
+      background-color: #000;
       font-size: 12px;
       @include rounded(5px);
       @include opacity(0.7);

--- a/src/less/summernote-lite.less
+++ b/src/less/summernote-lite.less
@@ -20,7 +20,7 @@
     display: none;
     z-index: 100;
     color: @dropzone-color;
-    background-color: white;
+    background-color: #fff;
     opacity: 0.95;
     pointer-event: none;
 
@@ -29,7 +29,7 @@
       vertical-align: middle;
       text-align: center;
       font-size: 28px;
-      font-weight: bold;
+      font-weight: 700;
     }
 
     &.hover {
@@ -66,6 +66,25 @@
 
       sub {
         vertical-align: sub;
+      }
+      
+      a {
+        background-color: inherit;
+        text-decoration: inherit;
+        font-family: inherit;
+        font-weight: inherit;
+        color: #337ab7;
+      }
+      
+      a:hover,
+      a:focus {
+        color: #23527c;
+        text-decoration: underline;
+        outline: 0;
+      }
+      
+      figure {
+        margin: 0;
       }
     }
   }
@@ -139,6 +158,84 @@
     }
   }
 
+  /* Notification */
+  .note-status-output {
+    display: block;
+    width: 100%;
+    font-size: 14px;
+    line-height: 1.42857143;
+    height: 20px;
+    margin-bottom: 0;
+    color: #000;
+    border: 0;
+    border-top: 1px solid #e2e2e2;
+  }
+  
+  .note-status-output:empty {
+    height: 0;
+    border-top:0 solid transparent
+  }
+
+  .note-status-output .pull-right {
+    float: right !important
+  }
+
+  .note-status-output .text-muted {
+    color: #777
+  }
+
+  .note-status-output .text-primary {
+    color: #286090
+  }
+
+  .note-status-output .text-success {
+    color: #3c763d
+  }
+
+  .note-status-output .text-info {
+    color: #31708f
+  }
+
+  .note-status-output .text-warning {
+    color: #8a6d3b
+  }
+
+  .note-status-output .text-danger {
+    color:#a94442
+  }
+
+  .note-status-output .alert {
+    margin: -7px 0 0 0;
+    padding: 7px 10px 2px 10px;
+    border-radius: 0;
+    color: #000;
+    background-color: #f5f5f5;
+  }
+
+  .note-status-output .alert .note-icon{
+    margin-right:5px
+  }
+
+  .note-status-output .alert-success {
+    color: #3c763d !important;
+    background-color: #dff0d8 !important;
+  }
+
+  .note-status-output .alert-info {
+    color: #31708f !important;
+    background-color: #d9edf7 !important;
+  }
+
+  .note-status-output .alert-warning {
+    color: #8a6d3b !important;
+    background-color: #fcf8e3 !important;
+  }
+
+  .note-status-output .alert-danger {
+    color: #a94442 !important;
+    background-color: #f2dede !important;
+  }
+
   /* statusbar */
   .note-statusbar {
     background-color: @background-color;
@@ -155,39 +252,6 @@
         margin: 1px auto;
         border-top: 1px solid @border-color;
       }
-    }
-    .note-status-output {
-      font-size: 12px;
-      height: 25px;
-    }
-    .note-status-output .alert {
-      margin:-7px 0 0 0;
-      padding: 2px 10px;
-      border: 1px solid transparent;
-      border-radius: 0;
-    }
-    .note-status-output .alert .note-icon {
-      margin-right: 5px;
-    }
-    .note-status-output .alert .alert-success {
-      color: #3c763d;
-      background-color: #dff0d8;
-      border-color: #d6e9c6;
-    }
-    .note-status-output .alert .alert-info {
-      color: #31708f;
-      background-color: #d9edf7;
-      border-color: #bce8f1;
-    }
-    .note-status-output .alert .alert-warning {
-      color: #8a6d3b;
-      background-color: #fcf8e3;
-      border-color: #faebcc;
-    }
-    .note-status-output .alert .alert-danger {
-      color: #a94442;
-      background-color: #f2dede;
-      border-color: #ebccd1;
     }
   }
   .note-placeholder {
@@ -219,7 +283,7 @@
 .note-popover .note-popover-content, .note-toolbar {
   margin: 0;
   padding: 0 0 5px 5px;
-  background-color:white;
+  background-color: #fff;
 
   &>.note-btn-group {
     margin-top: 5px;
@@ -270,6 +334,9 @@
       padding-left: 5px;
     }
     .note-dropdown-menu {
+      -webkit-box-sizing: content-box;
+         -moz-box-sizing: content-box;
+              box-sizing: content-box;
       min-width: 346px;
       .note-palette {
         display: inline-block;
@@ -381,9 +448,9 @@
 
   .note-modal-body {
     label {
-      margin-bottom:2px;
-      padding:2px 5px;
-      display:inline-block;
+      margin-bottom: 2px;
+      padding: 2px 5px;
+      display: inline-block;
     }
 
     .help-list-item:hover {

--- a/src/less/summernote-lite.less
+++ b/src/less/summernote-lite.less
@@ -151,7 +151,7 @@
     width: 100% !important;
     z-index: 1050; /* bs3 modal-backdrop: 1030, bs2: 1040 */
     .note-editable {
-      background-color: white;
+      background-color: #fff;
     }
     .note-resizebar {
       display: none;
@@ -360,8 +360,8 @@
           width: 100%;
           cursor: pointer;
           .rounded(5px);
-          background-color: white; 
-          border:0px;
+          background-color: #fff; 
+          border:0;
         }
 
         .note-color-row {
@@ -415,7 +415,7 @@
     }
 
     .note-dropdown-item > * {
-      margin:0px;
+      margin: 0;
     }
 
   }
@@ -454,7 +454,7 @@
     }
 
     .help-list-item:hover {
-      background-color:#e0e0e0;
+      background-color: #e0e0e0;
     }
   }
 
@@ -487,14 +487,14 @@
     .note-control-selection-bg {
       width: 100%;
       height: 100%;
-      background-color: black;
+      background-color: #000;
       .opacity(0.30)
     }
 
     .note-control-handle {
       width: 7px;
       height: 7px;
-      border: 1px solid black;
+      border: 1px solid #000;
     }
 
     .note-control-holder {
@@ -503,7 +503,7 @@
 
     .note-control-sizing {
       .note-control-handle;
-      background-color: white;
+      background-color: #fff;
     }
 
     .note-control-nw {
@@ -544,8 +544,8 @@
       bottom: 0;
       padding: 5px;
       margin: 5px;
-      color: white;
-      background-color: black;
+      color: #fff;
+      background-color: #000;
       font-size: 12px;
       .rounded(5px);
       .opacity(0.7);
@@ -572,7 +572,7 @@
           clear: both;
           font-weight: 400;
           line-height: 1.4;
-          color: white;
+          color: #fff;
           white-space: nowrap;
           text-decoration: none;
           background-color: #428bca;

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -22,7 +22,7 @@
     display: none;
     z-index: 100;
     color: @dropzone-color;
-    background-color: white;
+    background-color: #fff;
     opacity: 0.95;
 
     .note-dropzone-message {
@@ -30,7 +30,7 @@
       vertical-align: middle;
       text-align: center;
       font-size: 28px;
-      font-weight: bold;
+      font-weight: 700;
     }
 
     &.hover {
@@ -128,7 +128,7 @@
     width: 100% !important;
     z-index: 1050; /* bs3 modal-backdrop: 1030, bs2: 1040 */
     .note-editable {
-      background-color: white;
+      background-color: #fff;
     }
     .note-resizebar {
       display: none;
@@ -463,20 +463,20 @@
   .note-control-selection {
     position: absolute;
     display: none;
-    border: 1px solid black;
+    border: 1px solid #000;
     &>div { position: absolute; }
 
     .note-control-selection-bg {
       width: 100%;
       height: 100%;
-      background-color: black;
+      background-color: #000;
       .opacity(0.30)
     }
 
     .note-control-handle {
       width: 7px;
       height: 7px;
-      border: 1px solid black;
+      border: 1px solid #000;
     }
 
     .note-control-holder {
@@ -485,7 +485,7 @@
 
     .note-control-sizing {
       .note-control-handle;
-      background-color: white;
+      background-color: #fff;
     }
 
     .note-control-nw {
@@ -526,8 +526,8 @@
       bottom: 0;
       padding: 5px;
       margin: 5px;
-      color: white;
-      background-color: black;
+      color: #fff;
+      background-color: #000;
       font-size: 12px;
       .rounded(5px);
       .opacity(0.7);
@@ -554,7 +554,7 @@
           clear: both;
           font-weight: 400;
           line-height: 1.4;
-          color: white;
+          color: #fff;
           white-space: nowrap;
           text-decoration: none;
           background-color: #428bca;

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -135,6 +135,84 @@
     }
   }
 
+/* Notifications */
+  .note-status-output {
+    display: block;
+    width: 100%;
+    font-size: 14px;
+    line-height: 1.42857143;
+    height: 20px;
+    margin-bottom: 0;
+    color: #000;
+    border: 0;
+    border-top: 1px solid #e2e2e2
+  }
+
+  .note-status-output:empty {
+    height: 0;
+    border-top:0 solid transparent
+  }
+
+  .note-status-output .pull-right {
+    float: right !important
+  }
+
+  .note-status-output .text-muted {
+    color: #777
+  }
+
+  .note-status-output .text-primary {
+    color: #286090
+  }
+
+  .note-status-output .text-success {
+    color: #3c763d
+  }
+
+  .note-status-output .text-info {
+    color: #31708f
+  }
+
+  .note-status-output .text-warning {
+    color: #8a6d3b
+  }
+
+  .note-status-output .text-danger {
+    color:#a94442
+  }
+
+  .note-status-output .alert {
+    margin: -7px 0 0 0;
+    padding: 7px 10px 2px 10px;
+    border-radius: 0;
+    color: #000;
+    background-color: #f5f5f5;
+  }
+
+  .note-status-output .alert .note-icon{
+    margin-right:5px
+  }
+
+  .note-status-output .alert-success {
+    color: #3c763d !important;
+    background-color: #dff0d8 !important;
+  }
+
+  .note-status-output .alert-info {
+    color: #31708f !important;
+    background-color: #d9edf7 !important;
+  }
+
+  .note-status-output .alert-warning {
+    color: #8a6d3b !important;
+    background-color: #fcf8e3 !important;
+  }
+
+  .note-status-output .alert-danger {
+    color: #a94442 !important;
+    background-color: #f2dede !important;
+  }
+
   /* statusbar */
   .note-statusbar {
     background-color: @background-color;
@@ -151,40 +229,6 @@
         margin: 1px auto;
         border-top: 1px solid @border-color;
       }
-    }
-    .note-status-output {
-      display: inline;
-      font-size: 12px;
-      height: 25px;
-    }
-    .note-status-output .alert {
-      margin:-7px 0 0 0;
-      padding: 2px 10px;
-      border: 1px solid transparent;
-      border-radius: 0;
-    }
-    .note-status-output .alert .note-icon {
-      margin-right: 5px;
-    }
-    .note-status-output .alert .alert-success {
-      color: #3c763d;
-      background-color: #dff0d8;
-      border-color: #d6e9c6;
-    }
-    .note-status-output .alert .alert-info {
-      color: #31708f;
-      background-color: #d9edf7;
-      border-color: #bce8f1;
-    }
-    .note-status-output .alert .alert-warning {
-      color: #8a6d3b;
-      background-color: #fcf8e3;
-      border-color: #faebcc;
-    }
-    .note-status-output .alert .alert-danger {
-      color: #a94442;
-      background-color: #f2dede;
-      border-color: #ebccd1;
     }
   }
   .note-placeholder {

--- a/src/less/summernote.scss
+++ b/src/less/summernote.scss
@@ -134,6 +134,84 @@ $img-margin-right: 10px;
     }
   }
 
+/* Notifications */
+  .note-status-output {
+    display: block;
+    width: 100%;
+    font-size: 14px;
+    line-height: 1.42857143;
+    height: 20px;
+    margin-bottom: 0;
+    color: #000;
+    border: 0;
+    border-top: 1px solid #e2e2e2
+  }
+
+  .note-status-output:empty {
+    height: 0;
+    border-top:0 solid transparent
+  }
+
+  .note-status-output .pull-right {
+    float: right !important
+  }
+
+  .note-status-output .text-muted {
+    color: #777
+  }
+
+  .note-status-output .text-primary {
+    color: #286090
+  }
+
+  .note-status-output .text-success {
+    color: #3c763d
+  }
+
+  .note-status-output .text-info {
+    color: #31708f
+  }
+
+  .note-status-output .text-warning {
+    color: #8a6d3b
+  }
+
+  .note-status-output .text-danger {
+    color:#a94442
+  }
+
+  .note-status-output .alert {
+    margin: -7px 0 0 0;
+    padding: 7px 10px 2px 10px;
+    border-radius: 0;
+    color: #000;
+    background-color: #f5f5f5;
+  }
+
+  .note-status-output .alert .note-icon{
+    margin-right:5px
+  }
+
+  .note-status-output .alert-success {
+    color: #3c763d !important;
+    background-color: #dff0d8 !important;
+  }
+
+  .note-status-output .alert-info {
+    color: #31708f !important;
+    background-color: #d9edf7 !important;
+  }
+
+  .note-status-output .alert-warning {
+    color: #8a6d3b !important;
+    background-color: #fcf8e3 !important;
+  }
+
+  .note-status-output .alert-danger {
+    color: #a94442 !important;
+    background-color: #f2dede !important;
+  }
+
   /* statusbar */
   .note-statusbar {
     background-color: $background-color;

--- a/src/less/summernote.scss
+++ b/src/less/summernote.scss
@@ -21,7 +21,7 @@ $img-margin-right: 10px;
     display: none;
     z-index: 100;
     color: $dropzone-color;
-    background-color: white;
+    background-color: #fff;
     opacity: 0.95;
 
     .note-dropzone-message {
@@ -29,7 +29,7 @@ $img-margin-right: 10px;
       vertical-align: middle;
       text-align: center;
       font-size: 28px;
-      font-weight: bold;
+      font-weight: 700;
     }
 
     &.hover {
@@ -127,7 +127,7 @@ $img-margin-right: 10px;
     width: 100% !important;
     z-index: 1050; /* bs3 modal-backdrop: 1030, bs2: 1040 */
     .note-editable {
-      background-color: white;
+      background-color: #fff;
     }
     .note-resizebar {
       display: none;
@@ -228,39 +228,6 @@ $img-margin-right: 10px;
         margin: 1px auto;
         border-top: 1px solid $border-color;
       }
-    }
-    .note-status-output {
-      font-size: 12px;
-      height: 25px;
-    }
-    .note-status-output .alert {
-      margin:-7px 0 0 0;
-      padding: 2px 10px;
-      border: 1px solid transparent;
-      border-radius: 0;
-    }
-    .note-status-output .alert .note-icon {
-      margin-right: 5px;
-    }
-    .note-status-output .alert .alert-success {
-      color: #3c763d;
-      background-color: #dff0d8;
-      border-color: #d6e9c6;
-    }
-    .note-status-output .alert .alert-info {
-      color: #31708f;
-      background-color: #d9edf7;
-      border-color: #bce8f1;
-    }
-    .note-status-output .alert .alert-warning {
-      color: #8a6d3b;
-      background-color: #fcf8e3;
-      border-color: #faebcc;
-    }
-    .note-status-output .alert .alert-danger {
-      color: #a94442;
-      background-color: #f2dede;
-      border-color: #ebccd1;
     }
   }
   .note-placeholder {
@@ -480,20 +447,20 @@ $img-margin-right: 10px;
   .note-control-selection {
     position: absolute;
     display: none;
-    border: 1px solid black;
+    border: 1px solid #000;
     &>div { position: absolute; }
 
     .note-control-selection-bg {
       width: 100%;
       height: 100%;
-      background-color: black;
+      background-color: #000;
       @include opacity(0.3);
     }
 
     .note-control-handle {
       width: 7px;
       height: 7px;
-      border: 1px solid black;
+      border: 1px solid #000;
     }
 
     .note-control-holder {
@@ -502,7 +469,7 @@ $img-margin-right: 10px;
 
     .note-control-sizing {
       @extend .note-control-handle;
-      background-color: white;
+      background-color: #000;
     }
 
     .note-control-nw {
@@ -543,8 +510,8 @@ $img-margin-right: 10px;
       bottom: 0;
       padding: 5px;
       margin: 5px;
-      color: white;
-      background-color: black;
+      color: #fff;
+      background-color: #000;
       font-size: 12px;
       @include rounded(5px);
       @include opacity(0.7);


### PR DESCRIPTION
Update summernote css to reflect Notification area styles and fix notification area markup.

#### What does this PR do?

- Fixes styling for summernote-lite and addon styling in for all versions for Notification area (fixed from the previous PR).
- Fix markup area's for Notification Output for Normal mode and AirMode. Normal area is above status/resize area, AirMode is above editing area. Both only display if content is present inside the output, otherwise their height is 0.
- refactor style markup mainly in the summernote-lite stylesheet, some classes were not being used.

Using the Notification area is easy. Any content inserted into the `<output/>` element will make the element's height grow to suite.
Target the area using its className of `note-status-output` for e.g.

`$('.note-status-output').html('<div class="alert alert-danger"><i class="note-icon note-icon-summernote"></i>This is an error using a Bootstrap alert that has been restyled to fit here.</div>');`

Different levels of status can be used just like using Bootstrap's Alerts for `alert-primary` `alert-danger` `alert-warning` `alert-info` `alert-success`, as well as using icons, as in the example above.

There is also a `float-right` class for displaying content to the right if needed, and classes for `text-primary` `text-danger` `text-warning` `text-info` `text-succes`.

These also work in the bs3, and bs4 versions of Summernote, though the colours are based on the Bootstrap 3 colours.
  