### PR TITLE
Add missing translations in zh-CN for table, etc

### DIFF
--- a/lang/summernote-zh-CN.js
+++ b/lang/summernote-zh-CN.js
@@ -27,13 +27,13 @@
         shapeThumbnail: '形状: 缩略图',
         shapeNone: '形状: 无',
         dragImageHere: '将图片拖拽至此处',
-        dropImage: 'Drop image or Text',
+        dropImage: '拖拽图片或文本',
         selectFromFiles: '从本地上传',
         maximumFileSize: '文件大小最大值',
         maximumFileSizeError: '文件大小超出最大值。',
         url: '图片地址',
         remove: '移除图片',
-        original: 'Original'
+        original: '原始图片'
       },
       video: {
         video: '视频',
@@ -53,13 +53,13 @@
       },
       table: {
         table: '表格',
-        addRowAbove: 'Add row above',
-        addRowBelow: 'Add row below',
-        addColLeft: 'Add column left',
-        addColRight: 'Add column right',
-        delRow: 'Delete row',
-        delCol: 'Delete column',
-        delTable: 'Delete table'
+        addRowAbove: '在上方插入行',
+        addRowBelow: '在下方插入行',
+        addColLeft: '在左侧插入列',
+        addColRight: '在右侧插入列',
+        delRow: '删除行',
+        delCol: '删除列',
+        delTable: '删除表格'
       },
       hr: {
         insert: '水平线'
@@ -147,8 +147,8 @@
         redo: '重做'
       },
       specialChar: {
-        specialChar: 'SPECIAL CHARACTERS',
-        select: 'Select Special characters'
+        specialChar: '特殊字符',
+        select: '选取特殊字符'
       }
     }
   });


### PR DESCRIPTION
#### What does this PR do?

- add missing translations in zh-CN for table,  

#### Where should the reviewer start?

- start on the lang/summernote-zh-CN.js

#### How should this be manually tested?

- After loading summernote-zh-CN.js, table popover menu's tooltip should show Chinese characters instead of original English menu.

#### Any background context you want to provide?

None

#### What are the relevant tickets?

None

#### Screenshot (if for frontend)
None

### Checklist
None
