### PR TITLE
Add inheritPlaceholder option

### DIFF
--- a/src/js/base/module/Placeholder.js
+++ b/src/js/base/module/Placeholder.js
@@ -5,6 +5,12 @@ export default class Placeholder {
 
     this.$editingArea = context.layoutInfo.editingArea;
     this.options = context.options;
+
+    if (this.options.inheritPlaceholder === true) {
+      // get placeholder value from the original element
+      this.options.placeholder = this.context.$note.attr('placeholder') || this.options.placeholder;
+    }
+
     this.events = {
       'summernote.init summernote.change': () => {
         this.update();

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -125,6 +125,8 @@ $.summernote = $.extend($.summernote, {
     maxTextLength: 0,
     blockquoteBreakingLevel: 2,
     spellCheck: true,
+    placeholder: null,
+    inheritPlaceholder: false,
 
     styleTags: ['p', 'blockquote', 'pre', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
 

--- a/test/base/module/Placeholder.spec.js
+++ b/test/base/module/Placeholder.spec.js
@@ -1,0 +1,31 @@
+/**
+ * Placeholder.spec.js
+ * (c) 2015~ Summernote Team
+ * summernote may be freely distributed under the MIT license./
+ */
+import chai from 'chai';
+import $ from 'jquery';
+import Context from '../../../src/js/base/Context';
+import '../../../src/js/bs4/settings';
+
+describe('Placeholder', () => {
+  var assert = chai.assert;
+
+  it('should not be initialized by placeholder attribute without inheritPlaceHolder', () => {
+    var options = $.extend({}, $.summernote.options);
+    var context = new Context($('<textarea placeholder="custom_placeholder"><p>hello</p></textarea>'), options);
+    var $editor = context.layoutInfo.editor;
+
+    assert.isTrue($editor.find('.note-placeholder').length === 0);
+  });
+
+  it('should be initialized by placeholder attribute with inheritPlaceHolder', () => {
+    var options = $.extend({}, $.summernote.options);
+    options.inheritPlaceholder = true;
+    var context = new Context($('<textarea placeholder="custom_placeholder"><p>hello</p></textarea>'), options);
+    var $editor = context.layoutInfo.editor;
+
+    assert.isTrue($editor.find('.note-placeholder').length === 1);
+    assert.isTrue($editor.find('.note-placeholder').html() === 'custom_placeholder');
+  });
+});


### PR DESCRIPTION
#### What does this PR do?

- This adds `inheritPlaceholder`option.

#### Where should the reviewer start?

- `_initialize` of `src/js/base/Context.js`

#### How should this be manually tested?

- Set `inheritPlaceholder` as `true` and put `placeholder` attribute on the original element.

#### What are the relevant tickets?

- #3127 

### Checklist
- [x] added relevant tests
- [x] didn't break anything