### PR TITLE
The drop-Event in Firefox contains two moz-specific Datatransfer-Type…

### DIFF
--- a/src/js/base/module/Dropzone.js
+++ b/src/js/base/module/Dropzone.js
@@ -89,6 +89,10 @@ export default class Dropzone {
         this.context.invoke('editor.insertImagesOrCallback', dataTransfer.files);
       } else {
         $.each(dataTransfer.types, (idx, type) => {
+          // skip moz-specific types
+          if (type.toLowerCase().indexOf('_moz_') > -1) {
+            return;
+          }
           const content = dataTransfer.getData(type);
 
           if (type.toLowerCase().indexOf('text') > -1) {


### PR DESCRIPTION
Bugfix for issue #2701:

The drop-Event in Firefox contains two moz-specific Datatransfer-Types: "text/_moz_htmlcontext" and "text/_moz_htmlinfo". Those aren't meant to be inserted via .pasteHTML().

So you can prevent the editor from inserting its whole editor DOM (stored in text/_moz_htmlcontext...) by skipping those types from being processed.
