### PR TITLE
Add Video Popover

### DIFF
--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -108,8 +108,8 @@ function isInline(node) {
          !isHr(node) &&
          !isPara(node) &&
          !isTable(node) &&
-         !isBlockquote(node) &&
          !isVideo(node) &&
+         !isBlockquote(node) &&
          !isData(node);
 }
 
@@ -1006,7 +1006,7 @@ function isCustomStyleTag(node) {
  * @param {Node} an HTML DOM node
  */
 function isVideo(node) {
-  return node && $(node).hasClass('note-video-clip-wrapper');
+  return node && $(node).hasClass('note-video-clip');
 };
 
 export default {

--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -109,6 +109,7 @@ function isInline(node) {
          !isPara(node) &&
          !isTable(node) &&
          !isBlockquote(node) &&
+         !isVideo(node) &&
          !isData(node);
 }
 

--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -998,13 +998,13 @@ function isCustomStyleTag(node) {
 
 /**
  * @method isVideo
- * 
+ *
  * assert if a node contains a "note-styletag" class,
  * which implies that's a custom-made style tag node
  *
  * @param {Node} an HTML DOM node
  */
-var isVideo = function (node) {
+function isVideo(node) {
   return node && $(node).hasClass('note-video-clip-wrapper');
 };
 

--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -996,6 +996,18 @@ function isCustomStyleTag(node) {
   return node && !isText(node) && lists.contains(node.classList, 'note-styletag');
 }
 
+/**
+ * @method isVideo
+ * 
+ * assert if a node contains a "note-styletag" class,
+ * which implies that's a custom-made style tag node
+ *
+ * @param {Node} an HTML DOM node
+ */
+var isVideo = function (node) {
+  return node && $(node).hasClass('note-video-clip-wrapper');
+};
+
 export default {
   /** @property {String} NBSP_CHAR */
   NBSP_CHAR,
@@ -1036,6 +1048,7 @@ export default {
   isS: makePredByNodeName('S'),
   isI: makePredByNodeName('I'),
   isImg: makePredByNodeName('IMG'),
+  isVideo,
   isTextarea,
   isEmpty,
   isEmptyAnchor: func.and(isAnchor, isEmpty),

--- a/src/js/base/module/Handle.js
+++ b/src/js/base/module/Handle.js
@@ -92,9 +92,13 @@ export default class Handle {
     }
 
     const isImage = dom.isImg(target);
+    const isVideo = dom.isVideo(target);
+    
     const $selection = this.$handle.find('.note-control-selection');
 
     this.context.invoke('imagePopover.update', target);
+    this.context.invoke('videoPopover.update', target);
+
 
     if (isImage) {
       const $image = $(target);
@@ -127,8 +131,37 @@ export default class Handle {
     } else {
       this.hide();
     }
+    
+    if (isVideo) {
+      const $video = $(target);
+      const position = $video.position();
+      const pos = {
+        left: position.left + parseInt($video.css('marginLeft'), 10),
+        top: position.top + parseInt($video.css('marginTop'), 10)
+      };
 
-    return isImage;
+      // exclude margin
+      const videoSize = {
+        w: $video.outerWidth(false),
+        h: $video.outerHeight(false)
+      };
+
+      $selection.css({
+        display: 'block',
+        left: pos.left,
+        top: pos.top,
+        width: videoSize.w,
+        height: videoSize.h
+      }).data('target', $video); // save current image element.
+      
+      const sizingText = videoSize.w + 'x' + videoSize.h;
+      $selection.find('.note-control-selection-info').text(sizingText);
+      this.context.invoke('editor.saveTarget', target);
+    } else {
+      this.hide();
+    }
+
+    return isImage ? isImage : isVideo;
   }
 
   /**

--- a/src/js/base/module/Handle.js
+++ b/src/js/base/module/Handle.js
@@ -93,12 +93,11 @@ export default class Handle {
 
     const isImage = dom.isImg(target);
     const isVideo = dom.isVideo(target);
-    
+
     const $selection = this.$handle.find('.note-control-selection');
 
     this.context.invoke('imagePopover.update', target);
     this.context.invoke('videoPopover.update', target);
-
 
     if (isImage) {
       const $image = $(target);
@@ -131,7 +130,7 @@ export default class Handle {
     } else {
       this.hide();
     }
-    
+
     if (isVideo) {
       const $video = $(target);
       const position = $video.position();
@@ -152,8 +151,8 @@ export default class Handle {
         top: pos.top,
         width: videoSize.w,
         height: videoSize.h
-      }).data('target', $video); // save current image element.
-      
+      }).data('target', $video); // save current video element.
+
       const sizingText = videoSize.w + 'x' + videoSize.h;
       $selection.find('.note-control-selection-info').text(sizingText);
       this.context.invoke('editor.saveTarget', target);
@@ -161,7 +160,8 @@ export default class Handle {
       this.hide();
     }
 
-    return isImage ? isImage : isVideo;
+    if (isImage) return isImage;
+    if (isVideo) return isVideo;
   }
 
   /**

--- a/src/js/base/module/Handle.js
+++ b/src/js/base/module/Handle.js
@@ -161,7 +161,6 @@ export default class Handle {
     } else {
       this.hide();
     }
-
   }
 
   /**

--- a/src/js/base/module/Handle.js
+++ b/src/js/base/module/Handle.js
@@ -127,6 +127,7 @@ export default class Handle {
       const sizingText = imageSize.w + 'x' + imageSize.h + ' (' + this.lang.image.original + ': ' + origImageObj.width + 'x' + origImageObj.height + ')';
       $selection.find('.note-control-selection-info').text(sizingText);
       this.context.invoke('editor.saveTarget', target);
+      return isImage;
     } else {
       this.hide();
     }
@@ -156,12 +157,11 @@ export default class Handle {
       const sizingText = videoSize.w + 'x' + videoSize.h;
       $selection.find('.note-control-selection-info').text(sizingText);
       this.context.invoke('editor.saveTarget', target);
+      return isVideo;
     } else {
       this.hide();
     }
 
-    if (isImage) return isImage;
-    if (isVideo) return isVideo;
   }
 
   /**

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -124,7 +124,7 @@ export default class VideoDialog {
         .attr('frameborder', 0)
         .attr('height', '310')
         .attr('width', '500')
-        .attr('src', 'http://v.qq.com/iframe/player.html?vid=' + vid + '&amp;auto=0');
+        .attr('src', '//v.qq.com/iframe/player.html?vid=' + vid + '&auto=0');
     } else if (mp4Match || oggMatch || webmMatch) {
       $video = $('<video controls>')
         .attr('src', url)

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -67,6 +67,12 @@ export default class VideoDialog {
     const youkuRegExp = /\/\/v\.youku\.com\/v_show\/id_(\w+)=*\.html/;
     const youkuMatch = url.match(youkuRegExp);
 
+    const qqRegExp = /\/\/v\.qq\.com.*?vid=(.+)/;
+    const qqMatch = url.match(qqRegExp);
+
+    const qqRegExp2 = /\/\/v\.qq\.com\/x?\/?(page|cover).*?\/([^\/]+)\.html\??.*/;
+    const qqMatch2 = url.match(qqRegExp2);
+
     const mp4RegExp = /^.+.(mp4|m4v)$/;
     const mp4Match = url.match(mp4RegExp);
 
@@ -112,6 +118,13 @@ export default class VideoDialog {
         .attr('height', '498')
         .attr('width', '510')
         .attr('src', '//player.youku.com/embed/' + youkuMatch[1]);
+    } else if ((qqMatch && qqMatch[1].length) || (qqMatch2 && qqMatch2[2].length)) {
+      const vid = ((qqMatch && qqMatch[1].length) ? qqMatch[1] : qqMatch2[2]);
+      $video = $('<iframe webkitallowfullscreen mozallowfullscreen allowfullscreen>')
+        .attr('frameborder', 0)
+        .attr('height', '310')
+        .attr('width', '500')
+        .attr('src', '//v.qq.com/iframe/player.html?vid=' + vid + '&auto=0');
     } else if (mp4Match || oggMatch || webmMatch) {
       $video = $('<video controls>')
         .attr('src', url)
@@ -122,9 +135,9 @@ export default class VideoDialog {
     }
 
     $video.addClass('note-video-clip');
-    const $wrapper = $('<div class="note-video-clip-wrapper"></div>').append($video);
+    $video = $('<div class="note-video-clip-wrapper"></div>').append($video);
 
-    return $wrapper[0];
+    return $video[0];
   }
 
   show() {

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -118,13 +118,6 @@ export default class VideoDialog {
         .attr('height', '498')
         .attr('width', '510')
         .attr('src', '//player.youku.com/embed/' + youkuMatch[1]);
-    } else if ((qqMatch && qqMatch[1].length) || (qqMatch2 && qqMatch2[2].length)) {
-      const vid = ((qqMatch && qqMatch[1].length) ? qqMatch[1] : qqMatch2[2]);
-      $video = $('<iframe webkitallowfullscreen mozallowfullscreen allowfullscreen>')
-        .attr('frameborder', 0)
-        .attr('height', '310')
-        .attr('width', '500')
-        .attr('src', '//v.qq.com/iframe/player.html?vid=' + vid + '&auto=0');
     } else if (mp4Match || oggMatch || webmMatch) {
       $video = $('<video controls>')
         .attr('src', url)
@@ -135,9 +128,9 @@ export default class VideoDialog {
     }
 
     $video.addClass('note-video-clip');
-    const $wrapper = $('<div class="note-video-clip-wrapper"></div>').append($video[0]);
+    const $wrapper = $('<div class="note-video-clip-wrapper"></div>').append($video);
 
-    return $wrapper;
+    return $wrapper[0];
   }
 
   show() {

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -18,8 +18,9 @@ export default class VideoDialog {
 
     const body = [
       '<div class="form-group note-form-group row-fluid">',
-      `<label class="note-form-label">${this.lang.video.url} <small class="text-muted">${this.lang.video.providers}</small></label>`,
+      `<label class="note-form-label">${this.lang.video.url} </label>`,
       '<input class="note-video-url form-control note-form-control note-input" type="text" />',
+      `<small class="help-block text-muted">${this.lang.video.providers}</small>`,
       '</div>'
     ].join('');
     const buttonClass = 'btn btn-primary note-btn note-btn-primary note-video-btn';
@@ -88,11 +89,14 @@ export default class VideoDialog {
       $video = $('<iframe>')
         .attr('frameborder', 0)
         .attr('src', '//www.youtube.com/embed/' + youtubeId)
-        .attr('width', '640').attr('height', '360');
+        .attr('data-target', '//www.youtube.com/embed/' + youtubeId)
+        .attr('width', '640')
+        .attr('height', '360');
     } else if (igMatch && igMatch[0].length) {
       $video = $('<iframe>')
         .attr('frameborder', 0)
         .attr('src', 'https://instagram.com/p/' + igMatch[1] + '/embed/')
+        .attr('data-target', 'https://instagram.com/p/' + igMatch[1] + '/embed/')
         .attr('width', '612').attr('height', '710')
         .attr('scrolling', 'no')
         .attr('allowtransparency', 'true');
@@ -100,48 +104,55 @@ export default class VideoDialog {
       $video = $('<iframe>')
         .attr('frameborder', 0)
         .attr('src', vMatch[0] + '/embed/simple')
+        .attr('data-target', vMatch[0] + '/embed/simple')
         .attr('width', '600').attr('height', '600')
         .attr('class', 'vine-embed');
     } else if (vimMatch && vimMatch[3].length) {
       $video = $('<iframe webkitallowfullscreen mozallowfullscreen allowfullscreen>')
         .attr('frameborder', 0)
         .attr('src', '//player.vimeo.com/video/' + vimMatch[3])
+        .attr('data-target', '//player.vimeo.com/video/' + vimMatch[3])
         .attr('width', '640').attr('height', '360');
     } else if (dmMatch && dmMatch[2].length) {
       $video = $('<iframe>')
         .attr('frameborder', 0)
         .attr('src', '//www.dailymotion.com/embed/video/' + dmMatch[2])
+        .attr('data-target', '//www.dailymotion.com/embed/video/' + dmMatch[2])
         .attr('width', '640').attr('height', '360');
     } else if (youkuMatch && youkuMatch[1].length) {
       $video = $('<iframe webkitallowfullscreen mozallowfullscreen allowfullscreen>')
         .attr('frameborder', 0)
         .attr('height', '498')
         .attr('width', '510')
-        .attr('src', '//player.youku.com/embed/' + youkuMatch[1]);
+        .attr('src', '//player.youku.com/embed/' + youkuMatch[1])
+        .attr('data-target', '//player.youku.com/embed/' + youkuMatch[1]);
     } else if ((qqMatch && qqMatch[1].length) || (qqMatch2 && qqMatch2[2].length)) {
       const vid = ((qqMatch && qqMatch[1].length) ? qqMatch[1] : qqMatch2[2]);
       $video = $('<iframe webkitallowfullscreen mozallowfullscreen allowfullscreen>')
         .attr('frameborder', 0)
         .attr('height', '310')
         .attr('width', '500')
-        .attr('src', '//v.qq.com/iframe/player.html?vid=' + vid + '&auto=0');
+        .attr('src', 'http://v.qq.com/iframe/player.html?vid=' + vid + '&amp;auto=0')
+        .attr('data-target', 'http://v.qq.com/iframe/player.html?vid=' + vid + '&amp;auto=0');
     } else if (mp4Match || oggMatch || webmMatch) {
       $video = $('<video controls>')
         .attr('src', url)
+        .attr('data-target', url)
         .attr('width', '640').attr('height', '360');
     } else {
       // this is not a known video link. Now what, Cat? Now what?
       return false;
     }
 
-    const $wrapper = $('<div class="note-video-clip-wrapper"></div>').append($video);
-
-    return $wrapper[0];
+    $video.addClass('note-video-clip');
+    
+    return $video[0];
   }
 
   show() {
     const text = this.context.invoke('editor.getSelectedText');
     this.context.invoke('editor.saveRange');
+
     this.showVideoDialog(text).then((url) => {
       // [workaround] hide dialog before restore range for IE range focus
       this.ui.hideDialog(this.$dialog);

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -145,7 +145,7 @@ export default class VideoDialog {
     }
 
     $video.addClass('note-video-clip');
-    
+
     return $video[0];
   }
 

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -67,12 +67,6 @@ export default class VideoDialog {
     const youkuRegExp = /\/\/v\.youku\.com\/v_show\/id_(\w+)=*\.html/;
     const youkuMatch = url.match(youkuRegExp);
 
-    const qqRegExp = /\/\/v\.qq\.com.*?vid=(.+)/;
-    const qqMatch = url.match(qqRegExp);
-
-    const qqRegExp2 = /\/\/v\.qq\.com\/x?\/?(page|cover).*?\/([^\/]+)\.html\??.*/;
-    const qqMatch2 = url.match(qqRegExp2);
-
     const mp4RegExp = /^.+.(mp4|m4v)$/;
     const mp4Match = url.match(mp4RegExp);
 

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -137,7 +137,7 @@ export default class VideoDialog {
     $video.addClass('note-video-clip');
     const $wrapper = $('<div class="note-video-clip-wrapper"></div>').append($video);
 
-    return $wrapper[0];
+    return $wrapper;
   }
 
   show() {

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -135,7 +135,7 @@ export default class VideoDialog {
     }
 
     $video.addClass('note-video-clip');
-    const $wrapper = $('<div class="note-video-clip-wrapper"></div>').append($video);
+    const $wrapper = $('<div class="note-video-clip-wrapper"></div>').append($video[0]);
 
     return $wrapper;
   }

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -135,7 +135,6 @@ export default class VideoDialog {
     }
 
     $video.addClass('note-video-clip');
-    $video.attr('frameborder', 0);
     const $wrapper = $('<div class="note-video-clip-wrapper"></div>').append($video);
 
     return $wrapper[0];

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -139,7 +139,6 @@ export default class VideoDialog {
     const $wrapper = $('<div class="note-video-clip-wrapper"></div>').append($video);
 
     return $wrapper[0];
-  
   }
 
   show() {

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -135,8 +135,11 @@ export default class VideoDialog {
     }
 
     $video.addClass('note-video-clip');
+    $video.attr('frameborder', 0);
+    const $wrapper = $('<div class="note-video-clip-wrapper"></div>').append($video);
 
-    return $video[0];
+    return $wrapper[0];
+  
   }
 
   show() {

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -162,7 +162,7 @@ export default class VideoDialog {
   }
 
   /**
-   * show image dialog
+   * show video dialog
    *
    * @param {jQuery} $dialog
    * @return {Promise}

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -134,10 +134,9 @@ export default class VideoDialog {
       return false;
     }
 
-    $video.addClass('note-video-clip');
-    $video = $('<div class="note-video-clip-wrapper"></div>').append($video);
+    const $wrapper = $('<div class="note-video-clip-wrapper"></div>').append($video);
 
-    return $video[0];
+    return $wrapper[0];
   }
 
   show() {

--- a/src/js/base/module/VideoPopover.js
+++ b/src/js/base/module/VideoPopover.js
@@ -1,0 +1,59 @@
+import $ from 'jquery';
+import lists from '../core/lists';
+import dom from '../core/dom';
+
+/**
+ * Video popover module
+ *  mouse events that show/hide popover will be handled by Handle.js.
+ *  Handle.js will receive the events and invoke 'videoPopover.update'.
+ */
+export default class VideoPopover {
+  constructor(context) {
+    this.context = context;
+    this.ui = $.summernote.ui;
+
+    this.editable = context.layoutInfo.editable[0];
+    this.options = context.options;
+
+    this.events = {
+      'summernote.disable': () => {
+        this.hide();
+      }
+    };
+  }
+
+  shouldInitialize() {
+    return !lists.isEmpty(this.options.popover.video);
+  }
+
+  initialize() {
+    this.$popover = this.ui.popover({
+      className: 'note-video-popover'
+    }).render().appendTo(this.options.container);
+    const $content = this.$popover.find('.popover-content,.note-popover-content');
+    
+    this.context.invoke('buttons.build', $content, this.options.popover.video);
+  }
+
+  destroy() {
+    this.$popover.remove();
+  }
+
+  update(target) {
+    if (dom.isVideo(target)) {
+      const pos = dom.posFromPlaceholder(target);
+      const posEditor = dom.posFromPlaceholder(this.editable);
+      this.$popover.css({
+        display: 'block',
+        left: this.options.popatmouse ? event.pageX - 20 : pos.left,
+        top: this.options.popatmouse ? event.pageY : Math.min(pos.top, posEditor.top)
+      });
+    } else {
+      this.hide();
+    }
+  }
+
+  hide() {
+    this.$popover.hide();
+  }
+}

--- a/src/js/base/module/VideoPopover.js
+++ b/src/js/base/module/VideoPopover.js
@@ -31,7 +31,7 @@ export default class VideoPopover {
       className: 'note-video-popover'
     }).render().appendTo(this.options.container);
     const $content = this.$popover.find('.popover-content,.note-popover-content');
-    
+
     this.context.invoke('buttons.build', $content, this.options.popover.video);
   }
 

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -20,6 +20,7 @@ import ImageDialog from '../base/module/ImageDialog';
 import ImagePopover from '../base/module/ImagePopover';
 import TablePopover from '../base/module/TablePopover';
 import VideoDialog from '../base/module/VideoDialog';
+import VideoPopover from '../base/module/VideoPopover';
 import HelpDialog from '../base/module/HelpDialog';
 import AirPopover from '../base/module/AirPopover';
 import HintPopover from '../base/module/HintPopover';
@@ -54,6 +55,7 @@ $.summernote = $.extend($.summernote, {
       'imagePopover': ImagePopover,
       'tablePopover': TablePopover,
       'videoDialog': VideoDialog,
+      'videoPopover': VideoPopover,
       'helpDialog': HelpDialog,
       'airPopover': AirPopover
     },

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -85,6 +85,9 @@ $.summernote = $.extend($.summernote, {
         ['float', ['floatLeft', 'floatRight', 'floatNone']],
         ['remove', ['removeMedia']]
       ],
+      video: [
+        ['remove', ['removeMedia']]
+      ],
       link: [
         ['link', ['linkDialogShow', 'unlink']]
       ],

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -79,10 +79,13 @@ $.summernote = $.extend($.summernote, {
 
     // popover
     popatmouse: true,
-    popover: {
+    popover: { 
       image: [
         ['imagesize', ['imageSize100', 'imageSize50', 'imageSize25']],
         ['float', ['floatLeft', 'floatRight', 'floatNone']],
+        ['remove', ['removeMedia']]
+      ],
+      video: [
         ['remove', ['removeMedia']]
       ],
       link: [

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -79,7 +79,7 @@ $.summernote = $.extend($.summernote, {
 
     // popover
     popatmouse: true,
-    popover: { 
+    popover: {
       image: [
         ['imagesize', ['imageSize100', 'imageSize50', 'imageSize25']],
         ['float', ['floatLeft', 'floatRight', 'floatNone']],

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -20,6 +20,7 @@ import ImageDialog from '../base/module/ImageDialog';
 import ImagePopover from '../base/module/ImagePopover';
 import TablePopover from '../base/module/TablePopover';
 import VideoDialog from '../base/module/VideoDialog';
+import VideoPopover from '../base/module/VideoPopover';
 import HelpDialog from '../base/module/HelpDialog';
 import AirPopover from '../base/module/AirPopover';
 import HintPopover from '../base/module/HintPopover';
@@ -54,6 +55,7 @@ $.summernote = $.extend($.summernote, {
       'imagePopover': ImagePopover,
       'tablePopover': TablePopover,
       'videoDialog': VideoDialog,
+      'videoPopover': VideoPopover,
       'helpDialog': HelpDialog,
       'airPopover': AirPopover
     },

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -19,6 +19,7 @@ import ImageDialog from '../base/module/ImageDialog';
 import ImagePopover from '../base/module/ImagePopover';
 import TablePopover from '../base/module/TablePopover';
 import VideoDialog from '../base/module/VideoDialog';
+import VideoPopover from '../base/module/VideoPopover';
 import HelpDialog from '../base/module/HelpDialog';
 import AirPopover from '../base/module/AirPopover';
 import HintPopover from '../base/module/HintPopover';
@@ -52,6 +53,7 @@ $.summernote = $.extend($.summernote, {
       'imagePopover': ImagePopover,
       'tablePopover': TablePopover,
       'videoDialog': VideoDialog,
+      'videoPopover': VideoPopover,
       'helpDialog': HelpDialog,
       'airPopover': AirPopover
     },
@@ -82,6 +84,9 @@ $.summernote = $.extend($.summernote, {
       image: [
         ['imagesize', ['imageSize100', 'imageSize50', 'imageSize25']],
         ['float', ['floatLeft', 'floatRight', 'floatNone']],
+        ['remove', ['removeMedia']]
+      ],
+      video: [
         ['remove', ['removeMedia']]
       ],
       link: [

--- a/src/less/lite-ui/form.less
+++ b/src/less/lite-ui/form.less
@@ -41,3 +41,92 @@
 .note-input:-ms-input-placeholder {
   color: @gray-lighter;
 }
+
+.note-input-group {
+  position: relative;
+  display: inline-table;
+  width: 75%;
+  border-collapse: separate;
+  float: none;
+  padding-right: 0;
+  padding-left: 0;
+}
+
+.note-input-group .note-form-control {
+  position: relative;
+  z-index: 2;
+  float: left;
+  width: 100%;
+  margin-bottom: 0;
+}
+
+.note-input-group-addon,
+.note-input-group-btn,
+.note-input-group .form-control {
+  display: table-cell;
+}
+
+.note-input-group-addon:not(:first-child):not(:last-child),
+.note-input-group-btn:not(:first-child):not(:last-child),
+.note-input-group .form-control:not(:first-child):not(:last-child) {
+  border-radius: 0;
+}
+
+.note-input-group-addon,
+.note-input-group-btn {
+  width: 1%;
+  white-space: nowrap;
+  vertical-align: middle;
+}
+
+.note-input-group-addon {
+  padding: 6px 12px;
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 1;
+  color: #555;
+  text-align: center;
+  background-color: #eee;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.input-group-addon input[type="radio"],
+.input-group-addon input[type="checkbox"] {
+  margin-top: 0;
+}
+
+.note-input-group .note-form-control:first-child,
+.note-input-group-addon:first-child,
+.note-input-group-btn:first-child > .note-btn,
+.note-input-group-btn:first-child > .note-btn-group > .note-btn,
+.note-input-group-btn:last-child > .note-btn-group:not(:last-child) > .note-btn {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.note-input-group-addon:first-child {
+  border-right: 0;
+}
+.note-input-group .form-control:last-child,
+.note-input-group-addon:last-child,
+.note-input-group-btn:last-child > .note-btn,
+.note-input-group-btn:last-child > .note-btn-group > .note-btn,
+.note-input-group-btn:first-child > .note-btn:not(:first-child),
+.note-input-group-btn:first-child > .note-btn-group:not(:first-child) > .note-btn {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}
+
+.note-input-group-addon:last-child {
+  border-left: 0;
+}
+
+.note-help-block {
+  display: block;
+  font-size: 80%;
+  margin-top: 0;
+  margin-bottom: 5px;
+  color: #737373;
+  text-align: right;
+}

--- a/src/less/summernote-bs4.less
+++ b/src/less/summernote-bs4.less
@@ -464,6 +464,7 @@
   .note-control-selection {
     position: absolute;
     display: none;
+    z-index: 1040;
     border: 1px solid black;
     &>div { position: absolute; }
 
@@ -534,6 +535,21 @@
       .opacity(0.7);
     }
   }
+}
+
+.note-video-clip-wrapper {
+  position: relative;
+}
+.note-video-clip-wrapper:after {
+  content: '';
+  position: absolute;
+  display: block;
+  top: 0;
+  right: 55px;
+  bottom: 0;
+  left: 0;
+  background-color: #000;
+  opacity: 0;
 }
 
 .note-hint-popover {

--- a/src/less/summernote-bs4.less
+++ b/src/less/summernote-bs4.less
@@ -537,19 +537,17 @@
   }
 }
 
-.note-video-clip-wrapper {
+/* Video Wrapper
+------------------------------------------*/
+.note-video-clip {
   position: relative;
+  display: inline-block;
 }
-.note-video-clip-wrapper:after {
-  content: '';
-  position: absolute;
-  display: block;
-  top: 0;
-  right: 55px;
-  bottom: 0;
-  left: 0;
-  background-color: #000;
-  opacity: 0;
+
+.note-video-clip:hover{
+  content: 'Click to Edit';
+  padding-left: 100px;
+  background: rgba(0, 0, 0, .5) url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAALCAYAAADoWAqZAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4gEdAhUSz8P16QAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAARLSURBVEjHtZZdaBxVFMfP3d2YZNVq09JWUPtQUSRULXkSxPogKIgWQYJCrCAU3/rQvoiCotKKH/Qh2IdibYWqEYlWolJRaUpSbBWSEEPSaqChRhKtzdd2d/Zj7vn/ffBsHIbd2bTBA5eZMzP33DO/+Z85V8QsDMMmAGsBbLSxTlWzhULBiYiQfID/2k3mv0OSsgIjGZIclBUayTaSG2WVRrKZ5C0kN8XG+oQ5z0ffi2RfzN8QnZ8SEalUKpvT6fQB59ykiPxp45Jz7uvW1ta76qz1k4h8Kv+PnbQcVmuPi8iMiMzGxq9XEeM7Efkw4v8lIiNVJ5PL5W7MZDLHRWQbyYMkT4lISURud851isgWETkf+0rOOdcrIr0kU0NDQ+jo6BDnXMNswjCUpqamZV9VJZ1OV+NWY8yLSBhbs2Z8kjIxMSHt7e01l7PjYyKiket5EZFSqSQtLS1JCnbOuffsPO2cUxFZFJG56AvsIckwDLeTdFNTU2LBnapmAKTqlPD+eAmr6l4AkwDyAE6EYXh3rRL23j9Nkqr6bo2kn+N/VrJjxuA/BGAQwBUAF1X11eq88fHxWgB2ROdHrVgsilXfVgBjAOYB7FPVrljJ9pL0dn7I4sFyKwmAMZJ93vuWfD6f9DXiAN+KLgTguN2/SHKM5O8kv4oAHDDIOwFQVburCoyt8wTJiiU5bPHS3vtHLf7fJMdJXiBJAP0JOVcBbiN5T2TcaRA3ASDJKxbzDwDnYwC/rPokXyGpJIskR0iOCoAQwIEV/JDrAlTVR0h6AJ+Uy+V1puA2AA9GAJ5R1V0G781yuZyuVY52PEmyEr0HYAjApKreJyKSz+ezqvq+KfmpBgDjNm8xPyAZqmqnKfw2AMP1AJq/QHI0mlgAoHs1AAHsJslCobAhoQsXARRVdVcQBKla6os8P0gyjAEkgBej13K53M2mwteuRYGmtpnYOnsbAFwkORbtwsPOuXu992vqwQPQiG/KVFdMeKZZRFpISjabxTV21fLZs2eXnYWFhWJ0/QQbc879Ehm/2fW0iCzD6erqEhHxV5WRqj5jZbDbe7+8v5mbm8uo6h0A1q5AgTssxv4gCJoNZhbAlogCRwActBLeEwSBS/hg/TUUOAngtKreKiIyOzubUtWXTIE7kxSYsM5nJAPv/XYr4TYA3yYpEMBlkueWgywuLjYD6DE4P5P8iORRAH32w36yEcBcLtcKYMDu/wDgKMnvSX4RAXjKEvjYYL9cr4wBVLvd5yR7SKZU9Vm7NgzgGMlvDN5IPp+/oUEJHyF5ODJeN2BbI43vGMkBADMNAPZbI+khebiqtutUtQvAjwCK1ljOAdhXVWWjLjw/P389gLcBXALgAZz23t8f38Z47zMAjhjEN2q9eBAE6wGcAFCpbkOmp6dT3vtOAKMW/zKA7qWlpTXRBrTCJjIe2VI9DOACgBKAQwBeSAJYKpU2AzgDwJPkP4ggwCvkhJE9AAAAAElFTkSuQmCC) no-repeat 10px 10px;
 }
 
 .note-hint-popover {

--- a/src/less/summernote-bs4.scss
+++ b/src/less/summernote-bs4.scss
@@ -520,19 +520,17 @@ $img-margin-right: 10px;
   }
 }
 
-.note-video-clip-wrapper {
+/* Video Wrapper
+------------------------------------------*/
+.note-video-clip {
   position: relative;
+  display: inline-block;
 }
-.note-video-clip-wrapper:after {
-  content: '';
-  position: absolute;
-  display: block;
-  top: 0;
-  right: 55px;
-  bottom: 0;
-  left: 0;
-  background-color: #000;
-  opacity: 0;
+
+.note-video-clip:hover{
+  content: 'Click to Edit';
+  padding-left: 100px;
+  background: rgba(0, 0, 0, .5) url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAALCAYAAADoWAqZAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4gEdAhUSz8P16QAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAARLSURBVEjHtZZdaBxVFMfP3d2YZNVq09JWUPtQUSRULXkSxPogKIgWQYJCrCAU3/rQvoiCotKKH/Qh2IdibYWqEYlWolJRaUpSbBWSEEPSaqChRhKtzdd2d/Zj7vn/ffBsHIbd2bTBA5eZMzP33DO/+Z85V8QsDMMmAGsBbLSxTlWzhULBiYiQfID/2k3mv0OSsgIjGZIclBUayTaSG2WVRrKZ5C0kN8XG+oQ5z0ffi2RfzN8QnZ8SEalUKpvT6fQB59ykiPxp45Jz7uvW1ta76qz1k4h8Kv+PnbQcVmuPi8iMiMzGxq9XEeM7Efkw4v8lIiNVJ5PL5W7MZDLHRWQbyYMkT4lISURud851isgWETkf+0rOOdcrIr0kU0NDQ+jo6BDnXMNswjCUpqamZV9VJZ1OV+NWY8yLSBhbs2Z8kjIxMSHt7e01l7PjYyKiket5EZFSqSQtLS1JCnbOuffsPO2cUxFZFJG56AvsIckwDLeTdFNTU2LBnapmAKTqlPD+eAmr6l4AkwDyAE6EYXh3rRL23j9Nkqr6bo2kn+N/VrJjxuA/BGAQwBUAF1X11eq88fHxWgB2ROdHrVgsilXfVgBjAOYB7FPVrljJ9pL0dn7I4sFyKwmAMZJ93vuWfD6f9DXiAN+KLgTguN2/SHKM5O8kv4oAHDDIOwFQVburCoyt8wTJiiU5bPHS3vtHLf7fJMdJXiBJAP0JOVcBbiN5T2TcaRA3ASDJKxbzDwDnYwC/rPokXyGpJIskR0iOCoAQwIEV/JDrAlTVR0h6AJ+Uy+V1puA2AA9GAJ5R1V0G781yuZyuVY52PEmyEr0HYAjApKreJyKSz+ezqvq+KfmpBgDjNm8xPyAZqmqnKfw2AMP1AJq/QHI0mlgAoHs1AAHsJslCobAhoQsXARRVdVcQBKla6os8P0gyjAEkgBej13K53M2mwteuRYGmtpnYOnsbAFwkORbtwsPOuXu992vqwQPQiG/KVFdMeKZZRFpISjabxTV21fLZs2eXnYWFhWJ0/QQbc879Ehm/2fW0iCzD6erqEhHxV5WRqj5jZbDbe7+8v5mbm8uo6h0A1q5AgTssxv4gCJoNZhbAlogCRwActBLeEwSBS/hg/TUUOAngtKreKiIyOzubUtWXTIE7kxSYsM5nJAPv/XYr4TYA3yYpEMBlkueWgywuLjYD6DE4P5P8iORRAH32w36yEcBcLtcKYMDu/wDgKMnvSX4RAXjKEvjYYL9cr4wBVLvd5yR7SKZU9Vm7NgzgGMlvDN5IPp+/oUEJHyF5ODJeN2BbI43vGMkBADMNAPZbI+khebiqtutUtQvAjwCK1ljOAdhXVWWjLjw/P389gLcBXALgAZz23t8f38Z47zMAjhjEN2q9eBAE6wGcAFCpbkOmp6dT3vtOAKMW/zKA7qWlpTXRBrTCJjIe2VI9DOACgBKAQwBeSAJYKpU2AzgDwJPkP4ggwCvkhJE9AAAAAElFTkSuQmCC) no-repeat 10px 10px;
 }
 
 .note-hint-popover {

--- a/src/less/summernote-bs4.scss
+++ b/src/less/summernote-bs4.scss
@@ -447,6 +447,7 @@ $img-margin-right: 10px;
   .note-control-selection {
     position: absolute;
     display: none;
+    z-index: 1040;
     border: 1px solid black;
     &>div { position: absolute; }
 
@@ -517,6 +518,21 @@ $img-margin-right: 10px;
       @include opacity(0.7);
     }
   }
+}
+
+.note-video-clip-wrapper {
+  position: relative;
+}
+.note-video-clip-wrapper:after {
+  content: '';
+  position: absolute;
+  display: block;
+  top: 0;
+  right: 55px;
+  bottom: 0;
+  left: 0;
+  background-color: #000;
+  opacity: 0;
 }
 
 .note-hint-popover {

--- a/src/less/summernote-lite.less
+++ b/src/less/summernote-lite.less
@@ -481,6 +481,7 @@
   .note-control-selection {
     position: absolute;
     display: none;
+    z-index: 1040;
     border: 1px solid black;
     &>div { position: absolute; }
 
@@ -551,6 +552,21 @@
       .opacity(0.7);
     }
   }
+}
+
+.note-video-clip-wrapper {
+  position: relative;
+}
+.note-video-clip-wrapper:after {
+  content: '';
+  position: absolute;
+  display: block;
+  top: 0;
+  right: 55px;
+  bottom: 0;
+  left: 0;
+  background-color: #000;
+  opacity: 0;
 }
 
 .note-hint-popover {

--- a/src/less/summernote-lite.less
+++ b/src/less/summernote-lite.less
@@ -554,19 +554,17 @@
   }
 }
 
-.note-video-clip-wrapper {
+/* Video Wrapper
+------------------------------------------*/
+.note-video-clip {
   position: relative;
+  display: inline-block;
 }
-.note-video-clip-wrapper:after {
-  content: '';
-  position: absolute;
-  display: block;
-  top: 0;
-  right: 55px;
-  bottom: 0;
-  left: 0;
-  background-color: #000;
-  opacity: 0;
+
+.note-video-clip:hover{
+  content: 'Click to Edit';
+  padding-left: 100px;
+  background: rgba(0, 0, 0, .5) url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAALCAYAAADoWAqZAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4gEdAhUSz8P16QAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAARLSURBVEjHtZZdaBxVFMfP3d2YZNVq09JWUPtQUSRULXkSxPogKIgWQYJCrCAU3/rQvoiCotKKH/Qh2IdibYWqEYlWolJRaUpSbBWSEEPSaqChRhKtzdd2d/Zj7vn/ffBsHIbd2bTBA5eZMzP33DO/+Z85V8QsDMMmAGsBbLSxTlWzhULBiYiQfID/2k3mv0OSsgIjGZIclBUayTaSG2WVRrKZ5C0kN8XG+oQ5z0ffi2RfzN8QnZ8SEalUKpvT6fQB59ykiPxp45Jz7uvW1ta76qz1k4h8Kv+PnbQcVmuPi8iMiMzGxq9XEeM7Efkw4v8lIiNVJ5PL5W7MZDLHRWQbyYMkT4lISURud851isgWETkf+0rOOdcrIr0kU0NDQ+jo6BDnXMNswjCUpqamZV9VJZ1OV+NWY8yLSBhbs2Z8kjIxMSHt7e01l7PjYyKiket5EZFSqSQtLS1JCnbOuffsPO2cUxFZFJG56AvsIckwDLeTdFNTU2LBnapmAKTqlPD+eAmr6l4AkwDyAE6EYXh3rRL23j9Nkqr6bo2kn+N/VrJjxuA/BGAQwBUAF1X11eq88fHxWgB2ROdHrVgsilXfVgBjAOYB7FPVrljJ9pL0dn7I4sFyKwmAMZJ93vuWfD6f9DXiAN+KLgTguN2/SHKM5O8kv4oAHDDIOwFQVburCoyt8wTJiiU5bPHS3vtHLf7fJMdJXiBJAP0JOVcBbiN5T2TcaRA3ASDJKxbzDwDnYwC/rPokXyGpJIskR0iOCoAQwIEV/JDrAlTVR0h6AJ+Uy+V1puA2AA9GAJ5R1V0G781yuZyuVY52PEmyEr0HYAjApKreJyKSz+ezqvq+KfmpBgDjNm8xPyAZqmqnKfw2AMP1AJq/QHI0mlgAoHs1AAHsJslCobAhoQsXARRVdVcQBKla6os8P0gyjAEkgBej13K53M2mwteuRYGmtpnYOnsbAFwkORbtwsPOuXu992vqwQPQiG/KVFdMeKZZRFpISjabxTV21fLZs2eXnYWFhWJ0/QQbc879Ehm/2fW0iCzD6erqEhHxV5WRqj5jZbDbe7+8v5mbm8uo6h0A1q5AgTssxv4gCJoNZhbAlogCRwActBLeEwSBS/hg/TUUOAngtKreKiIyOzubUtWXTIE7kxSYsM5nJAPv/XYr4TYA3yYpEMBlkueWgywuLjYD6DE4P5P8iORRAH32w36yEcBcLtcKYMDu/wDgKMnvSX4RAXjKEvjYYL9cr4wBVLvd5yR7SKZU9Vm7NgzgGMlvDN5IPp+/oUEJHyF5ODJeN2BbI43vGMkBADMNAPZbI+khebiqtutUtQvAjwCK1ljOAdhXVWWjLjw/P389gLcBXALgAZz23t8f38Z47zMAjhjEN2q9eBAE6wGcAFCpbkOmp6dT3vtOAKMW/zKA7qWlpTXRBrTCJjIe2VI9DOACgBKAQwBeSAJYKpU2AzgDwJPkP4ggwCvkhJE9AAAAAElFTkSuQmCC) no-repeat 10px 10px;
 }
 
 .note-hint-popover {

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -536,19 +536,17 @@
   }
 }
 
-.note-video-clip-wrapper {
+/* Video Wrapper
+------------------------------------------*/
+.note-video-clip {
   position: relative;
+  display: inline-block;
 }
-.note-video-clip-wrapper:after {
-  content: '';
-  position: absolute;
-  display: block;
-  top: 0;
-  right: 55px;
-  bottom: 0;
-  left: 0;
-  background-color: #000;
-  opacity: 0;
+
+.note-video-clip:hover{
+  content: 'Click to Edit';
+  padding-left: 100px;
+  background: rgba(0, 0, 0, .5) url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAALCAYAAADoWAqZAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4gEdAhUSz8P16QAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAARLSURBVEjHtZZdaBxVFMfP3d2YZNVq09JWUPtQUSRULXkSxPogKIgWQYJCrCAU3/rQvoiCotKKH/Qh2IdibYWqEYlWolJRaUpSbBWSEEPSaqChRhKtzdd2d/Zj7vn/ffBsHIbd2bTBA5eZMzP33DO/+Z85V8QsDMMmAGsBbLSxTlWzhULBiYiQfID/2k3mv0OSsgIjGZIclBUayTaSG2WVRrKZ5C0kN8XG+oQ5z0ffi2RfzN8QnZ8SEalUKpvT6fQB59ykiPxp45Jz7uvW1ta76qz1k4h8Kv+PnbQcVmuPi8iMiMzGxq9XEeM7Efkw4v8lIiNVJ5PL5W7MZDLHRWQbyYMkT4lISURud851isgWETkf+0rOOdcrIr0kU0NDQ+jo6BDnXMNswjCUpqamZV9VJZ1OV+NWY8yLSBhbs2Z8kjIxMSHt7e01l7PjYyKiket5EZFSqSQtLS1JCnbOuffsPO2cUxFZFJG56AvsIckwDLeTdFNTU2LBnapmAKTqlPD+eAmr6l4AkwDyAE6EYXh3rRL23j9Nkqr6bo2kn+N/VrJjxuA/BGAQwBUAF1X11eq88fHxWgB2ROdHrVgsilXfVgBjAOYB7FPVrljJ9pL0dn7I4sFyKwmAMZJ93vuWfD6f9DXiAN+KLgTguN2/SHKM5O8kv4oAHDDIOwFQVburCoyt8wTJiiU5bPHS3vtHLf7fJMdJXiBJAP0JOVcBbiN5T2TcaRA3ASDJKxbzDwDnYwC/rPokXyGpJIskR0iOCoAQwIEV/JDrAlTVR0h6AJ+Uy+V1puA2AA9GAJ5R1V0G781yuZyuVY52PEmyEr0HYAjApKreJyKSz+ezqvq+KfmpBgDjNm8xPyAZqmqnKfw2AMP1AJq/QHI0mlgAoHs1AAHsJslCobAhoQsXARRVdVcQBKla6os8P0gyjAEkgBej13K53M2mwteuRYGmtpnYOnsbAFwkORbtwsPOuXu992vqwQPQiG/KVFdMeKZZRFpISjabxTV21fLZs2eXnYWFhWJ0/QQbc879Ehm/2fW0iCzD6erqEhHxV5WRqj5jZbDbe7+8v5mbm8uo6h0A1q5AgTssxv4gCJoNZhbAlogCRwActBLeEwSBS/hg/TUUOAngtKreKiIyOzubUtWXTIE7kxSYsM5nJAPv/XYr4TYA3yYpEMBlkueWgywuLjYD6DE4P5P8iORRAH32w36yEcBcLtcKYMDu/wDgKMnvSX4RAXjKEvjYYL9cr4wBVLvd5yR7SKZU9Vm7NgzgGMlvDN5IPp+/oUEJHyF5ODJeN2BbI43vGMkBADMNAPZbI+khebiqtutUtQvAjwCK1ljOAdhXVWWjLjw/P389gLcBXALgAZz23t8f38Z47zMAjhjEN2q9eBAE6wGcAFCpbkOmp6dT3vtOAKMW/zKA7qWlpTXRBrTCJjIe2VI9DOACgBKAQwBeSAJYKpU2AzgDwJPkP4ggwCvkhJE9AAAAAElFTkSuQmCC) no-repeat 10px 10px;
 }
 
 .note-hint-popover {

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -463,6 +463,7 @@
   .note-control-selection {
     position: absolute;
     display: none;
+    z-index: 1040;
     border: 1px solid #000;
     &>div { position: absolute; }
 
@@ -533,6 +534,21 @@
       .opacity(0.7);
     }
   }
+}
+
+.note-video-clip-wrapper {
+  position: relative;
+}
+.note-video-clip-wrapper:after {
+  content: '';
+  position: absolute;
+  display: block;
+  top: 0;
+  right: 55px;
+  bottom: 0;
+  left: 0;
+  background-color: #000;
+  opacity: 0;
 }
 
 .note-hint-popover {

--- a/src/less/summernote.scss
+++ b/src/less/summernote.scss
@@ -520,19 +520,17 @@ $img-margin-right: 10px;
   }
 }
 
-.note-video-clip-wrapper {
+/* Video Wrapper
+------------------------------------------*/
+.note-video-clip {
   position: relative;
+  display: inline-block;
 }
-.note-video-clip-wrapper:after {
-  content: '';
-  position: absolute;
-  display: block;
-  top: 0;
-  right: 55px;
-  bottom: 0;
-  left: 0;
-  background-color: #000;
-  opacity: 0;
+
+.note-video-clip:hover{
+  content: 'Click to Edit';
+  padding-left: 100px;
+  background: rgba(0, 0, 0, .5) url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFAAAAALCAYAAADoWAqZAAAABmJLR0QA/wD/AP+gvaeTAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAB3RJTUUH4gEdAhUSz8P16QAAABl0RVh0Q29tbWVudABDcmVhdGVkIHdpdGggR0lNUFeBDhcAAARLSURBVEjHtZZdaBxVFMfP3d2YZNVq09JWUPtQUSRULXkSxPogKIgWQYJCrCAU3/rQvoiCotKKH/Qh2IdibYWqEYlWolJRaUpSbBWSEEPSaqChRhKtzdd2d/Zj7vn/ffBsHIbd2bTBA5eZMzP33DO/+Z85V8QsDMMmAGsBbLSxTlWzhULBiYiQfID/2k3mv0OSsgIjGZIclBUayTaSG2WVRrKZ5C0kN8XG+oQ5z0ffi2RfzN8QnZ8SEalUKpvT6fQB59ykiPxp45Jz7uvW1ta76qz1k4h8Kv+PnbQcVmuPi8iMiMzGxq9XEeM7Efkw4v8lIiNVJ5PL5W7MZDLHRWQbyYMkT4lISURud851isgWETkf+0rOOdcrIr0kU0NDQ+jo6BDnXMNswjCUpqamZV9VJZ1OV+NWY8yLSBhbs2Z8kjIxMSHt7e01l7PjYyKiket5EZFSqSQtLS1JCnbOuffsPO2cUxFZFJG56AvsIckwDLeTdFNTU2LBnapmAKTqlPD+eAmr6l4AkwDyAE6EYXh3rRL23j9Nkqr6bo2kn+N/VrJjxuA/BGAQwBUAF1X11eq88fHxWgB2ROdHrVgsilXfVgBjAOYB7FPVrljJ9pL0dn7I4sFyKwmAMZJ93vuWfD6f9DXiAN+KLgTguN2/SHKM5O8kv4oAHDDIOwFQVburCoyt8wTJiiU5bPHS3vtHLf7fJMdJXiBJAP0JOVcBbiN5T2TcaRA3ASDJKxbzDwDnYwC/rPokXyGpJIskR0iOCoAQwIEV/JDrAlTVR0h6AJ+Uy+V1puA2AA9GAJ5R1V0G781yuZyuVY52PEmyEr0HYAjApKreJyKSz+ezqvq+KfmpBgDjNm8xPyAZqmqnKfw2AMP1AJq/QHI0mlgAoHs1AAHsJslCobAhoQsXARRVdVcQBKla6os8P0gyjAEkgBej13K53M2mwteuRYGmtpnYOnsbAFwkORbtwsPOuXu992vqwQPQiG/KVFdMeKZZRFpISjabxTV21fLZs2eXnYWFhWJ0/QQbc879Ehm/2fW0iCzD6erqEhHxV5WRqj5jZbDbe7+8v5mbm8uo6h0A1q5AgTssxv4gCJoNZhbAlogCRwActBLeEwSBS/hg/TUUOAngtKreKiIyOzubUtWXTIE7kxSYsM5nJAPv/XYr4TYA3yYpEMBlkueWgywuLjYD6DE4P5P8iORRAH32w36yEcBcLtcKYMDu/wDgKMnvSX4RAXjKEvjYYL9cr4wBVLvd5yR7SKZU9Vm7NgzgGMlvDN5IPp+/oUEJHyF5ODJeN2BbI43vGMkBADMNAPZbI+khebiqtutUtQvAjwCK1ljOAdhXVWWjLjw/P389gLcBXALgAZz23t8f38Z47zMAjhjEN2q9eBAE6wGcAFCpbkOmp6dT3vtOAKMW/zKA7qWlpTXRBrTCJjIe2VI9DOACgBKAQwBeSAJYKpU2AzgDwJPkP4ggwCvkhJE9AAAAAElFTkSuQmCC) no-repeat 10px 10px;
 }
 
 .note-hint-popover {

--- a/src/less/summernote.scss
+++ b/src/less/summernote.scss
@@ -447,6 +447,7 @@ $img-margin-right: 10px;
   .note-control-selection {
     position: absolute;
     display: none;
+    z-index: 1040;
     border: 1px solid #000;
     &>div { position: absolute; }
 
@@ -517,6 +518,21 @@ $img-margin-right: 10px;
       @include opacity(0.7);
     }
   }
+}
+
+.note-video-clip-wrapper {
+  position: relative;
+}
+.note-video-clip-wrapper:after {
+  content: '';
+  position: absolute;
+  display: block;
+  top: 0;
+  right: 55px;
+  bottom: 0;
+  left: 0;
+  background-color: #000;
+  opacity: 0;
 }
 
 .note-hint-popover {


### PR DESCRIPTION
This PR, adds VideoPopover.js and events to allow Videos to have the ability to have a popover for adding editing options. So far only a Remove button is added.

When inserting a video a div with a class of .note-video-clip-wrapper is wrapped on the iframe video element with an invisible after element to allow clicking on the video (we don't usually play videos when editing content). The image highlighter/resizer appears over the video, can be resized, but it doesn't affect the video only it's own element at this stage unless someone else wants to add this in for resizing videos.
