### PR TITLE
Implemented commit command (resets history but keeps editor content).

### DIFF
--- a/src/js/base/editing/History.js
+++ b/src/js/base/editing/History.js
@@ -46,6 +46,21 @@ export default class History {
   }
 
   /**
+  *  @method commit
+  *  Resets history stack, but keeps current editor's content.
+  */
+  commit() {
+    // Clear the stack.
+    this.stack = [];
+
+    // Restore stackOffset to its original value.
+    this.stackOffset = -1;
+
+    // Record our first snapshot (of nothing).
+    this.recordUndo();
+  }
+
+  /**
   * @method reset
   * Resets the history stack completely; reverting to an empty editor.
   */

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -509,6 +509,15 @@ export default class Editor {
     this.context.triggerEvent('change', this.$editable.html());
   }
 
+  /*
+  * commit
+  */
+  commit() {
+    this.context.triggerEvent('before.command', this.$editable.html());
+    this.history.commit();
+    this.context.triggerEvent('change', this.$editable.html());
+  }
+
   /**
    * redo
    */


### PR DESCRIPTION
Use case:
When editing content, we initialize summernote, then assign current content to editor using 'code' command. Immediately after that we need to make current content 'initial', as in "reset undo history but keep content" to prevent undoing editor into blank state.