### PR TITLE
Missing required parameter "event" causes the image resize handle to …

### DIFF
--- a/src/js/base/module/Handle.js
+++ b/src/js/base/module/Handle.js
@@ -58,7 +58,7 @@ export default class Handle {
             y: event.clientY - (posStart.top - scrollTop),
           }, $target, !event.shiftKey);
 
-          this.update($target[0]);
+          this.update($target[0], event);
         };
 
         this.$document


### PR DESCRIPTION
This is is a minor bug fix. When dragging an image resize handle, it causes a lot of errors because event.pageX is inaccessible (the required event parameter is missing).

Not tested on other environments than Chrome and Firefox / Mac OSX. The fix should be unproblematic.