### PR TITLE
Add forecolor and backcolor buttons

### DIFF
--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -69,6 +69,161 @@ export default class Buttons {
     return ((name !== '') && this.isFontInstalled(name) && ($.inArray(name, genericFamilies) === -1));
   }
 
+  colorPalette(className, tooltip, backColor, foreColor) {
+    return this.ui.buttonGroup({
+      className: 'note-color ' + className,
+      children: [
+        this.button({
+          className: 'note-current-color-button',
+          contents: this.ui.icon(this.options.icons.font + ' note-recent-color'),
+          tooltip: tooltip,
+          click: (e) => {
+            const $button = $(e.currentTarget);
+            if (backColor && foreColor) {
+              this.context.invoke('editor.color', {
+                backColor: $button.attr('data-backColor'),
+                foreColor: $button.attr('data-foreColor')
+              });
+            } else if (backColor) {
+              this.context.invoke('editor.color', {
+                backColor: $button.attr('data-backColor')
+              });
+            } else if (foreColor) {
+              this.context.invoke('editor.color', {
+                foreColor: $button.attr('data-foreColor')
+              });
+            }
+          },
+          callback: ($button) => {
+            const $recentColor = $button.find('.note-recent-color');
+            if (backColor) {
+              $recentColor.css('background-color', '#FFFF00');
+              $button.attr('data-backColor', '#FFFF00');
+            }
+            if (!foreColor) {
+              $recentColor.css('color', 'transparent');
+            }
+          }
+        }),
+        this.button({
+          className: 'dropdown-toggle',
+          contents: this.ui.dropdownButtonContents('', this.options),
+          tooltip: this.lang.color.more,
+          data: {
+            toggle: 'dropdown'
+          }
+        }),
+        this.ui.dropdown({
+          items: (backColor ? [
+            '<div class="note-palette">',
+            '  <div class="note-palette-title">' + this.lang.color.background + '</div>',
+            '  <div>',
+            '    <button type="button" class="note-color-reset btn btn-light" data-event="backColor" data-value="inherit">',
+            this.lang.color.transparent,
+            '    </button>',
+            '  </div>',
+            '  <div class="note-holder" data-event="backColor"/>',
+            '  <div>',
+            '    <button type="button" class="note-color-select btn" data-event="openPalette" data-value="backColorPicker">',
+            this.lang.color.cpSelect,
+            '    </button>',
+            '    <input type="color" id="backColorPicker" class="note-btn note-color-select-btn" value="#FFFF00" data-event="backColorPalette">',
+            '  </div>',
+            '  <div class="note-holder-custom" id="backColorPalette" data-event="backColor"/>',
+            '</div>'
+          ].join('') : '') +
+          (foreColor ? [
+            '<div class="note-palette">',
+            '  <div class="note-palette-title">' + this.lang.color.foreground + '</div>',
+            '  <div>',
+            '    <button type="button" class="note-color-reset btn btn-light" data-event="removeFormat" data-value="foreColor">',
+            this.lang.color.resetToDefault,
+            '    </button>',
+            '  </div>',
+            '  <div class="note-holder" data-event="foreColor"/>',
+            '  <div>',
+            '    <button type="button" class="note-color-select btn" data-event="openPalette" data-value="foreColorPicker">',
+            this.lang.color.cpSelect,
+            '    </button>',
+            '    <input type="color" id="foreColorPicker" class="note-btn note-color-select-btn" value="#000000" data-event="foreColorPalette">',
+            '  <div class="note-holder-custom" id="foreColorPalette" data-event="foreColor"/>',
+            '</div>'
+          ].join('') : ''),
+          callback: ($dropdown) => {
+            $dropdown.find('.note-holder').each((idx, item) => {
+              const $holder = $(item);
+              $holder.append(this.ui.palette({
+                colors: this.options.colors,
+                colorsName: this.options.colorsName,
+                eventName: $holder.data('event'),
+                container: this.options.container,
+                tooltip: this.options.tooltip
+              }).render());
+            });
+            /* TODO: do we have to record recent custom colors within cookies? */
+            var customColors = [
+              ['#FFFFFF', '#FFFFFF', '#FFFFFF', '#FFFFFF', '#FFFFFF', '#FFFFFF', '#FFFFFF', '#FFFFFF']
+            ];
+            $dropdown.find('.note-holder-custom').each((idx, item) => {
+              const $holder = $(item);
+              $holder.append(this.ui.palette({
+                colors: customColors,
+                colorsName: customColors,
+                eventName: $holder.data('event'),
+                container: this.options.container,
+                tooltip: this.options.tooltip
+              }).render());
+            });
+            $dropdown.find('input[type=color]').each((idx, item) => {
+              $(item).change(function() {
+                const $chip = $dropdown.find('#' + $(this).data('event')).find('.note-color-btn').first();
+                const color = this.value.toUpperCase();
+                $chip.css('background-color', color)
+                  .attr('aria-label', color)
+                  .attr('data-value', color)
+                  .attr('data-original-title', color);
+                $chip.click();
+              });
+            });
+          },
+          click: (event) => {
+            event.stopPropagation();
+
+            const $parent = $('.' + className);
+            const $button = $(event.target);
+            const eventName = $button.data('event');
+            let value = $button.attr('data-value');
+
+            if (eventName === 'openPalette') {
+              const $picker = $parent.find('#' + value);
+              const $palette = $($parent.find('#' + $picker.data('event')).find('.note-color-row')[0]);
+
+              // Shift palette chips
+              const $chip = $palette.find('.note-color-btn').last().detach();
+
+              // Set chip attributes
+              const color = $picker.val();
+              $chip.css('background-color', color)
+                .attr('aria-label', color)
+                .attr('data-value', color)
+                .attr('data-original-title', color);
+              $palette.prepend($chip);
+              $picker.click();
+            } else if (lists.contains(['backColor', 'foreColor'], eventName)) {
+              const key = eventName === 'backColor' ? 'background-color' : 'color';
+              const $color = $button.closest('.note-color').find('.note-recent-color');
+              const $currentButton = $button.closest('.note-color').find('.note-current-color-button');
+
+              $color.css(key, value);
+              $currentButton.attr('data-' + eventName, value);
+              this.context.invoke('editor.' + eventName, value);
+            }
+          }
+        })
+      ]
+    }).render();
+  }
+
   addToolbarButtons() {
     this.context.memo('button.style', () => {
       return this.ui.buttonGroup([
@@ -236,140 +391,15 @@ export default class Buttons {
     });
 
     this.context.memo('button.color', () => {
-      return this.ui.buttonGroup({
-        className: 'note-color',
-        children: [
-          this.button({
-            className: 'note-current-color-button',
-            contents: this.ui.icon(this.options.icons.font + ' note-recent-color'),
-            tooltip: this.lang.color.recent,
-            click: (e) => {
-              const $button = $(e.currentTarget);
-              this.context.invoke('editor.color', {
-                backColor: $button.attr('data-backColor'),
-                foreColor: $button.attr('data-foreColor')
-              });
-            },
-            callback: ($button) => {
-              const $recentColor = $button.find('.note-recent-color');
-              $recentColor.css('background-color', '#FFFF00');
-              $button.attr('data-backColor', '#FFFF00');
-            }
-          }),
-          this.button({
-            className: 'dropdown-toggle',
-            contents: this.ui.dropdownButtonContents('', this.options),
-            tooltip: this.lang.color.more,
-            data: {
-              toggle: 'dropdown'
-            }
-          }),
-          this.ui.dropdown({
-            items: [
-              '<div class="note-palette">',
-              '  <div class="note-palette-title">' + this.lang.color.background + '</div>',
-              '  <div>',
-              '    <button type="button" class="note-color-reset btn btn-light" data-event="backColor" data-value="inherit">',
-              this.lang.color.transparent,
-              '    </button>',
-              '  </div>',
-              '  <div class="note-holder" data-event="backColor"/>',
-              '  <div>',
-              '    <button type="button" class="note-color-select btn" data-event="openPalette" data-value="backColorPicker">',
-              this.lang.color.cpSelect,
-              '    </button>',
-              '    <input type="color" id="backColorPicker" class="note-btn note-color-select-btn" value="#FFFF00" data-event="backColorPalette">',
-              '  </div>',
-              '  <div class="note-holder-custom" id="backColorPalette" data-event="backColor"/>',
-              '</div>',
-              '<div class="note-palette">',
-              '  <div class="note-palette-title">' + this.lang.color.foreground + '</div>',
-              '  <div>',
-              '    <button type="button" class="note-color-reset btn btn-light" data-event="removeFormat" data-value="foreColor">',
-              this.lang.color.resetToDefault,
-              '    </button>',
-              '  </div>',
-              '  <div class="note-holder" data-event="foreColor"/>',
-              '  <div>',
-              '    <button type="button" class="note-color-select btn" data-event="openPalette" data-value="foreColorPicker">',
-              this.lang.color.cpSelect,
-              '    </button>',
-              '    <input type="color" id="foreColorPicker" class="note-btn note-color-select-btn" value="#000000" data-event="foreColorPalette">',
-              '  <div class="note-holder-custom" id="foreColorPalette" data-event="foreColor"/>',
-              '</div>'
-            ].join(''),
-            callback: ($dropdown) => {
-              $dropdown.find('.note-holder').each((idx, item) => {
-                const $holder = $(item);
-                $holder.append(this.ui.palette({
-                  colors: this.options.colors,
-                  colorsName: this.options.colorsName,
-                  eventName: $holder.data('event'),
-                  container: this.options.container,
-                  tooltip: this.options.tooltip
-                }).render());
-              });
-              /* TODO: do we have to record recent custom colors within cookies? */
-              var customColors = [
-                ['#FFFFFF', '#FFFFFF', '#FFFFFF', '#FFFFFF', '#FFFFFF', '#FFFFFF', '#FFFFFF', '#FFFFFF']
-              ];
-              $dropdown.find('.note-holder-custom').each((idx, item) => {
-                const $holder = $(item);
-                $holder.append(this.ui.palette({
-                  colors: customColors,
-                  colorsName: customColors,
-                  eventName: $holder.data('event'),
-                  container: this.options.container,
-                  tooltip: this.options.tooltip
-                }).render());
-              });
-              $dropdown.find('input[type=color]').each((idx, item) => {
-                $(item).change(function() {
-                  const $chip = $('#' + $(this).data('event')).find('.note-color-btn').first();
-                  const color = this.value.toUpperCase();
-                  $chip.css('background-color', color)
-                    .attr('aria-label', color)
-                    .attr('data-value', color)
-                    .attr('data-original-title', color);
-                  $chip.click();
-                });
-              });
-            },
-            click: (event) => {
-              event.stopPropagation();
+      return this.colorPalette('note-color-all', this.lang.color.recent, true, true);
+    });
 
-              const $button = $(event.target);
-              const eventName = $button.data('event');
-              let value = $button.attr('data-value');
+    this.context.memo('button.forecolor', () => {
+      return this.colorPalette('note-color-fore', this.lang.color.foreground, false, true);
+    });
 
-              if (eventName === 'openPalette') {
-                const $picker = $('#' + value);
-                const $palette = $($('#' + $picker.data('event')).find('.note-color-row')[0]);
-
-                // Shift palette chips
-                const $chip = $palette.find('.note-color-btn').last().detach();
-
-                // Set chip attributes
-                const color = $picker.val();
-                $chip.css('background-color', color)
-                  .attr('aria-label', color)
-                  .attr('data-value', color)
-                  .attr('data-original-title', color);
-                $palette.prepend($chip);
-                $picker.click();
-              } else if (lists.contains(['backColor', 'foreColor'], eventName)) {
-                const key = eventName === 'backColor' ? 'background-color' : 'color';
-                const $color = $button.closest('.note-color').find('.note-recent-color');
-                const $currentButton = $button.closest('.note-color').find('.note-current-color-button');
-
-                $color.css(key, value);
-                $currentButton.attr('data-' + eventName, value);
-                this.context.invoke('editor.' + eventName, value);
-              }
-            }
-          })
-        ]
-      }).render();
+    this.context.memo('button.backcolor', () => {
+      return this.colorPalette('note-color-back', this.lang.color.background, true, false);
     });
 
     this.context.memo('button.ul', () => {

--- a/src/less/summernote-bs4.less
+++ b/src/less/summernote-bs4.less
@@ -326,13 +326,18 @@
     }
   }
 
+  .note-color-all {
+    .dropdown-menu {
+      min-width: 337px;
+    }
+  }
+
   .note-color {
     .dropdown-toggle {
       width: 20px;
       padding-left: 5px;
     }
     .dropdown-menu {
-      min-width: 337px;
       .note-palette {
         display: inline-block;
         margin: 0;

--- a/src/less/summernote-bs4.scss
+++ b/src/less/summernote-bs4.scss
@@ -319,13 +319,18 @@ $img-margin-right: 10px;
     }
   }
 
+  .note-color-all {
+    .dropdown-menu {
+      min-width: 337px;
+    }
+  }
+
   .note-color {
     .dropdown-toggle {
       width: 20px;
       padding-left: 5px;
     }
     .dropdown-menu {
-      min-width: 340px;
       .btn-group {
         margin: 0;
         &:first-child {

--- a/src/less/summernote-lite.less
+++ b/src/less/summernote-lite.less
@@ -337,6 +337,12 @@
     }
   }
 
+  .note-color-all {
+    .dropdown-menu {
+      min-width: 346px;
+    }
+  }
+
   .note-color {
     .dropdown-toggle {
       width: 20px;
@@ -346,7 +352,6 @@
       -webkit-box-sizing: content-box;
          -moz-box-sizing: content-box;
               box-sizing: content-box;
-      min-width: 346px;
       .note-palette {
         display: inline-block;
         margin: 0;

--- a/src/less/summernote.less
+++ b/src/less/summernote.less
@@ -325,13 +325,18 @@
     }
   }
 
+  .note-color-all {
+    .dropdown-menu {
+      min-width: 337px;
+    }
+  }
+
   .note-color {
     .dropdown-toggle {
       width: 20px;
       padding-left: 5px;
     }
     .dropdown-menu {
-      min-width: 337px;
       .note-palette {
         display: inline-block;
         margin: 0;

--- a/src/less/summernote.scss
+++ b/src/less/summernote.scss
@@ -319,13 +319,18 @@ $img-margin-right: 10px;
     }
   }
 
+  .note-color-all {
+    .dropdown-menu {
+      min-width: 337px;
+    }
+  }
+
   .note-color {
     .dropdown-toggle {
       width: 20px;
       padding-left: 5px;
     }
     .dropdown-menu {
-      min-width: 340px;
       .btn-group {
         margin: 0;
         &:first-child {

--- a/test/unit/base/module/Buttons.spec.js
+++ b/test/unit/base/module/Buttons.spec.js
@@ -25,7 +25,7 @@ describe('Buttons', () => {
       ['font1', ['style', 'clear']],
       ['font2', ['bold', 'underline', 'italic', 'superscript', 'subscript', 'strikethrough']],
       ['font3', ['fontname', 'fontsize']],
-      ['color', ['color']],
+      ['color', ['color', 'forecolor', 'backcolor']],
       ['para', ['ul', 'ol', 'paragraph']],
       ['table', ['table']],
       ['insert', ['link', 'picture', 'video']],
@@ -181,22 +181,22 @@ describe('Buttons', () => {
     });
   });
 
-  describe('recent color button', () => {
+  describe('recent color button in all color button', () => {
     it('should execute color command when it is clicked', () => {
       range.createFromNode($editable.find('p')[0]).normalize().select();
 
-      $toolbar.find('.note-current-color-button').click();
+      $toolbar.find('.note-color-all').find('.note-current-color-button').click();
 
       var $span = $editable.find('span');
       expect($span).to.be.equalsStyle('#FFFF00', 'background-color');
     });
   });
 
-  describe('fore color button', () => {
+  describe('fore color button in all color button', () => {
     it('should execute fore color command when it is clicked', () => {
       range.createFromNode($editable.find('p')[0]).normalize().select();
 
-      var $button = $toolbar.find('[data-event=foreColor]').eq(10);
+      var $button = $toolbar.find('.note-color-all').find('[data-event=foreColor]').eq(10);
       $button.click();
 
       var $span = $editable.find('span');
@@ -204,11 +204,35 @@ describe('Buttons', () => {
     });
   });
 
-  describe('back color button', () => {
+  describe('back color button in all color button', () => {
     it('should execute back color command when it is clicked', () => {
       range.createFromNode($editable.find('p')[0]).normalize().select();
 
-      var $button = $toolbar.find('[data-event=backColor]').eq(10);
+      var $button = $toolbar.find('.note-color-all').find('[data-event=backColor]').eq(10);
+      $button.click();
+
+      var $span = $editable.find('span');
+      expect($span).to.be.equalsStyle($button.data('value'), 'background-color');
+    });
+  });
+
+  describe('color button in fore color button', () => {
+    it('should execute fore color command when it is clicked', () => {
+      range.createFromNode($editable.find('p')[0]).normalize().select();
+
+      var $button = $toolbar.find('.note-color-fore').find('[data-event=foreColor]').eq(4);
+      $button.click();
+
+      var $span = $editable.find('span');
+      expect($span).to.be.equalsStyle($button.data('value'), 'color');
+    });
+  });
+
+  describe('back color button in back color button', () => {
+    it('should execute back color command when it is clicked', () => {
+      range.createFromNode($editable.find('p')[0]).normalize().select();
+
+      var $button = $toolbar.find('.note-color-back').find('[data-event=backColor]').eq(20);
       $button.click();
 
       var $span = $editable.find('span');


### PR DESCRIPTION
#### What does this PR do?

- Add `forecolor` and `backcolor` as separated buttons from `color` button.

#### Where should the reviewer start?

- start on the `/src/js/base/module/Buttons.js`

#### How should this be manually tested?

- Run summernote locally and add `backcolor` and `forecolor` into the toolbar.

#### Any background context you want to provide?

- I tore the color palette and picking from the original `color` feature as a function. And I reused it for `forecolor` and `backcolor` in the same way.

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/742

#### Screenshot (if for frontend)
<img width="611" alt="screen shot 2018-08-29 at 12 04 34 pm" src="https://user-images.githubusercontent.com/579366/44762907-b88b4300-ab83-11e8-8885-257239436e95.png">


### Checklist
- [x] added relevant tests
- [x] didn't break anything
