### PR TITLE
Fix contains method to use .contains for DOMTokenList

### DIFF
--- a/src/js/base/core/lists.js
+++ b/src/js/base/core/lists.js
@@ -65,7 +65,12 @@ function all(array, pred) {
  */
 function contains(array, item) {
   if (array && array.length && item) {
-    return array.indexOf(item) !== -1;
+    if (array.indexOf) {
+      return array.indexOf(item) !== -1;
+    } else if (array.contains) {
+      // `DOMTokenList` doesn't implement `.indexOf`, but it implements `.contains`
+      return array.contains(item);
+    }
   }
   return false;
 }


### PR DESCRIPTION
#### What does this PR do?

Fixes a bug I ran into. I had custom style tags, whose `value` and `tag` were `"div"`. When I selected some text and changed the style tag to be one of these "div" styles, and then hit "Enter" a couple of times, I got `.indexOf is not a function`.

#### Where should the reviewer start?

There's only 1 file.

#### How should this be manually tested?

1. use a custom style tag that doesn't map to a header tag (I used a div)
2. highlight some text
3. use the custom style tag
4. de-select
5. hit Enter a couple of times
6. error shows in console

example custom style tags:

```
styleTags: [
  { title: 'BV Title 1', tag: 'h1', className: 'bv-title-1', value: 'h1' },
  { title: 'BV Title 2', tag: 'div', className: 'bv-title-2', value: 'div' },
  { title: 'BV Title 3', tag: 'div', className: 'bv-title-3', value: 'div' },
  { title: 'BV Title 4', tag: 'div', className: 'bv-title-4', value: 'div' },
  { title: 'BV Title 5', tag: 'div', className: 'bv-title-5', value: 'div' }
]
```

in this case, the "BV Title 1" works just fine. "BV Title 2" and others do not.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
Not sure.

#### Screenshot (if for frontend)


### Checklist
- [ ] added relevant tests
- [ ] didn't break anything
- [ ] ...
