### PR TITLE
Fix link autodetection

### DIFF
--- a/src/js/base/module/AutoLink.js
+++ b/src/js/base/module/AutoLink.js
@@ -3,7 +3,7 @@ import lists from '../core/lists';
 import key from '../core/key';
 
 const defaultScheme = 'http://';
-const linkPattern = /^([A-Za-z][A-Za-z0-9+-.]*\:[\/\/]?|mailto:[A-Z0-9._%+-]+@)?(www\.)?(.+)$/i;
+const linkPattern = /^([A-Za-z][A-Za-z0-9+-.]*\:[\/]{2}|mailto:[A-Z0-9._%+-]+@)?(www\.)?(.+)$/i;
 
 export default class AutoLink {
   constructor(context) {


### PR DESCRIPTION
#### What does this PR do?

- Fixes #2753
- Allows for any kind of protocols to be written and used to create a link, as long as there are exactly 2 /-characters

#### Where should the reviewer start?

- start on the src/js/base/module/AutoLink.js

#### How should this be manually tested?

- As described in #2753 

#### Any background context you want to provide?

- No additional context to provide

#### What are the relevant tickets?

#2753 

#### Screenshot (if for frontend)
Prior:
![image](https://user-images.githubusercontent.com/16817737/44403136-510a3d80-a55c-11e8-9a16-44cc5b0ab7be.png)

End result:
![image](https://user-images.githubusercontent.com/16817737/44402640-148a1200-a55b-11e8-876e-16d6d4e578b5.png)


### Checklist
- [x] didn't break anything