### PR TITLE
Fixed display position issue for tooltips in Summernote Lite that can…

### DIFF
--- a/src/js/lite/ui/TooltipUI.js
+++ b/src/js/lite/ui/TooltipUI.js
@@ -37,7 +37,10 @@ class TooltipUI {
 
   show() {
     const $node = this.$node;
-    const offset = $node.offset();
+    const offset = {
+      top: $node.offset().top - $node.parents(this.options.container).offset().top,
+      left: $node.offset().left - $node.parents(this.options.container).offset().left
+    };
 
     const $tooltip = this.$tooltip;
     const title = this.options.title || $node.attr('title') || $node.data('title');

--- a/src/less/lite-ui/toolbar.less
+++ b/src/less/lite-ui/toolbar.less
@@ -1,4 +1,5 @@
 .note-toolbar {
   padding: 10px 5px;
   border-bottom: 1px solid #e2e2e2;
+  box-sizing:border-box
 }


### PR DESCRIPTION

#### What does this PR do?

- Fixed display position issue for tooltips in Summernote Lite that can occur if <body> is relative or absolute positioned.  Also modified toolbar css to fit properly inside of containers.

#### Where should the reviewer start?

- src/js/lite/ui/TooltipUI.js
- src/less/lite-ui/toolbar.less

#### How should this be manually tested?

- Put an instance of Summernote Lite in a document with a relatively positioned body that's smaller than the width of the document.  The current version would calculate the offset of the tooltip based on the whole document but the offset would naturally be applied to the position of the <body> element, meaning if the body is not the same width as the document, the tooltip will be too far to the right.  My modifications take into account the offset of <body> from the document and subtract it to account for this difference.  You can compare the two versions and hover over the buttons to see the difference in tooltip positioning.

#### Any background context you want to provide?

- This is my first pull request ever and I have no idea what I'm doing.  Please feel free to thoroughly correct me on anything and everything I'm doing wrong.
- I wasn't able to compile the css with npm.  I ran npm run dist but it encountered an error at some point. npm run build ran fine.

#### What are the relevant tickets?

- I listed this as well as my fix in issue #2910 but I decided to try implementing it myself.  

#### Screenshot (if for frontend)
Image of bug:
![image](https://user-images.githubusercontent.com/12435739/43556691-af1e4c5e-95c6-11e8-9758-aa7a8f58f181.png)
Image of the fix:
![image](https://user-images.githubusercontent.com/12435739/43558793-d60ac004-95d0-11e8-9670-9091af47e96c.png)