### PR TITLE
Add color options for color buttons

### DIFF
--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -97,10 +97,13 @@ export default class Buttons {
           callback: ($button) => {
             const $recentColor = $button.find('.note-recent-color');
             if (backColor) {
-              $recentColor.css('background-color', '#FFFF00');
-              $button.attr('data-backColor', '#FFFF00');
+              $recentColor.css('background-color', this.options.colorButton.backColor);
+              $button.attr('data-backColor', this.options.colorButton.backColor);
             }
-            if (!foreColor) {
+            if (foreColor) {
+              $recentColor.css('color', this.options.colorButton.foreColor);
+              $button.attr('data-foreColor', this.options.colorButton.foreColor);
+            } else {
               $recentColor.css('color', 'transparent');
             }
           }
@@ -127,7 +130,7 @@ export default class Buttons {
             '    <button type="button" class="note-color-select btn" data-event="openPalette" data-value="backColorPicker">',
             this.lang.color.cpSelect,
             '    </button>',
-            '    <input type="color" id="backColorPicker" class="note-btn note-color-select-btn" value="#FFFF00" data-event="backColorPalette">',
+            '    <input type="color" id="backColorPicker" class="note-btn note-color-select-btn" value="' + this.options.colorButton.backColor + '" data-event="backColorPalette">',
             '  </div>',
             '  <div class="note-holder-custom" id="backColorPalette" data-event="backColor"/>',
             '</div>'
@@ -145,7 +148,7 @@ export default class Buttons {
             '    <button type="button" class="note-color-select btn" data-event="openPalette" data-value="foreColorPicker">',
             this.lang.color.cpSelect,
             '    </button>',
-            '    <input type="color" id="foreColorPicker" class="note-btn note-color-select-btn" value="#000000" data-event="foreColorPalette">',
+            '    <input type="color" id="foreColorPicker" class="note-btn note-color-select-btn" value="' + this.options.colorButton.foreColor + '" data-event="foreColorPalette">',
             '  <div class="note-holder-custom" id="foreColorPalette" data-event="foreColor"/>',
             '</div>'
           ].join('') : ''),

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -155,6 +155,11 @@ $.summernote = $.extend($.summernote, {
       ['Rosewood', 'Cinnamon', 'Olive', 'Parsley', 'Tiber', 'Midnight Blue', 'Valentino', 'Loulou']
     ],
 
+    colorButton: {
+      foreColor: '#000000',
+      backColor: '#FFFF00'
+    },
+
     lineHeights: ['1.0', '1.2', '1.4', '1.5', '1.6', '1.8', '2.0', '3.0'],
 
     tableClassName: 'table table-bordered',

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -158,6 +158,11 @@ $.summernote = $.extend($.summernote, {
       ['Rosewood', 'Cinnamon', 'Olive', 'Parsley', 'Tiber', 'Midnight Blue', 'Valentino', 'Loulou']
     ],
 
+    colorButton: {
+      foreColor: '#000000',
+      backColor: '#FFFF00'
+    },
+
     lineHeights: ['1.0', '1.2', '1.4', '1.5', '1.6', '1.8', '2.0', '3.0'],
 
     tableClassName: 'table table-bordered',

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -152,6 +152,11 @@ $.summernote = $.extend($.summernote, {
       ['Rosewood', 'Cinnamon', 'Olive', 'Parsley', 'Tiber', 'Midnight Blue', 'Valentino', 'Loulou']
     ],
 
+    colorButton: {
+      foreColor: '#000000',
+      backColor: '#FFFF00'
+    },
+
     lineHeights: ['1.0', '1.2', '1.4', '1.5', '1.6', '1.8', '2.0', '3.0'],
 
     tableClassName: 'table table-bordered',


### PR DESCRIPTION
#### What does this PR do?

- This patch provides options for color buttons – `color`, `forecolor`, and `backcolor`.

#### Where should the reviewer start?

- `src/js/base/module/Buttons.js`

#### How should this be manually tested?

- Set below options to Summernote and check whether colors of `color` buttons changed or not.
```javascript
colorButton: {
  foreColor: '#FF0000',
  backColor: '#0000FF'
},
```
#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/2680

### Checklist
- [ ] added relevant tests
- [x] didn't break anything