### PR TITLE
Fixed Content Jumping on Scroll

### DIFF
--- a/src/js/base/module/Toolbar.js
+++ b/src/js/base/module/Toolbar.js
@@ -10,6 +10,7 @@ export default class Toolbar {
     this.$note = context.layoutInfo.note;
     this.$editor = context.layoutInfo.editor;
     this.$toolbar = context.layoutInfo.toolbar;
+    this.$editable = context.layoutInfo.editable;
     this.options = context.options;
 
     this.followScroll = this.followScroll.bind(this);
@@ -83,12 +84,19 @@ export default class Toolbar {
         position: 'fixed',
         top: otherBarHeight,
         width: editorWidth,
+        zIndex: 1
+      });
+      this.$editable.css({
+       	paddingTop: this.$toolbar.height() + 10
       });
     } else {
       this.$toolbar.css({
         position: 'relative',
         top: 0,
         width: '100%',
+      });
+      this.$editable.css({
+       	paddingTop: ''
       });
     }
   }


### PR DESCRIPTION
Fixed Content Jumping as Scrolling to Activate Fixed Toolbar

#### What does this PR do?

- As the user scrolls past the fold, the content in the body being edited jumps to the top of the page, which is beneath the toolbar. This causes issues when the end of the page is right after the bottom of the editor. Chrome jumps and throws the user back up.
