### PR TITLE
Remove the asterisk selector from Lite UI

### DIFF
--- a/src/less/lite-ui/common.less
+++ b/src/less/lite-ui/common.less
@@ -1,5 +1,4 @@
-.note-frame * {
+.note-frame {
   .box-sizing(border-box);
   color: #000;
 }
-


### PR DESCRIPTION
#### What does this PR do?

- Remove the asterisk selector from Lite UI
- This selector is not necessary for Lite UI, basically. And this can bother applying intended global styles from the user.

#### Where should the reviewer start?

- start on the `src/less/lite-ui/common.less`

#### What are the relevant tickets?

- #3253 

### Checklist
- [ ] added relevant tests
- [x] didn't break anything