### PR TITLE
Fix undo error

### DIFF
--- a/src/js/base/editing/History.js
+++ b/src/js/base/editing/History.js
@@ -14,7 +14,7 @@ export default class History {
 
     return {
       contents: this.$editable.html(),
-      bookmark: (rng ? rng.bookmark(this.editable) : emptyBookmark),
+      bookmark: ((rng && rng.isOnEditable()) ? rng.bookmark(this.editable) : emptyBookmark),
     };
   }
 


### PR DESCRIPTION
#### What does this PR do?

- This fixes an undo error caused by malformed range object.
- Previously, Summernote record range objects even they're created from outside, not inside `editable`. So they cannot be used within the history module.

#### Where should the reviewer start?

- `src/js/base/editing/History.js`

#### How should this be manually tested?

- Initialize Summernote dynamically and undo it.

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/2017

### Checklist
- [ ] added relevant tests
- [x] didn't break anything