### PR TITLE
Add start parameter for YouTube embedding

### DIFF
--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -49,7 +49,8 @@ export default class VideoDialog {
 
   createVideoNode(url) {
     // video url patterns(youtube, instagram, vimeo, dailymotion, youku, mp4, ogg, webm)
-    const ytRegExp = /^(?:https?:\/\/)?(?:www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/;
+    const ytRegExp = /^(?:https?:\/\/)?(?:www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))([\w|-]{11})(?:(?:[\?&]t=)(\S+))?$/;
+    const ytRegExpForStart = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/;
     const ytMatch = url.match(ytRegExp);
 
     const igRegExp = /(?:www\.|\/\/)instagram\.com\/p\/(.[a-zA-Z0-9_-]*)/;
@@ -85,9 +86,18 @@ export default class VideoDialog {
     let $video;
     if (ytMatch && ytMatch[1].length === 11) {
       const youtubeId = ytMatch[1];
+      var start = 0;
+      if (typeof ytMatch[2] !== 'undefined') {
+        const ytMatchForStart = ytMatch[2].match(ytRegExpForStart);
+        if (ytMatchForStart) {
+          for (var n = [3600, 60, 1], i = 0, r = n.length; i < r; i++) {
+            start += (typeof ytMatchForStart[i + 1] !== 'undefined' ? n[i] * parseInt(ytMatchForStart[i + 1], 10) : 0);
+          }
+        }
+      }
       $video = $('<iframe>')
         .attr('frameborder', 0)
-        .attr('src', '//www.youtube.com/embed/' + youtubeId)
+        .attr('src', '//www.youtube.com/embed/' + youtubeId + (start > 0 ? '?start=' + start : ''))
         .attr('width', '640').attr('height', '360');
     } else if (igMatch && igMatch[0].length) {
       $video = $('<iframe>')

--- a/test/unit/base/module/VideoDialog.spec.js
+++ b/test/unit/base/module/VideoDialog.spec.js
@@ -41,8 +41,8 @@ describe('bs:module.VideoDialog', () => {
 
     it('should get proper iframe src when insert valid video urls', () => {
       // YouTube
-      expectUrl('https://www.youtube.com/watch?v=HisIM3pkEF0',
-        '//www.youtube.com/embed/HisIM3pkEF0');
+      expectUrl('https://www.youtube.com/watch?v=jNQXAC9IVRw',
+        '//www.youtube.com/embed/jNQXAC9IVRw');
       // Instagram
       expectUrl('https://www.instagram.com/p/Bi9cbsxjn-F',
         '//instagram.com/p/Bi9cbsxjn-F/embed/');

--- a/test/unit/bs/module/VideoDialog.spec.js
+++ b/test/unit/bs/module/VideoDialog.spec.js
@@ -15,7 +15,7 @@ describe('bs:module.VideoDialog', () => {
     var iframe = $video.createVideoNode(source);
     expect(iframe).to.not.equal(false);
     expect(iframe.tagName).to.equal('IFRAME');
-    expect(iframe.src).to.equal(target);
+    expect(iframe.src).to.be.have.string(target);
   }
 
   var context, $video;
@@ -33,16 +33,29 @@ describe('bs:module.VideoDialog', () => {
   });
 
   describe('#createVideoNode', () => {
-    it('should execute when insert other url', () => {
+    it('should get false when insert invalid urls', () => {
       expect($video.createVideoNode('http://www.google.com')).to.equal(false);
       expect($video.createVideoNode('http://www.youtube.com')).to.equal(false);
       expect($video.createVideoNode('http://www.facebook.com')).to.equal(false);
     });
-    it('should execute when insert v.qq.com', () => {
+
+    it('should get proper iframe src when insert valid video urls', () => {
+      // YouTube
+      expectUrl('https://www.youtube.com/watch?v=HisIM3pkEF0',
+        '//www.youtube.com/embed/HisIM3pkEF0');
+      // Instagram
+      expectUrl('https://www.instagram.com/p/Bi9cbsxjn-F',
+        '//instagram.com/p/Bi9cbsxjn-F/embed/');
+      // v.qq.com
       expectUrl('http://v.qq.com/cover/6/640ewqy2v071ppd.html?vid=f0196y2b2cx',
-        'http://v.qq.com/iframe/player.html?vid=f0196y2b2cx&amp;auto=0');
+        '//v.qq.com/iframe/player.html?vid=f0196y2b2cx&amp;auto=0');
       expectUrl('http://v.qq.com/x/page/p0330y279lm.html',
-        'http://v.qq.com/iframe/player.html?vid=p0330y279lm&amp;auto=0');
+        '//v.qq.com/iframe/player.html?vid=p0330y279lm&amp;auto=0');
+    });
+
+    it('should be embedded start parameter when insert YouTube video with t', () => {
+      expectUrl('https://youtu.be/wZZ7oFKsKzY?t=4h2m42s',
+        '//www.youtube.com/embed/wZZ7oFKsKzY?start=14562');
     });
   });
 });


### PR DESCRIPTION
#### What does this PR do?

- Allow `start` parameter for embedding YouTube video

#### Where should the reviewer start?

- start on the `src/js/base/module/VideoDialog.js`

#### How should this be manually tested?

- Embed YouTube videos with timestamps.

#### Any background context you want to provide?

As described in [YouTube Player API](https://developers.google.com/youtube/player_parameters#start), it uses `start` parameter only in seconds to set the starting point of the player. But its link generator gives the timestamp as `1h25m17s` format, so I had to convert them into seconds.

#### What are the relevant tickets?

- https://github.com/summernote/django-summernote/issues/285

### Checklist
- [ ] added relevant tests
- [x] didn't break anything
