### PR TITLE
#2732 fixed

### DIFF
--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -5273,7 +5273,7 @@
           this.lang = this.options.langInfo;
           this.events = {
               'summernote.mousedown': function (we, e) {
-                  if (_this.update(e.target)) {
+                  if (_this.update(e.target, e)) {
                       e.preventDefault();
                   }
               },
@@ -5339,13 +5339,13 @@
       Handle.prototype.destroy = function () {
           this.$handle.remove();
       };
-      Handle.prototype.update = function (target) {
+      Handle.prototype.update = function (target, event) {
           if (this.context.isDisabled()) {
               return false;
           }
           var isImage = dom.isImg(target);
           var $selection = this.$handle.find('.note-control-selection');
-          this.context.invoke('imagePopover.update', target);
+          this.context.invoke('imagePopover.update', target, event);
           if (isImage) {
               var $image = $$1(target);
               var position = $image.position();
@@ -6891,7 +6891,7 @@
       ImagePopover.prototype.destroy = function () {
           this.$popover.remove();
       };
-      ImagePopover.prototype.update = function (target) {
+      ImagePopover.prototype.update = function (target, event) {
           if (dom.isImg(target)) {
               var pos = dom.posFromPlaceholder(target);
               var posEditor = dom.posFromPlaceholder(this.editable);


### PR DESCRIPTION
Popover toolbars (like image toolbar) not showing in Firefox #2674

https://jsfiddle.net/gk09rocw/9/

1. Firefox:
![popover-firefox](https://user-images.githubusercontent.com/46490588/50839747-9d1e1900-1369-11e9-8413-21ade4baf221.png)

2. Chrome: 
![popover-chrome](https://user-images.githubusercontent.com/46490588/50839739-955e7480-1369-11e9-9c6e-8f5ca194cf1b.png)

Description: 
- On Firefox when you click on an image, it's only showing the selected image border and it's not showing the image popover with the action buttons.
- On Chrome that popover with the action buttons is showing.



