### PR TITLE
Add facebook video regex

### DIFF
--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -83,6 +83,9 @@ export default class VideoDialog {
     const webmRegExp = /^.+.(webm)$/;
     const webmMatch = url.match(webmRegExp);
 
+    const fbRegExp = /(?:www\.|\/\/)facebook\.com\/([^\/]+)\/videos\/([0-9]+)/;
+    const fbMatch = url.match(fbRegExp);
+
     let $video;
     if (ytMatch && ytMatch[1].length === 11) {
       const youtubeId = ytMatch[1];
@@ -139,6 +142,13 @@ export default class VideoDialog {
       $video = $('<video controls>')
         .attr('src', url)
         .attr('width', '640').attr('height', '360');
+    } else if (fbMatch && fbMatch[0].length) {
+      $video = $('<iframe>')
+        .attr('frameborder', 0)
+        .attr('src', 'https://www.facebook.com/plugins/video.php?href=' + encodeURIComponent(fbMatch[0]) + '&show_text=0&width=560')
+        .attr('width', '560').attr('height', '301')
+        .attr('scrolling', 'no')
+        .attr('allowtransparency', 'true');
     } else {
       // this is not a known video link. Now what, Cat? Now what?
       return false;

--- a/test/unit/base/module/VideoDialog.spec.js
+++ b/test/unit/base/module/VideoDialog.spec.js
@@ -51,6 +51,9 @@ describe('VideoDialog', () => {
         '//v.qq.com/iframe/player.html?vid=f0196y2b2cx&amp;auto=0');
       expectUrl('http://v.qq.com/x/page/p0330y279lm.html',
         '//v.qq.com/iframe/player.html?vid=p0330y279lm&amp;auto=0');
+      // Facebook
+      expectUrl('https://www.facebook.com/Engineering/videos/631826881803/',
+        '//www.facebook.com/plugins/video.php?href=www.facebook.com%2FEngineering%2Fvideos%2F631826881803');
     });
 
     it('should be embedded start parameter when insert YouTube video with t', () => {


### PR DESCRIPTION
#### What does this PR do?

- Allow Facebook Video URLs

#### Where should the reviewer start?

- `src/js/base/module/VideoDialog.js`

#### How should this be manually tested?

- Copy a URL of Facebook Video and put it on Video Dialog.

#### What are the relevant tickets?

- #2886 

#### Screenshot (if for frontend)

Nothing special, but let's see Mark of 10 years ago, who was talking about Memcached at FB Tech Talk.
<img width="676" alt="screen shot 2018-12-13 at 5 00 20 pm" src="https://user-images.githubusercontent.com/579366/49924071-a1851c80-fef8-11e8-8f34-b92f0294aea1.png">

### Checklist
- [x] added relevant tests
- [x] didn't break anything