### PR TITLE
Emptying URL field, in case of no URL in opening link dialog

### DIFF
--- a/src/js/base/core/func.js
+++ b/src/js/base/core/func.js
@@ -144,6 +144,16 @@ function debounce(func, wait, immediate) {
   };
 }
 
+/**
+ *
+ * @param {String} url
+ * @return {Boolean}
+ */
+function isValidUrl(url) {
+  const expression = /[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/gi;
+  return expression.test(url);
+}
+
 export default {
   eq,
   eq2,
@@ -158,5 +168,6 @@ export default {
   rect2bnd,
   invertObject,
   namespaceToCamel,
-  debounce
+  debounce,
+  isValidUrl
 };

--- a/src/js/base/module/LinkDialog.js
+++ b/src/js/base/module/LinkDialog.js
@@ -86,11 +86,6 @@ export default class LinkDialog {
       this.ui.onDialogShown(this.$dialog, () => {
         this.context.triggerEvent('dialog.shown');
 
-        // if no url was given, copy text to url
-        if (!linkInfo.url) {
-          linkInfo.url = linkInfo.text;
-        }
-
         $linkText.val(linkInfo.text);
 
         const handleLinkTextUpdate = () => {

--- a/src/js/base/module/LinkDialog.js
+++ b/src/js/base/module/LinkDialog.js
@@ -1,6 +1,7 @@
 import $ from 'jquery';
 import env from '../core/env';
 import key from '../core/key';
+import func from '../core/func';
 
 export default class LinkDialog {
   constructor(context) {
@@ -85,6 +86,11 @@ export default class LinkDialog {
 
       this.ui.onDialogShown(this.$dialog, () => {
         this.context.triggerEvent('dialog.shown');
+
+        // if no url was given and given text is valid URL then copy that into URL Field
+        if (!linkInfo.url && func.isValidUrl(linkInfo.text)) {
+          linkInfo.url = linkInfo.text;
+        }
 
         $linkText.val(linkInfo.text);
 


### PR DESCRIPTION
#### What does this PR do?

- This PR will empty the Link Modal URL field. Upon selecting any text and click on link button, if there is no URL then this will empty the URL field, before this, selected text was shown on URL field.

#### Where should the reviewer start?

- start on the src/js/base/module/LinkDialog.js

#### How should this be manually tested?

- Open the editor, select any text, then click on Link, A modal will appear having two fields, one for link text and second for URL, now the URL field should be empty only if there is no URL. Once url is add then every time it shows the URL in that field.


#### What are the relevant tickets?
this is related to #3021 

#### Screenshot (if for frontend)


### Checklist
- [ x ] didn't break anything