### PR TITLE
Fix callbacks

### DIFF
--- a/src/js/base/Context.js
+++ b/src/js/base/Context.js
@@ -98,7 +98,7 @@ export default class Context {
         this.layoutInfo.editable.html(html);
       }
       this.$note.val(html);
-      this.triggerEvent('change', html);
+      this.triggerEvent('change', html, this.layoutInfo.editable);
     }
   }
 

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -370,7 +370,7 @@ export default class Editor {
     this.$editable.html(dom.html(this.$note) || dom.emptyPara);
 
     this.$editable.on(env.inputEventName, func.debounce(() => {
-      this.context.triggerEvent('change', this.$editable.html());
+      this.context.triggerEvent('change', this.$editable.html(), this.$editable);
     }, 10));
 
     this.$editor.on('focusin', (event) => {
@@ -539,7 +539,7 @@ export default class Editor {
   undo() {
     this.context.triggerEvent('before.command', this.$editable.html());
     this.history.undo();
-    this.context.triggerEvent('change', this.$editable.html());
+    this.context.triggerEvent('change', this.$editable.html(), this.$editable);
   }
 
   /*
@@ -548,7 +548,7 @@ export default class Editor {
   commit() {
     this.context.triggerEvent('before.command', this.$editable.html());
     this.history.commit();
-    this.context.triggerEvent('change', this.$editable.html());
+    this.context.triggerEvent('change', this.$editable.html(), this.$editable);
   }
 
   /**
@@ -557,7 +557,7 @@ export default class Editor {
   redo() {
     this.context.triggerEvent('before.command', this.$editable.html());
     this.history.redo();
-    this.context.triggerEvent('change', this.$editable.html());
+    this.context.triggerEvent('change', this.$editable.html(), this.$editable);
   }
 
   /**
@@ -577,7 +577,7 @@ export default class Editor {
     this.normalizeContent();
     this.history.recordUndo();
     if (!isPreventTrigger) {
-      this.context.triggerEvent('change', this.$editable.html());
+      this.context.triggerEvent('change', this.$editable.html(), this.$editable);
     }
   }
 

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -174,9 +174,11 @@ $.summernote = $.extend($.summernote, {
     maximumImageFileSize: null,
 
     callbacks: {
+      onBeforeCommand: null,
       onBlur: null,
       onBlurCodeview: null,
       onChange: null,
+      onDialogShown: null,
       onEnter: null,
       onFocus: null,
       onImageLinkInsert: null,
@@ -185,7 +187,10 @@ $.summernote = $.extend($.summernote, {
       onInit: null,
       onKeydown: null,
       onKeyup: null,
+      onMousedown: null,
+      onMouseup: null,
       onPaste: null,
+      onScroll: null,
     },
 
     codemirror: {

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -174,16 +174,18 @@ $.summernote = $.extend($.summernote, {
     maximumImageFileSize: null,
 
     callbacks: {
-      onInit: null,
-      onFocus: null,
       onBlur: null,
       onBlurCodeview: null,
+      onChange: null,
       onEnter: null,
-      onKeyup: null,
-      onKeydown: null,
+      onFocus: null,
+      onImageLinkInsert: null,
       onImageUpload: null,
       onImageUploadError: null,
-      onImageLinkInsert: null,
+      onInit: null,
+      onKeydown: null,
+      onKeyup: null,
+      onPaste: null,
     },
 
     codemirror: {


### PR DESCRIPTION
#### What does this PR do?

- Reorder callback list by alphabetical order.
- Add omitted callback into the list – `onPaste` and `onChange`.

#### Any background context you want to provide?

- We could have more callbacks in the future.
- Example of https://summernote.org/deep-dive/#onchange shows there are two parameters will be passed to `onChange`, but only one caller sends `$editable`, actually. So I fixed the rest of them.