### PR TITLE
Fixed #2587

### DIFF
--- a/src/js/base/module/Dropzone.js
+++ b/src/js/base/module/Dropzone.js
@@ -50,6 +50,11 @@ export default class Dropzone {
         this.$dropzone.height(this.$editor.height());
         $dropzoneMessage.text(this.lang.image.dragImageHere);
       }
+	  
+	  if (collection.length > 1) {
+			collection = collection.not(collection);
+		}
+	  
       collection = collection.add(e.target);
     };
 


### PR DESCRIPTION
#### What does this PR do?

- Fixes 2587: Inability of IE11 to fire the DragLeave event on elements, causes the issue to appear. As a result, the collection gets extremely long and the condition of hiding the "dragover" never gets satisfied

#### Where should the reviewer start?

- start on the summernote\src\js\base\module\Dropzone.js

#### How should this be manually tested?

- As the description says, just cancel the ticket says, just cancel the drag and see the magic happen :)


#### What are the relevant tickets?

1. #2587 


### Checklist
- [ ] Made sure that it runs in all browsers
- [ ] didn't break anything
