### PR TITLE
Remove onSubmit callback from lite

### DIFF
--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -172,7 +172,6 @@ $.summernote = $.extend($.summernote, {
       onEnter: null,
       onKeyup: null,
       onKeydown: null,
-      onSubmit: null,
       onImageUpload: null,
       onImageUploadError: null
     },


### PR DESCRIPTION

#### What does this PR do?
It removes the onSubmit callback from the lite version of summernote as #1809

