### PR TITLE
Hide the tooltip when buttons are clicked

### DIFF
--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -170,6 +170,8 @@ const ui = {
           container: (options.container !== undefined) ? options.container : 'body',
           trigger: 'hover',
           placement: 'bottom',
+        }).on('click', (e) => {
+          $(e.currentTarget).tooltip('hide');
         });
       }
     })($node, options);

--- a/src/js/bs4/ui.js
+++ b/src/js/bs4/ui.js
@@ -172,6 +172,8 @@ const ui = {
           container: (options.container !== undefined) ? options.container : 'body',
           trigger: 'hover',
           placement: 'bottom',
+        }).on('click', (e) => {
+          $(e.currentTarget).tooltip('hide');
         });
       }
     })($node, options);

--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -35,7 +35,9 @@ const button = renderer.create('<button type="button" class="note-btn" role="but
     $node.data('_lite_tooltip', new TooltipUI($node, {
       title: options.tooltip,
       container: options.container,
-    }));
+    })).on('click', (e) => {
+      $(e.currentTarget).data('_lite_tooltip').hide();
+    });
   }
   if (options.contents) {
     $node.html(options.contents);


### PR DESCRIPTION
#### What does this PR do?

- Hide the tooltip when buttons are clicked.

#### How should this be manually tested?

- Run and hover over buttons and click them.

#### Any background context you want to provide?

- Tooltips are displayed over buttons and dropdowns even buttons were clicked. This is annoying and makes less usability.

#### Screenshot (if for frontend)

Before: tooltip is displayed over dropdowns
<img width="561" alt="screen shot 2018-11-30 at 9 00 49 pm" src="https://user-images.githubusercontent.com/579366/49288642-a7d0cd00-f4e4-11e8-8bed-490f39ac097b.png">

After: clean
<img width="551" alt="screen shot 2018-11-30 at 8 59 58 pm" src="https://user-images.githubusercontent.com/579366/49288640-a7d0cd00-f4e4-11e8-8c97-df523985575d.png">

### Checklist
- [ ] added relevant tests
- [x] didn't break anything