### PR TITLE
Add styles for custom color selection

### DIFF
--- a/src/less/summernote-bs4.less
+++ b/src/less/summernote-bs4.less
@@ -348,7 +348,8 @@
           border-bottom: 1px solid #eee;
         }
 
-        .note-color-reset {
+        .note-color-reset,
+        .note-color-select {
           margin: 3px;
           padding: 0 3px;
           width: 100%;
@@ -363,6 +364,16 @@
 
         .note-color-reset:hover {
           background: #eee;
+        }
+
+        .note-color-select-btn {
+          display: none;
+        }
+
+        .note-holder-custom {
+          .note-color-btn {
+            border: 1px solid #eee;
+          }
         }
       }
     }

--- a/src/less/summernote-bs4.scss
+++ b/src/less/summernote-bs4.scss
@@ -339,7 +339,8 @@ $img-margin-right: 10px;
           border-bottom: 1px solid #eee;
         }
 
-        .note-color-reset {
+        .note-color-reset,
+        .note-color-select {
           font-size: 11px;
           margin: 3px;
           padding: 0 3px;
@@ -353,6 +354,16 @@ $img-margin-right: 10px;
 
         .note-color-reset:hover {
           background: #eee;
+        }
+
+        .note-color-select-btn {
+          display: none;
+        }
+
+        .note-holder-custom {
+          .note-color-btn {
+            border: 1px solid #eee;
+          }
         }
       }
     }

--- a/src/less/summernote-lite.less
+++ b/src/less/summernote-lite.less
@@ -363,7 +363,8 @@
           border-bottom: 1px solid #eee;
         }
 
-        .note-color-reset {
+        .note-color-reset,
+        .note-color-select {
           margin: 3px;
           padding: 2px 3px;
           width: 100%;
@@ -379,6 +380,16 @@
 
         .note-color-reset:hover {
           background: #eee;
+        }
+
+        .note-color-select-btn {
+          display: none;
+        }
+
+        .note-holder-custom {
+          .note-color-btn {
+            border: 1px solid #eee;
+          }
         }
       }
     }

--- a/src/less/summernote.scss
+++ b/src/less/summernote.scss
@@ -339,7 +339,8 @@ $img-margin-right: 10px;
           border-bottom: 1px solid #eee;
         }
 
-        .note-color-reset {
+        .note-color-reset,
+        .note-color-select {
           font-size: 11px;
           margin: 3px;
           padding: 0 3px;
@@ -353,6 +354,16 @@ $img-margin-right: 10px;
 
         .note-color-reset:hover {
           background: #eee;
+        }
+
+        .note-color-select-btn {
+          display: none;
+        }
+
+        .note-holder-custom {
+          .note-color-btn {
+            border: 1px solid #eee;
+          }
         }
       }
     }


### PR DESCRIPTION
#### What does this PR do?

- #2936 missed some `less`/`scss` styles for custom color selection.

#### Where should the reviewer start?

- Updated scss/less files in `src/less/`.

#### How should this be manually tested?

- Run summernote with bs4 and lite theme.

#### What are the relevant tickets?

- #2936 

#### Screenshot (if for frontend)
<img width="860" alt="screen shot 2018-08-28 at 4 55 00 pm" src="https://user-images.githubusercontent.com/579366/44708852-259acc00-aae3-11e8-95ed-7122e9458ee9.png">
<img width="1015" alt="screen shot 2018-08-28 at 4 54 35 pm" src="https://user-images.githubusercontent.com/579366/44708853-26336280-aae3-11e8-8d97-ae290fec0926.png">

### Checklist
- [ ] added relevant tests
- [x] didn't break anything
