### PR TITLE
Incorrect usage of event variable in Handle and ImagePopover on Firefox

### DIFF
--- a/src/js/base/module/Handle.js
+++ b/src/js/base/module/Handle.js
@@ -11,7 +11,7 @@ export default class Handle {
 
     this.events = {
       'summernote.mousedown': (we, e) => {
-        if (this.update(e.target)) {
+        if (this.update(e.target, e)) {
           e.preventDefault();
         }
       },
@@ -86,7 +86,7 @@ export default class Handle {
     this.$handle.remove();
   }
 
-  update(target) {
+  update(target, event) {
     if (this.context.isDisabled()) {
       return false;
     }
@@ -94,7 +94,7 @@ export default class Handle {
     const isImage = dom.isImg(target);
     const $selection = this.$handle.find('.note-control-selection');
 
-    this.context.invoke('imagePopover.update', target);
+    this.context.invoke('imagePopover.update', target, event);
 
     if (isImage) {
       const $image = $(target);

--- a/src/js/base/module/ImagePopover.js
+++ b/src/js/base/module/ImagePopover.js
@@ -38,7 +38,7 @@ export default class ImagePopover {
     this.$popover.remove();
   }
 
-  update(target) {
+  update(target, event) {
     if (dom.isImg(target)) {
       const pos = dom.posFromPlaceholder(target);
       const posEditor = dom.posFromPlaceholder(this.editable);


### PR DESCRIPTION
Fixes:
#2904 In Firefox, click on the image to report the error "event is not defined".

Handle.js does not pass on the event variable. On Firefox, this stops the ImagePopover from working properly because there is no global event variable, unlike Chrome and Safari.

This can be seen while resizing an image in the editor. Its dimensions should show and update as your drag.