### PR TITLE
Allow relative URL

### DIFF
--- a/lang/summernote-gl-ES.js
+++ b/lang/summernote-gl-ES.js
@@ -66,7 +66,7 @@
       },
       style: {
         style: 'Estilo',
-        normal: 'Normal',
+        p: 'Normal',
         blockquote: 'Cita',
         pre: 'Código',
         h1: 'Título 1',

--- a/lang/summernote-pt-BR.js
+++ b/lang/summernote-pt-BR.js
@@ -66,7 +66,7 @@
       },
       style: {
         style: 'Estilo',
-        normal: 'Normal',
+        p: 'Normal',
         blockquote: 'Citação',
         pre: 'Código',
         h1: 'Título 1',

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -196,9 +196,12 @@ export default class Editor {
       if (this.options.onCreateLink) {
         linkUrl = this.options.onCreateLink(linkUrl);
       } else {
-        // if url doesn't match an URL schema, set http:// as default
-        linkUrl = /^[A-Za-z][A-Za-z0-9+-.]*\:[\/\/]?/.test(linkUrl)
-          ? linkUrl : 'http://' + linkUrl;
+        // if url is not relative,
+        if (!/^\.?\/(.*)/.test(linkUrl)) {
+          // if url doesn't match an URL schema, set http:// as default
+          linkUrl = /^[A-Za-z][A-Za-z0-9+-.]*\:[\/\/]?/.test(linkUrl)
+            ? linkUrl : 'http://' + linkUrl;
+        }
       }
 
       let anchors = [];
@@ -726,8 +729,9 @@ export default class Editor {
       url: $anchor.length ? $anchor.attr('href') : ''
     };
 
-    // Define isNewWindow when anchor exists.
+    // When anchor exists,
     if ($anchor.length) {
+      // Set isNewWindow by checking its target.
       linkInfo.isNewWindow = $anchor.attr('target') === '_blank';
     }
 

--- a/src/js/base/module/LinkDialog.js
+++ b/src/js/base/module/LinkDialog.js
@@ -80,7 +80,7 @@ export default class LinkDialog {
       const $linkText = this.$dialog.find('.note-link-text');
       const $linkUrl = this.$dialog.find('.note-link-url');
       const $linkBtn = this.$dialog.find('.note-link-btn');
-      const $openInNewWindow = this.$dialog.find('input[type=checkbox]');
+      const $openInNewWindow = this.$dialog.find('#sn-checkbox-open-in-new-window');
 
       this.ui.onDialogShown(this.$dialog, () => {
         this.context.triggerEvent('dialog.shown');
@@ -124,10 +124,10 @@ export default class LinkDialog {
         this.bindEnterKey($linkUrl, $linkBtn);
         this.bindEnterKey($linkText, $linkBtn);
 
-        const isChecked = linkInfo.isNewWindow !== undefined
+        const isNewWindowChecked = linkInfo.isNewWindow !== undefined
           ? linkInfo.isNewWindow : this.context.options.linkTargetBlank;
 
-        $openInNewWindow.prop('checked', isChecked);
+        $openInNewWindow.prop('checked', isNewWindowChecked);
 
         $linkBtn.one('click', (event) => {
           event.preventDefault();

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -105,6 +105,7 @@ $.summernote = $.extend($.summernote, {
 
     width: null,
     height: null,
+    linkTargetBlank: true,
 
     focus: false,
     tabSize: 4,

--- a/test/unit/base/module/Editor.spec.js
+++ b/test/unit/base/module/Editor.spec.js
@@ -371,6 +371,26 @@ describe('Editor', () => {
       expectContents(context, '<p><a href="http://summernote.org" target="_blank">summernote</a></p>');
     });
 
+    it('should create a relative link without scheme', () => {
+      var text = 'hello';
+      var editable = context.layoutInfo.editable;
+      var pNode = editable.find('p')[0];
+      var textNode = pNode.childNodes[0];
+      var startIndex = textNode.wholeText.indexOf(text);
+      var endIndex = startIndex + text.length;
+
+      var rng = range.create(textNode, startIndex, textNode, endIndex);
+
+      editor.createLink({
+        url: '/relative/url',
+        text: 'summernote',
+        range: rng,
+        isNewWindow: true
+      });
+
+      expectContents(context, '<p><a href="/relative/url" target="_blank">summernote</a></p>');
+    });
+
     it('should modify a link', () => {
       context.invoke('code', '<p><a href="http://summernote.org">hello world</a></p>');
 

--- a/test/unit/base/module/LinkDialog.spec.js
+++ b/test/unit/base/module/LinkDialog.spec.js
@@ -1,0 +1,56 @@
+/**
+ * LinkDialog.spec.js
+ * (c) 2015~ Summernote Team
+ * summernote may be freely distributed under the MIT license./
+ */
+import chai from 'chai';
+import $ from 'jquery';
+import range from '../../../../src/js/base/core/range';
+import Context from '../../../../src/js/base/Context';
+import LinkDialog from '../../../../src/js/base/module/LinkDialog';
+
+var expect = chai.expect;
+
+describe('bs:module.LinkDialog', () => {
+  var context, dialog, $editable;
+
+  beforeEach(() => {
+    var options = $.extend({}, $.summernote.options);
+    options.langInfo = $.extend(true, {}, $.summernote.lang['en-US'], $.summernote.lang[options.lang]);
+    options.toolbar = [
+      ['insert', ['link']]
+    ];
+    context = new Context(
+      $('<div>' +
+        '<p><a href="https://summernote.org/" target="_blank">hello</a></p>' +
+        '<p><a href="https://summernote.org/">world</a></p>' +
+        '</div>'),
+      options
+    );
+    context.initialize();
+
+    dialog = new LinkDialog(context);
+    dialog.initialize();
+
+    $editable = context.layoutInfo.editable;
+    $editable.appendTo('body');
+  });
+
+  describe('LinkDialog', () => {
+    it('should check new window when target=_blank', () => {
+      range.createFromNode($editable.find('a')[0]).normalize().select();
+      dialog.show();
+
+      var checked = dialog.$dialog.find('#sn-checkbox-open-in-new-window').is(':checked');
+      expect(checked).to.be.true;
+    });
+
+    it('should uncheck new window without target=_blank', () => {
+      range.createFromNode($editable.find('a')[1]).normalize().select();
+      dialog.show();
+
+      var checked = dialog.$dialog.find('#sn-checkbox-open-in-new-window').is(':checked');
+      expect(checked).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?

- Add a checkbox for relative urls in the link creation dialog

#### Where should the reviewer start?

- src/js/base/module/Editor.js
- src/js/base/module/LinkDialog.js

#### How should this be manually tested?

- Create links with or without relative URL checkbox.

#### Any background context you want to provide?

- Many users have requested to allow relative URLs in the link creation dialog. But every time we just told them to customize `editor.createLink. I thought this is very common usage - should be built in summernote by default.

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/2022
- https://github.com/summernote/summernote/issues/2922
- and so on

#### Screenshot (if for frontend)

<img width="770" alt="screen shot 2018-08-21 at 2 42 56 pm" src="https://user-images.githubusercontent.com/579366/44382596-8577fc80-a550-11e8-8136-47a854d4a1df.png">


### Checklist
- [x] added relevant tests
- [x] didn't break anything
