### PR TITLE
change inequality when maxTextLenth is compared

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -445,7 +445,7 @@ export default class Editor {
     }
 
     if (this.options.maxTextLength > 0) {
-      if ((this.$editable.text().length + pad) >= this.options.maxTextLength) {
+      if ((this.$editable.text().length + pad) > this.options.maxTextLength) {
         return true;
       }
     }


### PR DESCRIPTION
#### What does this PR do?

- change inequality when maxTextLenth is compared with editable text

#### What are the relevant tickets?
None

### Checklist
- [ ] added relevant tests
- [x] didn't break anything
