### PR TITLE
Revert "Simply the logic of disableDragAndDrop"

### DIFF
--- a/src/js/base/module/Dropzone.js
+++ b/src/js/base/module/Dropzone.js
@@ -17,15 +17,21 @@ export default class Dropzone {
     ].join('')).prependTo(this.$editor);
   }
 
-  shouldInitialize() {
-    return !this.options.disableDragAndDrop;
-  }
-
   /**
    * attach Drag and Drop Events
    */
   initialize() {
-    this.attachDragAndDropEvent();
+    if (this.options.disableDragAndDrop) {
+      // prevent default drop event
+      this.documentEventHandlers.onDrop = (e) => {
+        e.preventDefault();
+      };
+      // do not consider outside of dropzone
+      this.$eventListener = this.$dropzone;
+      this.$eventListener.on('drop', this.documentEventHandlers.onDrop);
+    } else {
+      this.attachDragAndDropEvent();
+    }
   }
 
   /**


### PR DESCRIPTION
This reverts commit aa745b4be8ef313b0f965a4ee311563f01616dec.

#### Any background context you want to provide?

- `disableDragAndDrop` also should disable the default drag-and-drop behavior of web browsers. I removed it by mistake.