### PR TITLE
Feature/1773 individual buttons

### DIFF
--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -457,10 +457,18 @@ export default class Buttons {
       click: this.context.createInvokeHandler('editor.indent'),
     });
 
-    this.context.memo('button.justifyLeft', func.invoke(justifyLeft, 'render'));
-    this.context.memo('button.justifyCenter', func.invoke(justifyCenter, 'render'));
-    this.context.memo('button.justifyRight', func.invoke(justifyRight, 'render'));
-    this.context.memo('button.justifyFull', func.invoke(justifyFull, 'render'));
+    this.context.memo('button.justifyLeft', () => {
+      return justifyLeft.render();
+    });
+    this.context.memo('button.justifyCenter', () => {
+      return justifyCenter.render();
+    });
+    this.context.memo('button.justifyRight', () => {
+      return justifyRight.render();
+    });
+    this.context.memo('button.justifyFull', () => {
+      return justifyFull.render();
+    });
     this.context.memo('button.outdent', func.invoke(outdent, 'render'));
     this.context.memo('button.indent', func.invoke(indent, 'render'));
 

--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -469,8 +469,12 @@ export default class Buttons {
     this.context.memo('button.justifyFull', () => {
       return justifyFull.render();
     });
-    this.context.memo('button.outdent', func.invoke(outdent, 'render'));
-    this.context.memo('button.indent', func.invoke(indent, 'render'));
+    this.context.memo('button.outdent', () => {
+      return outdent.render();
+    });
+    this.context.memo('button.indent', () => {
+      return indent.render();
+    });
 
     this.context.memo('button.paragraph', () => {
       return this.ui.buttonGroup([


### PR DESCRIPTION
#### What does this PR do?
- This PR allows for the paragraph buttons (justifyLeft, justifyCenter, justifyRight, justifyFull, indent, outdent) to be added direct to the toolbar as well as being apart of the paragraph group. 
- Fix issues raised in #1396 and #1773

#### Where should the reviewer start?
- file edited: `src/js/base/module/Buttons.js`

#### How should this be manually tested?
- Initialise summernote with the following buttons:
`['para', ['justifyLeft', 'justifyCenter', 'justifyRight', 'justifyFull', 'indent', 'outdent', 'paragraph']]`
which should show the paragraph dropdown as well as all the individual buttons directly in the para toolbar.
- Clicking both versions (dropdown and direct) should perform the actions correctly.

#### Any background context you want to provide?
- The invoke function passes through the arguments to the method. As the (invoked) render function was being called in the build method the context variable was being sent as the first param. This was being misinterpreted as a parent object and therefore was trying to append the button to the context variable which would throw an error (parent.append is not a function render@summernote.js:1796 )
- For other similar buttons the function that is passed the context is not the render function but the encapsulating function, the render function gets called without params, therefore mimicking this setup by using the invoke function.
- I believe these were the only current use for the `func.invoke` however I did not think it a good idea to update/remove this function as it is a generic function that could be used by other plugins.

#### What are the relevant tickets?
- #1396
- #1773

### Checklist
- [ ] current tests run successfully, ie. no regressions.