### PR TITLE
Replace font checking method to use canvas

### DIFF
--- a/src/js/base/core/env.js
+++ b/src/js/base/core/env.js
@@ -9,17 +9,17 @@ const isSupportAmd = typeof define === 'function' && define.amd; // eslint-disab
  */
 function isFontInstalled(fontName) {
   const testFontName = fontName === 'Comic Sans MS' ? 'Courier New' : 'Comic Sans MS';
-  const $tester = $('<div>').css({
-    position: 'absolute',
-    left: '-9999px',
-    top: '-9999px',
-    fontSize: '200px',
-  }).text('mmmmmmmmmwwwwwww').appendTo(document.body);
+  const testText = 'mmmmmmmmmmwwwww';
+  const testSize = '200px';
 
-  const originalWidth = $tester.css('fontFamily', testFontName).width();
-  const width = $tester.css('fontFamily', fontName + ',' + testFontName).width();
+  var canvas = document.createElement('canvas');
+  var context = canvas.getContext('2d');
 
-  $tester.remove();
+  context.font = testSize + " '" + testFontName + "'";
+  const originalWidth = context.measureText(testText).width;
+
+  context.font = testSize + " '" + fontName + "', '" + testFontName + "'";
+  const width = context.measureText(testText).width;
 
   return originalWidth !== width;
 }


### PR DESCRIPTION
#### What does this PR do?

- This reduces the total amount of time for checking font installations.

#### Where should the reviewer start?

- start on the `src/base/core/env.js`

#### How should this be manually tested?

- Record performance and track down the time consumed.

#### Any background context you want to provide?

- While investigating https://github.com/summernote/summernote/issues/3058, I found we could use `canvas.context.measureText`. Its performance is about 10x for most envs. You can check out the benchmark on https://codepen.io/lqez/pen/OaaNGj.
- This could not be ran on IE8, but we already dropped it.

#### What are the relevant tickets?

- #3058 

#### Screenshot (if for frontend)

In my case, it reduced from `66.3ms` to `10.5 ms`.

Using CSS / `width()`
<img width="605" alt="screen shot 2018-11-29 at 4 34 41 pm" src="https://user-images.githubusercontent.com/579366/49209966-3e2ac300-f3ff-11e8-93a3-047360383df1.png">

Using canvas / `context.measureText()`
<img width="689" alt="screen shot 2018-11-29 at 5 39 27 pm" src="https://user-images.githubusercontent.com/579366/49209967-3ec35980-f3ff-11e8-9bbc-761a0dfee561.png">


### Checklist
- [x] didn't break anything