### PR TITLE
Add an option for toggling spellcheck

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -358,6 +358,8 @@ export default class Editor {
       this.context.triggerEvent('paste', event);
     });
 
+    this.$editable.attr('spellcheck', this.options.spellCheck);
+
     // init content before set event
     this.$editable.html(dom.html(this.$note) || dom.emptyPara);
 

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -117,6 +117,7 @@ $.summernote = $.extend($.summernote, {
     container: 'body',
     maxTextLength: 0,
     blockquoteBreakingLevel: 2,
+    spellCheck: true,
 
     styleTags: ['p', 'blockquote', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
 


### PR DESCRIPTION
#### What does this PR do?

- Add an option for toggling built-in spellcheck feature of web browsers. This works on both standard mode and AirMode.

#### Where should the reviewer start?

- start on the `src/js/base/module/Editor.js`

#### How should this be manually tested?

- Add `spellCheck: true` in your settings and 

#### What are the relevant tickets?

- Fix #1967 

### Checklist
- [ ] added relevant tests
- [x] didn't break anything