### PR TITLE
Fix #2399 Link Dialog: if no link url present, use empty string not l…

### DIFF
--- a/src/js/base/module/LinkDialog.js
+++ b/src/js/base/module/LinkDialog.js
@@ -85,9 +85,9 @@ export default class LinkDialog {
       this.ui.onDialogShown(this.$dialog, () => {
         this.context.triggerEvent('dialog.shown');
 
-        // if no url was given, copy text to url
+        // if no url was given, use empty string
         if (!linkInfo.url) {
-          linkInfo.url = linkInfo.text;
+          linkInfo.url = '';
         }
 
         $linkText.val(linkInfo.text);


### PR DESCRIPTION
…ink text

#### What does this PR do?

Fixes #2399 per steps to reproduce on that ticket i.e.

1. Enter text into editor
2. Highlight text and click on Link icon
3. Entered text is in both fields 

#### Where should the reviewer start?

- start on the src/js/base/module/LinkDialog.js

#### How should this be manually tested?

1. Enter text into editor
2. Highlight text and click on Link icon
3. Entered text is in Link text field only

#### Any background context you want to provide?

- none

#### What are the relevant tickets?

#2399 

#### Screenshot (if for frontend)

none

### Checklist
- [ ] added relevant tests
- [x ] didn't break anything
