### PR TITLE
Fix pt-BR and gl-ES lang keys for style.p translations

### DIFF
--- a/lang/summernote-gl-ES.js
+++ b/lang/summernote-gl-ES.js
@@ -66,7 +66,7 @@
       },
       style: {
         style: 'Estilo',
-        normal: 'Normal',
+        p: 'Normal',
         blockquote: 'Cita',
         pre: 'Código',
         h1: 'Título 1',

--- a/lang/summernote-pt-BR.js
+++ b/lang/summernote-pt-BR.js
@@ -66,7 +66,7 @@
       },
       style: {
         style: 'Estilo',
-        normal: 'Normal',
+        p: 'Normal',
         blockquote: 'Citação',
         pre: 'Código',
         h1: 'Título 1',


### PR DESCRIPTION
#### What does this PR do?
Fix translations for `p` (normal text) style. In all but pt-br and gl-es the key is `p` while in these the key was incorrectly typed as `normal`

