### PR TITLE
Make AutoLink module follows linkTargetBlank option

### DIFF
--- a/src/js/base/module/AutoLink.js
+++ b/src/js/base/module/AutoLink.js
@@ -39,6 +39,9 @@ export default class AutoLink {
     if (match && (match[1] || match[2])) {
       const link = match[1] ? keyword : defaultScheme + keyword;
       const node = $('<a />').html(keyword).attr('href', link)[0];
+      if (this.context.options.linkTargetBlank) {
+        $(node).attr('target', '_blank');
+      }
 
       this.lastWordRange.insertNode(node);
       this.lastWordRange = null;


### PR DESCRIPTION
#### What does this PR do?

- `linkTargetBlank` affects `LinkDialog` module only.
- This makes `AutoLink` module follows `linkTargetBlank` option in same way.

#### Where should the reviewer start?

- `src/js/base/module/AutoLink.js`

#### How should this be manually tested?

- Type some URLs and check them has `target` attribute or not as well as `linkTargetBlank` defined.

#### What are the relevant tickets?

- #3009 

### Checklist
- [ ] added relevant tests
- [x] didn't break anything
