### PR TITLE
resolve issue which maxTextLenght not working on paste #3334

### DIFF
--- a/src/js/base/module/Clipboard.js
+++ b/src/js/base/module/Clipboard.js
@@ -18,12 +18,16 @@ export default class Clipboard {
   pasteByEvent(event) {
     const clipboardData = event.originalEvent.clipboardData;
     if (clipboardData && clipboardData.items && clipboardData.items.length) {
-      // paste img file
       const item = clipboardData.items.length > 1 ? clipboardData.items[1] : lists.head(clipboardData.items);
       if (item.kind === 'file' && item.type.indexOf('image/') !== -1) {
+        // paste img file
         this.context.invoke('editor.insertImagesOrCallback', [item.getAsFile()]);
+      } else if (item.kind === 'string' && this.context.invoke('editor.isLimited', clipboardData.getData('Text').length)) {
+        // prevent paste text over maxTextLength
+        event.preventDefault();
+      } else {
+        this.context.invoke('editor.afterCommand');
       }
-      this.context.invoke('editor.afterCommand');
     }
   }
 }


### PR DESCRIPTION
#### What does this PR do?

- correct that maxTextLenght not working on paste

#### Where should the reviewer start?

- start on the src/js/base/module/Clipboard.js

#### How should this be manually tested?

- npm run test 
- copy & paste "text" x 3  in browser editor

#### What are the relevant tickets?

#3334 

#### Screenshot (if for frontend)


### Checklist
- [ ] added relevant tests
- [x] didn't break anything
- [ ] ...