### PR TITLE
[FIX] don't add 'http://' when create link for '#'

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -199,7 +199,7 @@ export default class Editor {
         // if url is not relative,
         if (!/^\.?\/(.*)/.test(linkUrl)) {
           // if url doesn't match an URL schema, set http:// as default
-          linkUrl = /^[A-Za-z][A-Za-z0-9+-.]*\:[\/\/]?/.test(linkUrl)
+          linkUrl = linkUrl === '#' || /^[A-Za-z][A-Za-z0-9+-.]*\:[\/\/]?/.test(linkUrl)
             ? linkUrl : 'http://' + linkUrl;
         }
       }

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -199,7 +199,7 @@ export default class Editor {
         // if url is not relative,
         if (!/^\.?\/(.*)/.test(linkUrl)) {
           // if url doesn't match an URL schema, set http:// as default
-          linkUrl = linkUrl === '#' || /^[A-Za-z][A-Za-z0-9+-.]*\:[\/\/]?/.test(linkUrl)
+          linkUrl = /^(#|\/|([A-Za-z][A-Za-z0-9+-.]*\:[\/\/]?)/.test(linkUrl)
             ? linkUrl : 'http://' + linkUrl;
         }
       }


### PR DESCRIPTION
#### What does this PR do?

fix: create link with '#' does not work, because summernote add 'http://'
