### PR TITLE
Generate valid html markup when indenting nested list items.

### DIFF
--- a/test/unit/base/module/Editor.spec.js
+++ b/test/unit/base/module/Editor.spec.js
@@ -140,7 +140,13 @@ describe('Editor', () => {
       expectContents(context, '<ol><li>hello</li></ol>');
 
       editor.indent();
-      expectContents(context, '<ol><ol><li>hello</li></ol></ol>');
+      expectContents(context, '<ol><li><ol><li>hello</li></ol></li></ol>');
+
+      editor.indent();
+      expectContents(context, '<ol><li><ol><li><ol><li>hello</li></ol></li></ol></li></ol>');
+
+      editor.outdent();
+      expectContents(context, '<ol><li><ol><li>hello</li></ol></li></ol>');
 
       editor.outdent();
       expectContents(context, '<ol><li>hello</li></ol>');


### PR DESCRIPTION
#### What does this PR do?

- fixes #2647 
- renders a valid html nested list when indenting/outdenting a list item
- indenting a list item now wraps the indented item in a new list `<ul>` || `<ol>` and appends it to the previous list item
- outdenting a nested list item, removes it from the nested list and inserts it after the parent `<li>`
- list items in nested list that were after the outdented item are removed, wrapped into a new list and appened to the outdented item.

#### Where should the reviewer start?

- start on the src/js/editing/Bullet.js

#### How should this be manually tested?

It should be possible now to use CSS counters to get a correct numbering on ordered lists.

Expected result:
```
1. One
  1.1 One-one
  1.2 One-two
    1.2.1 One-two-one
  1.3 One-three
2. Two
3. Three
```
Using Example CSS snippet:
```css
    ol { 
      counter-reset: ordered-item;
      list-style: none;
    }
    ol li { display: block; }
    ol li:not(:empty):before {
      content: counters(ordered-item, ".") ". ";
      counter-increment: ordered-item;
    }
```

#### What are the relevant tickets?

#2647

### Checklist
- [x] added relevant tests
- [x] didn't break non-list outdenting functionality
