### PR TITLE
Escape dots in whitelist domains

### DIFF
--- a/src/js/base/module/Codeview.js
+++ b/src/js/base/module/Codeview.js
@@ -69,7 +69,7 @@ export default class CodeView {
           }
           for (const src of whitelist) {
             // pass if src is trusted
-            if ((new RegExp('src="(https?:)?\/\/' + src + '\/(.+)"')).test(tag)) {
+            if ((new RegExp('src="(https?:)?\/\/' + src.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&') + '\/(.+)"')).test(tag)) {
               return tag;
             }
           }

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -210,7 +210,8 @@ $.summernote = $.extend($.summernote, {
     codeviewIframeFilter: true,
     codeviewIframeWhitelistSrc: [],
     codeviewIframeWhitelistSrcBase: [
-      'www.youtube(?:-nocookie)?.com',
+      'www.youtube.com',
+      'www.youtube-nocookie.com',
       'www.facebook.com',
       'vine.co',
       'instagram.com',

--- a/test/base/module/Codeview.spec.js
+++ b/test/base/module/Codeview.spec.js
@@ -35,6 +35,9 @@ describe('Codeview', () => {
     expect(codeview.purify('<iframe frameborder="0" src="//www.youtube.com/embed/CXgsA98krxA" width="640" height="360" class="note-video-clip"></iframe>')).to.equalsIgnoreCase(
       '<iframe frameborder="0" src="//www.youtube.com/embed/CXgsA98krxA" width="640" height="360" class="note-video-clip"></iframe>'
     );
+    expect(codeview.purify('<iframe frameborder="0" src="//wwwXyoutube.com/embed/CXgsA98krxA" width="640" height="360" class="note-video-clip">')).to.equalsIgnoreCase(
+      ''
+    );
     expect(codeview.purify('<iframe frameborder="0" src="//www.fake-youtube.com/embed/CXgsA98krxA" width="640" height="360" class="note-video-clip">')).to.equalsIgnoreCase(
       ''
     );


### PR DESCRIPTION
#### What does this PR do?

- #3048 introduced a simple way to purify codes by regular expressions. But its whitelist domain sources were not well escaped, so it may not block malicious URLs.

#### Where should the reviewer start?

- `/src/js/base/module/Codeview.js`

#### How should this be manually tested?

- Test code was added on `/test/base/module/Codeview.spec.js`

#### Any background context you want to provide?

- I got an email from https://semmle.com/security with this vulnerability and fixed it. Thanks to them.

#### What are the relevant tickets?

- #3048 


### Checklist
- [x] added relevant tests
- [x] didn't break anything