### PR TITLE
Allow HTML on the placeholder

### DIFF
--- a/examples/placeholder.html
+++ b/examples/placeholder.html
@@ -17,23 +17,21 @@
   <link rel="stylesheet" href="../dist/summernote-bs4.css">
   <script type="text/javascript" src="../dist/summernote-bs4.js"></script>
 
+  <link rel="stylesheet" href="example.css">
   <script type="text/javascript">
     $(document).ready(function() {
       $('.summernote').summernote({
         height: 300,
         tabsize: 2,
-        placeholder: 'Enter text here'
+        placeholder: '<b>Enter text here</b><br>... even with multi-line placeholder'
       });
     });
   </script>
 </head>
 <body>
-  <div class="container">
-    <h5>
-      <i class="note-icon-summernote"></i> Summernote
-      <span class="badge badge-pill badge-info">Bootstrap v4.1.3</span>
-    </h5>
-    <div class="summernote"></div>
-  </div>
+<div class="container">
+  <h1>Summernote with Placeholder</h1>
+  <div class="summernote"></div>
+</div>
 </body>
 </html>

--- a/src/js/base/module/Placeholder.js
+++ b/src/js/base/module/Placeholder.js
@@ -23,7 +23,7 @@ export default class Placeholder {
     this.$placeholder = $('<div class="note-placeholder">');
     this.$placeholder.on('click', () => {
       this.context.invoke('focus');
-    }).text(this.options.placeholder).prependTo(this.$editingArea);
+    }).html(this.options.placeholder).prependTo(this.$editingArea);
 
     this.update();
   }


### PR DESCRIPTION
#### What does this PR do?

- This allows using HTML tags on the placeholder.

#### Where should the reviewer start?

- `src/js/base/module/Placeholder.js`

#### How should this be manually tested?

- Run dev server and connect to `examples/placeholder.html`

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/2982

#### Screenshot (if for frontend)

<img width="699" alt="screen shot 2018-11-19 at 4 50 21 pm" src="https://user-images.githubusercontent.com/579366/48693247-2d6a9800-ec1c-11e8-8720-4cca5b2595a4.png">


### Checklist
- [ ] added relevant tests
- [x] didn't break anything