### PR TITLE
Fix #2776 and match styles

### DIFF
--- a/src/js/base/module/ImageDialog.js
+++ b/src/js/base/module/ImageDialog.js
@@ -120,9 +120,9 @@ export default class ImageDialog {
       });
 
       this.ui.onDialogHidden(this.$dialog, () => {
-        $imageInput.off('change');
-        $imageUrl.off('input propertychange keypress');
-        $imageBtn.off('click');
+        $imageInput.off();
+        $imageUrl.off();
+        $imageBtn.off();
 
         if (deferred.state() === 'pending') {
           deferred.reject();

--- a/src/js/base/module/ImageDialog.js
+++ b/src/js/base/module/ImageDialog.js
@@ -103,26 +103,25 @@ export default class ImageDialog {
           deferred.resolve(event.target.files || event.target.value);
         }).val(''));
 
-        $imageBtn.click((event) => {
-          event.preventDefault();
-
-          deferred.resolve($imageUrl.val());
-        });
-
-        $imageUrl.on('keyup paste', () => {
-          const url = $imageUrl.val();
-          this.ui.toggleBtn($imageBtn, url);
+        $imageUrl.on('input paste propertychange', () => {
+          this.ui.toggleBtn($imageBtn, $imageUrl.val());
         }).val('');
 
         if (!env.isSupportTouch) {
           $imageUrl.trigger('focus');
         }
+
+        $imageBtn.click((event) => {
+          event.preventDefault();
+          deferred.resolve($imageUrl.val());
+        });
+
         this.bindEnterKey($imageUrl, $imageBtn);
       });
 
       this.ui.onDialogHidden(this.$dialog, () => {
         $imageInput.off('change');
-        $imageUrl.off('keyup paste keypress');
+        $imageUrl.off('input propertychange keypress');
         $imageBtn.off('click');
 
         if (deferred.state() === 'pending') {

--- a/src/js/base/module/LinkDialog.js
+++ b/src/js/base/module/LinkDialog.js
@@ -87,17 +87,21 @@ export default class LinkDialog {
       this.ui.onDialogShown(this.$dialog, () => {
         this.context.triggerEvent('dialog.shown');
 
-        // if no url was given and given text is valid URL then copy that into URL Field
+        // If no url was given and given text is valid URL then copy that into URL Field
         if (!linkInfo.url && func.isValidUrl(linkInfo.text)) {
           linkInfo.url = linkInfo.text;
         }
 
         $linkText.on('input paste propertychange', () => {
+          // If linktext was modified by input events,
+          // cloning text from linkUrl will be stopped.
           linkInfo.text = $linkText.val();
           this.toggleLinkBtn($linkBtn, $linkText, $linkUrl);
         }).val(linkInfo.text);
 
         $linkUrl.on('input paste propertychange', () => {
+          // Display same text on `Text to display` as default
+          // when linktext has no text
           if (!linkInfo.text) {
             $linkText.val($linkUrl.val());
           }
@@ -132,9 +136,9 @@ export default class LinkDialog {
 
       this.ui.onDialogHidden(this.$dialog, () => {
         // detach events
-        $linkText.off('input paste keypress');
-        $linkUrl.off('input paste keypress');
-        $linkBtn.off('click');
+        $linkText.off();
+        $linkUrl.off();
+        $linkBtn.off();
 
         if (deferred.state() === 'pending') {
           deferred.reject();

--- a/src/js/base/module/LinkDialog.js
+++ b/src/js/base/module/LinkDialog.js
@@ -92,30 +92,16 @@ export default class LinkDialog {
           linkInfo.url = linkInfo.text;
         }
 
-        $linkText.val(linkInfo.text);
-
-        const handleLinkTextUpdate = () => {
-          this.toggleLinkBtn($linkBtn, $linkText, $linkUrl);
-          // if linktext was modified by keyup,
-          // stop cloning text from linkUrl
+        $linkText.on('input paste propertychange', () => {
           linkInfo.text = $linkText.val();
-        };
-
-        $linkText.on('input', handleLinkTextUpdate).on('paste', () => {
-          setTimeout(handleLinkTextUpdate, 0);
-        });
-
-        const handleLinkUrlUpdate = () => {
           this.toggleLinkBtn($linkBtn, $linkText, $linkUrl);
-          // display same link on `Text to display` input
-          // when create a new link
+        }).val(linkInfo.text);
+
+        $linkUrl.on('input paste propertychange', () => {
           if (!linkInfo.text) {
             $linkText.val($linkUrl.val());
           }
-        };
-
-        $linkUrl.on('input', handleLinkUrlUpdate).on('paste', () => {
-          setTimeout(handleLinkUrlUpdate, 0);
+          this.toggleLinkBtn($linkBtn, $linkText, $linkUrl);
         }).val(linkInfo.url);
 
         if (!env.isSupportTouch) {

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -193,7 +193,7 @@ export default class VideoDialog {
       this.ui.onDialogShown(this.$dialog, () => {
         this.context.triggerEvent('dialog.shown');
 
-        $videoUrl.val(text).on('input', () => {
+        $videoUrl.on('input paste propertychange', () => {
           this.ui.toggleBtn($videoBtn, $videoUrl.val());
         });
 
@@ -203,7 +203,6 @@ export default class VideoDialog {
 
         $videoBtn.click((event) => {
           event.preventDefault();
-
           deferred.resolve($videoUrl.val());
         });
 
@@ -211,7 +210,7 @@ export default class VideoDialog {
       });
 
       this.ui.onDialogHidden(this.$dialog, () => {
-        $videoUrl.off('input');
+        $videoUrl.off('input propertychange keypress');
         $videoBtn.off('click');
 
         if (deferred.state() === 'pending') {

--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -210,8 +210,8 @@ export default class VideoDialog {
       });
 
       this.ui.onDialogHidden(this.$dialog, () => {
-        $videoUrl.off('input propertychange keypress');
-        $videoBtn.off('click');
+        $videoUrl.off();
+        $videoBtn.off();
 
         if (deferred.state() === 'pending') {
           deferred.reject();


### PR DESCRIPTION
#### What does this PR do?

- Fix #2776 
- Match styles between `ImageDialog.js`, `VideoDialog.js`, and `LinkDialog.js`

#### Where should the reviewer start?

- `src/js/base/module/ImageDialog.js`
- `src/js/base/module/VideoDialog.js`
- `src/js/base/module/LinkDialog.js`

#### How should this be manually tested?

- Paste an URL on Image Dialog and check whether the insertion button is activated or not.

#### Any background context you want to provide?

- `keyup paste` event cannot capture a paste event from the context menu. (usually called by mouse right button) Thus, `VideoDialog` have used `input` event instead. And I also add `propertychange` event for Internet Explorer.

#### What are the relevant tickets?

- #2776, #3166 

### Checklist
- [ ] added relevant tests
- [ ] didn't break anything

Travis test still stuck in failure because of PhantomJS 2.1.1 (Linux). On PhantomJS 2.1.1 (Mac OS X) does not have any problem.