### PR TITLE
Fix ui.js problems

### DIFF
--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -19,8 +19,8 @@ const statusbar = renderer.create([
 
 const airEditor = renderer.create('<div class="note-editor"/>');
 const airEditable = renderer.create([
-  '  <output class="note-status-output" aria-live="polite"/>',
-  '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>'
+  '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>',
+  '<output class="note-status-output" aria-live="polite"/>'
 ].join(''));
 
 const buttonGroup = renderer.create('<div class="note-btn-group btn-group">');

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -167,7 +167,7 @@ const ui = {
           title: options.tooltip,
           'aria-label': options.tooltip
         }).tooltip({
-          container: options.container,
+          container: (options.container !== undefined) ? options.container : 'body',
           trigger: 'hover',
           placement: 'bottom'
         });

--- a/src/js/bs4/ui.js
+++ b/src/js/bs4/ui.js
@@ -169,7 +169,7 @@ const ui = {
           title: options.tooltip,
           'aria-label': options.tooltip
         }).tooltip({
-          container: options.container,
+          container: (options.container !== undefined) ? options.container : 'body',
           trigger: 'hover',
           placement: 'bottom'
         });

--- a/src/js/bs4/ui.js
+++ b/src/js/bs4/ui.js
@@ -20,8 +20,8 @@ const statusbar = renderer.create([
 
 const airEditor = renderer.create('<div class="note-editor"/>');
 const airEditable = renderer.create([
-  '<output class="note-status-output" aria-live="polite"/>',
-  '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>'
+  '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>',
+  '<output class="note-status-output" aria-live="polite"/>'
 ].join(''));
 
 const buttonGroup = renderer.create('<div class="note-btn-group btn-group">');

--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -21,8 +21,8 @@ const statusbar = renderer.create([
 
 const airEditor = renderer.create('<div class="note-editor"/>');
 const airEditable = renderer.create([
-  '<output class="note-status-output" role="status" aria-live="polite"/>',
-  '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>'
+  '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>',
+  '<output class="note-status-output" role="status" aria-live="polite"/>'
 ].join(''));
 
 const buttonGroup = renderer.create('<div class="note-btn-group">');


### PR DESCRIPTION
#### What does this PR do?

- Fix `ui.js` for setting the default container for external plugins.
- Fix order of Airmode elements.

#### Where should the reviewer start?

- start on each `ui.js`

#### Any background context you want to provide?

- Old `ui.js` did not occur an error while creating a button without `options.container`. So many external plugins could create their buttons with only a few parameters. But now we have to assign `options.container` to add tooltips per every button creation. I understood why `ui.js` needs `container` - because they don't have any context or options since they were refactored. But this breaks backward compatibilites with many external plugins and I think putting `body` as a default value is much better than letting them broken.

- After adding `status` (to show error messages for some features) area, Airmode has a 'gap' in front of the document. So I moved it to the end of the document.

#### Screenshot (if for frontend)

Before:
<img width="622" alt="screen shot 2018-11-13 at 3 21 49 pm" src="https://user-images.githubusercontent.com/579366/48394697-debe8900-e757-11e8-9e25-515a0184e43e.png">

After:
<img width="635" alt="screen shot 2018-11-13 at 3 21 20 pm" src="https://user-images.githubusercontent.com/579366/48394696-debe8900-e757-11e8-8c1d-bff4dffaf5eb.png">


### Checklist
- [x] didn't break anything