### PR TITLE
Fix toolbar issues

### DIFF
--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -1,8 +1,8 @@
 import $ from 'jquery';
 import renderer from '../base/renderer';
 
-const editor = renderer.create('<div class="note-editor note-frame panel"/>');
-const toolbar = renderer.create('<div class="note-toolbar-wrapper panel-default"><div class="note-toolbar panel-heading" role="toolbar"></div></div>');
+const editor = renderer.create('<div class="note-editor note-frame panel panel-default"/>');
+const toolbar = renderer.create('<div class="note-toolbar panel-heading" role="toolbar"></div></div>');
 const editingArea = renderer.create('<div class="note-editing-area"/>');
 const codable = renderer.create('<textarea class="note-codable" role="textbox" aria-multiline="true"/>');
 const editable = renderer.create('<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>');

--- a/src/js/bs4/ui.js
+++ b/src/js/bs4/ui.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import renderer from '../base/renderer';
 
 const editor = renderer.create('<div class="note-editor note-frame card"/>');
-const toolbar = renderer.create('<div class="note-toolbar-wrapper"><div class="note-toolbar card-header" role="toolbar"></div></div>');
+const toolbar = renderer.create('<div class="note-toolbar card-header" role="toolbar"></div>');
 const editingArea = renderer.create('<div class="note-editing-area"/>');
 const codable = renderer.create('<textarea class="note-codable" role="textbox" aria-multiline="true"/>');
 const editable = renderer.create('<div class="note-editable card-block" contentEditable="true" role="textbox" aria-multiline="true"/>');


### PR DESCRIPTION
#### What does this PR do?

- Fix toolbar's fullscreen toggling issue on Bootstrap3.
- Fix wrong clipping problem on Bootstrap4.

#### Where should the reviewer start?

- `src/js/bs3/ui.js`
- `src/js/bs4/ui.js`

#### How should this be manually tested?

- For BS3, toggle full screen repeatedly.
- For BS4, type some text and scroll within the editor.

#### Screenshot (if for frontend)

Initial state of the toolbar on Bootstrap3.
<img width="748" alt="screen shot 2018-09-28 at 4 03 59 pm" src="https://user-images.githubusercontent.com/579366/46195314-f7f1ae80-c33e-11e8-9c95-b0a1c9b86e79.png">

Toggle full screen and back to WYSIWYG mode. Toolbar shade disappears.
<img width="746" alt="screen shot 2018-09-28 at 4 04 06 pm" src="https://user-images.githubusercontent.com/579366/46195323-ffb15300-c33e-11e8-99ba-9527371edae5.png">

Text are flooding over toolbar on Bootstrap4.
<img width="715" alt="screen shot 2018-09-28 at 4 42 14 pm" src="https://user-images.githubusercontent.com/579366/46195328-050e9d80-c33f-11e8-8877-7b2fa2f3c8cb.png">


### Checklist
- [ ] added relevant tests
- [x] didn't break anything