### PR TITLE
WIP #2654

### DIFF
--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -955,7 +955,7 @@ function html($node, isNewlineOnBlock) {
 
       return match + ((isEndOfInlineContainer || isBlockNode) ? '\n' : '');
     });
-    markup = $.trim(markup);
+    markup = markup.trim();
   }
 
   return markup;


### PR DESCRIPTION
#### What does this PR do?

Replaces jQuerys '$.trim(markup)' with 'markup.trim()', to make summernote a little less dependent on jQuery. Supported by all major browsers and IE9+.

#### Where should the reviewer start?

- src/js/base/core/dom.js

#### Any background context you want to provide?

Taking small steps towards removing jQuery dependency

#### What are the relevant tickets?

#2654 

### Checklist
- [ ] added relevant tests
- [X] didn't break anything