### PR TITLE
Fixes #2067

### DIFF
--- a/src/js/base/core/env.js
+++ b/src/js/base/core/env.js
@@ -41,34 +41,6 @@ if (isMSIE) {
 const isEdge = /Edge\/\d+/.test(userAgent);
 
 let hasCodeMirror = !!window.CodeMirror;
-if (!hasCodeMirror && isSupportAmd) {
-  // Webpack
-  if (typeof __webpack_require__ === 'function') { // eslint-disable-line
-    try {
-      // If CodeMirror can't be resolved, `require.resolve` will throw an
-      // exception and `hasCodeMirror` won't be set to `true`.
-      require.resolve('codemirror');
-      hasCodeMirror = true;
-    } catch (e) {
-      // do nothing
-    }
-  } else if (typeof require !== 'undefined') {
-    // Browserify
-    if (typeof require.resolve !== 'undefined') {
-      try {
-        // If CodeMirror can't be resolved, `require.resolve` will throw an
-        // exception and `hasCodeMirror` won't be set to `true`.
-        require.resolve('codemirror');
-        hasCodeMirror = true;
-      } catch (e) {
-        // do nothing
-      }
-    // Almond/Require
-    } else if (typeof require.specified !== 'undefined') {
-      hasCodeMirror = require.specified('codemirror');
-    }
-  }
-}
 
 const isSupportTouch =
   (('ontouchstart' in window) ||

--- a/src/js/base/module/Codeview.js
+++ b/src/js/base/module/Codeview.js
@@ -3,13 +3,7 @@ import dom from '../core/dom';
 
 let CodeMirror;
 if (env.hasCodeMirror) {
-  if (env.isSupportAmd) {
-    require(['codemirror'], function(cm) {
-      CodeMirror = cm;
-    });
-  } else {
-    CodeMirror = window.CodeMirror;
-  }
+  CodeMirror = window.CodeMirror;
 }
 
 /**


### PR DESCRIPTION
#### What does this PR do?

Removed automatic requirement of CodeMirror to reduce bundle size.

If you want to use CodeMirror, pull it in before Summernote, like so:
window.CodeMirror = require('codemirror');
require('bs4-summernote');

Or pull it in via CDN.

#### Where should the reviewer start?

- src/js/base/core/env.js
- src/js/base/module/Codeview.js

#### What are the relevant tickets?

#2067 

### Checklist
- [ ] added relevant tests
- [X] didn't break anything