### PR TITLE
Do not add quotes to the generic font families, otherwise the style is invalid.

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -68,7 +68,9 @@ export default class Editor {
     }
 
     this.fontName = this.wrapCommand((value) => {
-      return this.fontStyling('font-family', "\'" + value + "\'");
+      const genericFamilies = ['sans-serif', 'serif', 'monospace', 'cursive', 'fantasy'];
+      const name = ($.inArray(value.toLowerCase(), genericFamilies) === -1) ? `'${value}'` : value;
+      return this.fontStyling('font-family', name);
     });
 
     this.fontSize = this.wrapCommand((value) => {


### PR DESCRIPTION
Hello Team,

font family names are quoted before applying to element, but generic font families must have no quotes, otherwise browsers (Chrome/Firefox) don't recognise the fonts and the `serif` is rendered.