### PR TITLE
Add Safari to airmode focusout workaround

### DIFF
--- a/src/js/base/module/AirPopover.js
+++ b/src/js/base/module/AirPopover.js
@@ -19,9 +19,9 @@ export default class AirPopover {
         this.hide();
       },
       'summernote.focusout': (we, e) => {
-        // [workaround] Firefox doesn't support relatedTarget on focusout
-        //  - Ignore hide action on focus out in FF.
-        if (env.isFF) {
+        // [workaround] Firefox/Safari don't support relatedTarget on focusout
+        //  - Ignore hide action on focus out in FF/Safari.
+        if (env.isFF || env.isSafari) {
           return;
         }
 


### PR DESCRIPTION
The Airmode focusout event includes a workaround for Firefox where the relatedTarget is not available. The same issue exists in Safari as well so this PR adds Safari to the workaround.
Fixes #3312.

An alternative solution could be to use `o.$popover.is(':active')` to check if the popover has focus in a more compatible way.