### PR TITLE
fixed selection on redo unlink command

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -532,6 +532,7 @@ export default class Editor {
    * @param {Boolean} isPreventTrigger
    */
   afterCommand(isPreventTrigger) {
+    this.normalizeContent();
     this.history.recordUndo();
     if (!isPreventTrigger) {
       this.context.triggerEvent('change', this.$editable.html());
@@ -849,5 +850,12 @@ export default class Editor {
    */
   empty() {
     this.context.invoke('code', dom.emptyPara);
+  }
+
+  /**
+   * normalize content
+   */
+  normalizeContent() {
+    this.$editable[0].normalize();
   }
 }


### PR DESCRIPTION
#### What does this PR do?

Adds content normalizer, which just join adjacent text nodes. This is necessary because snapshot relies on node's positions(path property in bookmark). But those positions aren't correctly saving in content of snapshot. 
Suppose content has div with 2 textnodes:
`<div>"textnode1" "textnode2"</div>` 
in snapshot it looks like this:
`{
      contents: '<div>textnode1textnode2</div>',
      bookmark: ...
}`
Thus selection won't restore correctly when that snapshot is applying.

This issue is actual for all commands wich split text nodes or unwrap some of them

#### Where should the reviewer start?

method afterCommand in Editor module

#### Steps to reproduce
1.Create link
![1](https://user-images.githubusercontent.com/9252130/34992782-f0a2f17e-fad6-11e7-81e5-e195d7c5e733.jpg)
2. Unlink created link(unlnik command)
3. Press ctrl+z (undo unlink)
4. Press ctrl+y (redo unlink). Expected selection on place where lnk was. Actual result on screenshot
![2](https://user-images.githubusercontent.com/9252130/34992791-f76635d4-fad6-11e7-982d-71a92153428a.jpg)

