### PR TITLE
Use localized tooltip on buttons like style.h1

### DIFF
--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -110,7 +110,7 @@ export default class Buttons {
         return this.button({
           className: 'note-btn-style-' + item,
           contents: '<div data-value="' + item + '">' + item.toUpperCase() + '</div>',
-          tooltip: item.toUpperCase(),
+          tooltip: this.lang.style[item],
           click: this.context.createInvokeHandler('editor.formatBlock')
         }).render();
       });


### PR DESCRIPTION
#### What does this PR do?

- Fix tooltips on style buttons defined with `style.h1` and the likes

#### Where should the reviewer start?

- start on the the only file `Buttons.js`

#### How should this be manually tested?

Add `toolbar: [['style', ['style.h1']]]` to the settings.

#### Screenshot (if for frontend)

**Before**

![image](https://user-images.githubusercontent.com/1153134/35183639-74398520-fe24-11e7-8aaa-3a44aa1d410d.png)

**After**

![image](https://user-images.githubusercontent.com/1153134/35183618-56445158-fe24-11e7-9ece-033c7766b3aa.png)

cc @lqez