### PR TITLE
Calculate image selection to cover other layouts and content formats

### DIFF
--- a/src/js/base/module/ImagePopover.js
+++ b/src/js/base/module/ImagePopover.js
@@ -40,12 +40,16 @@ export default class ImagePopover {
 
   update(target) {
     if (dom.isImg(target)) {
-      const pos = dom.posFromPlaceholder(target);
-      const posEditor = dom.posFromPlaceholder(this.editable);
+      const position = $(target).offset();
+      const editingOffset = $(this.context.layoutInfo.editingArea).offset();
+      const pos = {
+        left: position.left - editingOffset.left,
+        top: position.top - editingOffset.top
+      };
       this.$popover.css({
         display: 'block',
         left: this.options.popatmouse ? event.pageX - 20 : pos.left,
-        top: this.options.popatmouse ? event.pageY : Math.min(pos.top, posEditor.top)
+        top: this.options.popatmouse ? event.pageY : pos.top
       });
     } else {
       this.hide();


### PR DESCRIPTION
#### What does this PR do?

- this PR fixes image selection rendering when image is part of a div based content, within editor that is positioned relatively and aligned to the center

#### Where should the reviewer start?

- start on the src/js/base/module/ImagePopover.js

#### How should this be manually tested?

- open the editor, upload an image, click on the image and make sure that the image selection is exactly on the image place.

#### Any background context you want to provide?

- I used the summernote with react-summernote

#### What are the relevant tickets?

### Checklist
- [ x ] didn't break anything (tests run ok and image selection works with the summernote editor used for testing)
