### PR TITLE
FIX #2788

### DIFF
--- a/src/js/base/module/HintPopover.js
+++ b/src/js/base/module/HintPopover.js
@@ -39,6 +39,7 @@ export default class HintPopover {
 
   initialize() {
     this.lastWordRange = null;
+    this.matchingWord = null;
     this.$popover = this.ui.popover({
       className: 'note-hint-popover',
       hideArrow: true,
@@ -104,11 +105,38 @@ export default class HintPopover {
 
     if ($item.length) {
       const node = this.nodeFromItem($item);
-      // XXX: consider to move codes to editor for recording redo/undo.
-      this.lastWordRange.insertNode(node);
-      range.createFromNode(node).collapse().select();
 
+      // If matchingWord length = 0 -> capture OK / open hint / but as mention capture "" (\w*)
+      if (this.matchingWord !== null && this.matchingWord.length === 0) {
+        this.lastWordRange.so = this.lastWordRange.eo;
+      // Else si > 0 and normal case -> adjust range "before" for correct position of insertion
+      } else if (this.matchingWord !== null && this.matchingWord.length > 0 && !this.lastWordRange.isCollapsed()) {
+          let rangeCompute = this.lastWordRange.eo - this.lastWordRange.so - this.matchingWord.length;
+          if (rangeCompute > 0) {
+            this.lastWordRange.so += rangeCompute;
+          }
+      }
+      if (document.queryCommandSupported('insertText')) { 
+        this.context.triggerEvent('before.command', this.$editable.html());
+        this.lastWordRange.deleteContents().collapse().select();
+        this.context.invoke('editor.focus');
+        document.execCommand('insertText', false, node.textContent);
+        // -- Normalize
+        this.$editable = this.context.layoutInfo.editable;
+        this.$editable[0].normalize();
+        // -- Add To history
+        this.history = new History(this.$editable);
+        this.history.recordUndo();
+      }
+      // Default : if insertText not work
+      else {
+        // XXX: consider to move codes to editor for recording redo/undo.
+        this.lastWordRange.insertNode(node);
+        range.createFromNode(node).collapse().select();
+      }
+      
       this.lastWordRange = null;
+      this.matchingWord = null;
       this.hide();
       this.context.triggerEvent('change', this.$editable.html(), this.$editable[0]);
       this.context.invoke('editor.focus');
@@ -159,6 +187,7 @@ export default class HintPopover {
     const hint = this.hints[index];
     if (hint && hint.match.test(keyword) && hint.search) {
       const matches = hint.match.exec(keyword);
+      this.matchingWord = matches[1];
       hint.search(matches[1], callback);
     } else {
       callback();

--- a/src/js/base/module/HintPopover.js
+++ b/src/js/base/module/HintPopover.js
@@ -118,7 +118,7 @@ export default class HintPopover {
       }
       if (document.queryCommandSupported('insertText')) {
         this.context.triggerEvent('before.command', this.$editable.html());
-        this.lastWordRange.deleteContents().collapse().select();
+        this.lastWordRange.select();
         this.context.invoke('editor.focus');
         document.execCommand('insertText', false, node.textContent);
         // -- Normalize

--- a/src/js/base/module/HintPopover.js
+++ b/src/js/base/module/HintPopover.js
@@ -111,12 +111,12 @@ export default class HintPopover {
         this.lastWordRange.so = this.lastWordRange.eo;
       // Else si > 0 and normal case -> adjust range "before" for correct position of insertion
       } else if (this.matchingWord !== null && this.matchingWord.length > 0 && !this.lastWordRange.isCollapsed()) {
-          let rangeCompute = this.lastWordRange.eo - this.lastWordRange.so - this.matchingWord.length;
-          if (rangeCompute > 0) {
-            this.lastWordRange.so += rangeCompute;
-          }
+        let rangeCompute = this.lastWordRange.eo - this.lastWordRange.so - this.matchingWord.length;
+        if (rangeCompute > 0) {
+          this.lastWordRange.so += rangeCompute;
+        }
       }
-      if (document.queryCommandSupported('insertText')) { 
+      if (document.queryCommandSupported('insertText')) {
         this.context.triggerEvent('before.command', this.$editable.html());
         this.lastWordRange.deleteContents().collapse().select();
         this.context.invoke('editor.focus');
@@ -127,14 +127,14 @@ export default class HintPopover {
         // -- Add To history
         this.history = new History(this.$editable);
         this.history.recordUndo();
-      }
+
       // Default : if insertText not work
-      else {
+      } else {
         // XXX: consider to move codes to editor for recording redo/undo.
         this.lastWordRange.insertNode(node);
         range.createFromNode(node).collapse().select();
       }
-      
+
       this.lastWordRange = null;
       this.matchingWord = null;
       this.hide();


### PR DESCRIPTION
#### What does this PR do?

- FIX #2788 : 
1. Allow regexp more... complicated to work with hint
2. Solve : break font-family/font-size because of use of createNode

#### Where should the reviewer start?

- start on the src/js/base/module/HintPopover.js

#### How should this be manually tested?

Please use : 
```
hint: {
    mentions: ['jayden', 'sam', 'alvin', 'david'],
    match: /^\w*#(\w*)$/,
    search: function (keyword, callback) {
      callback($.grep(this.mentions, function (item) {
        return item.indexOf(keyword) == 0;
      }));
    },
    content: function (item) {
      return item;
    }    
  },
```

Test : 
1. I AM A NICE BOY
2. I AM A NICE# BOY
3. Choose a name from the list, ex : jayden

Before patch : 
Result : I AM A #jayden BOY
After patch : 
Result : I AM A NICE#jayden BOY

With this sample this seem not important but if you want to use hint for replacing some char like I do : this mega important !

#### What are the relevant tickets?
FIX #2788


