### PR TITLE
When creating a link Summernote now checks maxTextLength

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -186,6 +186,10 @@ export default class Editor {
       const linkText = linkInfo.text;
       const isNewWindow = linkInfo.isNewWindow;
       let rng = linkInfo.range || this.createRange();
+      const additionalTextLength = linkText.length - rng.toString().length;
+      if (additionalTextLength > 0 && this.isLimited(additionalTextLength)) {
+        return;
+      }
       const isTextChanged = rng.toString() !== linkText;
 
       // handle spaced urls from input

--- a/test/unit/base/module/Editor.spec.js
+++ b/test/unit/base/module/Editor.spec.js
@@ -386,5 +386,39 @@ describe('Editor', () => {
 
       expectContents(context, '<p><a href="http://wow.summernote.org">summernote wow</a></p>');
     });
+
+    it('should be limited when creating a link', () => {
+      var options = $.extend({}, $.summernote.options);
+      options.langInfo = $.extend(true, {}, $.summernote.lang['en-US'], $.summernote.lang[options.lang]);
+      options.maxTextLength = 5;
+      context = new Context($('<div><p>hello</p></div>'), options);
+      editor = context.modules.editor;
+
+      editor.createLink({
+        url: 'http://summernote.org',
+        text: 'summernote'
+      });
+      expectContents(context, '<p>hello</p>');
+    });
+
+    it('should be limited when modifying a link', () => {
+      var options = $.extend({}, $.summernote.options);
+      options.langInfo = $.extend(true, {}, $.summernote.lang['en-US'], $.summernote.lang[options.lang]);
+      options.maxTextLength = 5;
+      context = new Context($('<p><a href="http://summernote.org">hello</a></p>'), options);
+
+      var editable = context.layoutInfo.editable;
+      var anchorNode = editable.find('a')[0];
+      var rng = range.createFromNode(anchorNode);
+      editor = context.modules.editor;
+
+      editor.createLink({
+        url: 'http://summernote.org',
+        text: 'hello world',
+        range: rng
+      });
+
+      expectContents(context, '<a href="http://summernote.org">hello</a>');
+    });
   });
 });


### PR DESCRIPTION
#### What does this PR do?

- prevents users from going over the maxTextLength by creating/modifying links.

#### Where should the reviewer start?

- start on the src/js/base/module/Editor.js

#### How should this be manually tested?

- set maxTextLength with a small value and try to `createLink`

#### Any background context you want to provide?

Users are able to bypass the maxTextLength option by creating or modifying links. Something to consider is the following scenario: A user tries to modify a link by changing the Link Text and the Link URL. The new link text would put the total number of characters above maxTextLength. Should the URL change but the text remain the same or should neither change? This PR doesn't change either if the new link text puts the total number of characters above maxTextLength.

#### What are the relevant tickets?

- [#118](https://github.com/summernote/summernote/issues/118)
- [#1384](https://github.com/summernote/summernote/issues/1384)
- [#1957](https://github.com/summernote/summernote/issues/1957)
- [#2554](https://github.com/summernote/summernote/pull/2554)