### PR TITLE
Fix wrong arguments result due to the use of incorrect function type

### DIFF
--- a/src/js/base/core/func.js
+++ b/src/js/base/core/func.js
@@ -31,7 +31,7 @@ function fail() {
 }
 
 function not(f) {
-  return () => {
+  return function() {
     return !f.apply(f, arguments);
   };
 }
@@ -47,7 +47,7 @@ function self(a) {
 }
 
 function invoke(obj, method) {
-  return () => {
+  return function() {
     return obj[method].apply(obj, arguments);
   };
 }
@@ -126,7 +126,7 @@ function namespaceToCamel(namespace, prefix) {
  */
 function debounce(func, wait, immediate) {
   let timeout;
-  return () => {
+  return function() {
     const context = this;
     const args = arguments;
     const later = () => {

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -577,7 +577,7 @@ export default class Editor {
    * run given function between beforeCommand and afterCommand
    */
   wrapCommand(fn) {
-    return () => {
+    return function() {
       this.beforeCommand();
       fn.apply(this, arguments);
       this.afterCommand();

--- a/src/js/base/renderer.js
+++ b/src/js/base/renderer.js
@@ -54,7 +54,7 @@ class Renderer {
 
 export default {
   create: (markup, callback) => {
-    return () => {
+    return function() {
       const options = typeof arguments[1] === 'object' ? arguments[1] : arguments[0];
       let children = $.isArray(arguments[0]) ? arguments[0] : [];
       if (options && options.children) {


### PR DESCRIPTION
#### What does this PR do?

- Fix wrong usage of `arguments` in the arrow function

#### Where should the reviewer start?

- src/js/base/core/func.js
- src/js/base/module/Editor.js
- src/js/base/renderer.js

#### How should this be manually tested?

- Successfully compile and initialize under webpack

#### Any background context you want to provide?

- the arrow function does not have it's own `arguments`, in webpack with hot reload, the `arguments` result in wrong parameters.

#### What are the relevant tickets?
issue #2930

#### Screenshot (if for frontend)
None

### Checklist
None
