### PR TITLE
Hide icon bar when resize is disabled

### DIFF
--- a/src/js/base/module/Statusbar.js
+++ b/src/js/base/module/Statusbar.js
@@ -37,5 +37,6 @@ export default class Statusbar {
 
   destroy() {
     this.$statusbar.off();
+    this.$statusbar.addClass('locked');
   }
 }

--- a/src/less/summernote-bs4.less
+++ b/src/less/summernote-bs4.less
@@ -230,6 +230,15 @@
         border-top: 1px solid @border-color;
       }
     }
+
+    &.locked {
+      .note-resizebar {
+        cursor: default;
+        .note-icon-bar {
+          display: none;
+        }
+      }
+    }
   }
   .note-placeholder {
     padding: 10px;

--- a/src/less/summernote-bs4.scss
+++ b/src/less/summernote-bs4.scss
@@ -229,6 +229,15 @@ $img-margin-right: 10px;
         border-top: 1px solid $border-color;
       }
     }
+
+    &.locked {
+      .note-resizebar {
+        cursor: default;
+        .note-icon-bar {
+          display: none;
+        }
+      }
+    }
   }
   .note-placeholder {
     padding: 10px;

--- a/src/less/summernote-lite.less
+++ b/src/less/summernote-lite.less
@@ -253,6 +253,15 @@
         border-top: 1px solid @border-color;
       }
     }
+
+    &.locked {
+      .note-resizebar {
+        cursor: default;
+        .note-icon-bar {
+          display: none;
+        }
+      }
+    }
   }
   .note-placeholder {
     padding: 10px;

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -230,6 +230,15 @@
         border-top: 1px solid @border-color;
       }
     }
+
+    &.locked {
+      .note-resizebar {
+        cursor: default;
+        .note-icon-bar {
+          display: none;
+        }
+      }
+    }
   }
   .note-placeholder {
     padding: 10px;

--- a/src/less/summernote.scss
+++ b/src/less/summernote.scss
@@ -229,6 +229,15 @@ $img-margin-right: 10px;
         border-top: 1px solid $border-color;
       }
     }
+
+    &.locked {
+      .note-resizebar {
+        cursor: default;
+        .note-icon-bar {
+          display: none;
+        }
+      }
+    }
   }
   .note-placeholder {
     padding: 10px;


### PR DESCRIPTION
#### What does this PR do?

- Hides icon bar when `disableResizeEditor` is set to true
- Changes cursor back to default when `disableResizeEditor` is set to true

#### Where should the reviewer start?

- start on the `src/js/base/module/Statusbar.js` where a class `locked` is added to the statusbar inside the `destroy` method
- look at the added styles in `src/less/summernote.less` and equivalent .less and .scss files


#### How should this be manually tested?

- this can be tested using the option `disableResizeEditor` set to `true`

#### Any background context you want to provide?

- This is a followup to the work done in #2212 that disables the resizing of the editor. #1931 addresses this and a workaround can be found there.

#### What are the relevant tickets?

#2212
#1931

#### Screenshots
Before:
<img width="1125" alt="screen shot 2018-01-30 at 00 18 36" src="https://user-images.githubusercontent.com/3029838/35542440-ebf0578a-0557-11e8-8b76-6b994df39ac6.png">

After:
<img width="1128" alt="screen shot 2018-01-30 at 00 18 51" src="https://user-images.githubusercontent.com/3029838/35542451-f6ea0564-0557-11e8-8408-a04d35467d0a.png">


### Checklist
- [ ] added relevant tests
- [x] didn't break anything
