### PR TITLE
Add form-control-file into ImageDialog for Bootstrap4

### DIFF
--- a/src/js/base/module/ImageDialog.js
+++ b/src/js/base/module/ImageDialog.js
@@ -26,7 +26,7 @@ export default class ImageDialog {
     const body = [
       '<div class="form-group note-form-group note-group-select-from-files">',
       '<label class="note-form-label">' + this.lang.image.selectFromFiles + '</label>',
-      '<input class="note-image-input note-form-control note-input" ',
+      '<input class="note-image-input form-control-file note-form-control note-input" ',
       ' type="file" name="files" accept="image/*" multiple="multiple" />',
       imageLimitation,
       '</div>',


### PR DESCRIPTION
#### What does this PR do?

- Add `.form-control-file` class into ImageDialog for Bootstrap4

#### Where should the reviewer start?

- `src/js/base/module/ImageDialog.js`

#### Any background context you want to provide?

- See https://getbootstrap.com/docs/4.0/components/forms/#form-controls

#### Screenshot (if for frontend)

Before:
<img width="491" alt="screen shot 2018-12-10 at 2 47 41 pm" src="https://user-images.githubusercontent.com/579366/49714214-71871080-fc8f-11e8-9ccc-0ffda64303bb.png">

After:
<img width="494" alt="screen shot 2018-12-10 at 2 47 24 pm" src="https://user-images.githubusercontent.com/579366/49714221-76e45b00-fc8f-11e8-8248-10f85d3dd46f.png">