### PR TITLE
Resolve #3313 - Add checkbox to use protocol

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -190,6 +190,7 @@ export default class Editor {
       let linkUrl = linkInfo.url;
       const linkText = linkInfo.text;
       const isNewWindow = linkInfo.isNewWindow;
+      const checkProtocol = linkInfo.checkProtocol;
       let rng = linkInfo.range || this.getLastRange();
       const additionalTextLength = linkText.length - rng.toString().length;
       if (additionalTextLength > 0 && this.isLimited(additionalTextLength)) {
@@ -204,7 +205,7 @@ export default class Editor {
 
       if (this.options.onCreateLink) {
         linkUrl = this.options.onCreateLink(linkUrl);
-      } else {
+      } else if (checkProtocol) {
         // if url doesn't have any protocol and not even a relative or a label, use http:// as default
         linkUrl = /^([A-Za-z][A-Za-z0-9+-.]*\:|#|\/)/.test(linkUrl)
           ? linkUrl : 'http://' + linkUrl;
@@ -445,7 +446,7 @@ export default class Editor {
     }
 
     if (this.options.maxTextLength > 0) {
-      if ((this.$editable.text().length + pad) >= this.options.maxTextLength) {
+      if ((this.$editable.text().length + pad) > this.options.maxTextLength) {
         return true;
       }
     }

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -208,7 +208,7 @@ export default class Editor {
       } else if (checkProtocol) {
         // if url doesn't have any protocol and not even a relative or a label, use http:// as default
         linkUrl = /^([A-Za-z][A-Za-z0-9+-.]*\:|#|\/)/.test(linkUrl)
-          ? linkUrl : 'http://' + linkUrl;
+          ? linkUrl : this.options.defaultProtocol + linkUrl;
       }
 
       let anchors = [];

--- a/src/js/base/module/LinkDialog.js
+++ b/src/js/base/module/LinkDialog.js
@@ -128,8 +128,8 @@ export default class LinkDialog {
 
         $openInNewWindow.prop('checked', isNewWindowChecked);
 
-        const useProtocolChecked = linkInfo.checkProtocol !== undefined
-          ? linkInfo.checkProtocol : this.context.options.useProtocol;
+        const useProtocolChecked = linkInfo.url
+          ? false : this.context.options.useProtocol;
 
         $useProtocol.prop('checked', useProtocolChecked);
 

--- a/src/js/base/module/LinkDialog.js
+++ b/src/js/base/module/LinkDialog.js
@@ -35,6 +35,11 @@ export default class LinkDialog {
           checked: true,
         }).render()).html()
         : '',
+      $('<div/>').append(this.ui.checkbox({
+        className: 'sn-checkbox-use-protocol',
+        text: this.lang.link.useProtocol,
+        checked: true,
+      }).render()).html(),
     ].join('');
 
     const buttonClass = 'btn btn-primary note-btn note-btn-primary note-link-btn';
@@ -83,6 +88,8 @@ export default class LinkDialog {
       const $linkBtn = this.$dialog.find('.note-link-btn');
       const $openInNewWindow = this.$dialog
         .find('.sn-checkbox-open-in-new-window input[type=checkbox]');
+      const $useProtocol = this.$dialog
+        .find('.sn-checkbox-use-protocol input[type=checkbox]');
 
       this.ui.onDialogShown(this.$dialog, () => {
         this.context.triggerEvent('dialog.shown');
@@ -121,6 +128,11 @@ export default class LinkDialog {
 
         $openInNewWindow.prop('checked', isNewWindowChecked);
 
+        const useProtocolChecked = linkInfo.checkProtocol !== undefined
+          ? linkInfo.checkProtocol : this.context.options.useProtocol;
+
+        $useProtocol.prop('checked', useProtocolChecked);
+
         $linkBtn.one('click', (event) => {
           event.preventDefault();
 
@@ -129,6 +141,7 @@ export default class LinkDialog {
             url: $linkUrl.val(),
             text: $linkText.val(),
             isNewWindow: $openInNewWindow.is(':checked'),
+            checkProtocol: $useProtocol.is(':checked'),
           });
           this.ui.hideDialog(this.$dialog);
         });

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -114,6 +114,7 @@ $.summernote = $.extend($.summernote, {
     height: null,
     linkTargetBlank: true,
     useProtocol: true,
+    defaultProtocol: 'http://',
 
     focus: false,
     tabSize: 4,

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -113,6 +113,7 @@ $.summernote = $.extend($.summernote, {
     width: null,
     height: null,
     linkTargetBlank: true,
+    useProtocol: true,
 
     focus: false,
     tabSize: 4,

--- a/src/js/base/summernote-en-US.js
+++ b/src/js/base/summernote-en-US.js
@@ -56,6 +56,7 @@ $.extend($.summernote.lang, {
       textToDisplay: 'Text to display',
       url: 'To what URL should this link go?',
       openInNewWindow: 'Open in new window',
+      useProtocol: 'Use default protocol',
     },
     table: {
       table: 'Table',

--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -478,7 +478,11 @@ const linkDialog = function(opt) {
       ? '<div class="checkbox">' +
       '<label>' + '<input type="checkbox" checked> ' + opt.lang.link.openInNewWindow + '</label>' +
       '</div>' : ''
-    );
+    ) +
+    '<div class="checkbox">' +
+    '<label>' + '<input type="checkbox" checked> ' + opt.lang.link.useProtocol + '</label>' +
+    '</div>'
+    ;
   const footer = [
     '<button href="#" type="button" class="note-btn note-btn-primary note-link-btn disabled" disabled>',
     opt.lang.link.insert,

--- a/test/base/module/LinkDialog.spec.js
+++ b/test/base/module/LinkDialog.spec.js
@@ -23,6 +23,9 @@ describe('LinkDialog', () => {
       $('<div>' +
         '<p><a href="https://summernote.org/" target="_blank">hello</a></p>' +
         '<p><a href="https://summernote.org/">world</a></p>' +
+        '<p><a href="summernote.org/">summer</a></p>' +
+        '<p>summer</p>' +
+        '<p>http://summer</p>' +
         '</div>'),
       options
     );
@@ -36,6 +39,7 @@ describe('LinkDialog', () => {
   });
 
   describe('LinkDialog', () => {
+    // open-in-new-window
     it('should check new window when target=_blank', () => {
       range.createFromNode($editable.find('a')[0]).normalize().select();
       context.invoke('editor.setLastRange');
@@ -54,6 +58,51 @@ describe('LinkDialog', () => {
 
       var checked = dialog.$dialog.find('#sn-checkbox-open-in-new-window').is(':checked');
       expect(checked).to.be.false;
+    });
+
+    // use default protocol
+    it('should uncheck default protocol if link (with protocol) exists', () => {
+      range.createFromNode($editable.find('a')[1]).normalize().select();
+      context.invoke('editor.setLastRange');
+      dialog.show();
+
+      var checked = dialog.$dialog
+        .find('.sn-checkbox-use-protocol input[type=checkbox]')
+        .is(':checked');
+      expect(checked).to.be.false;
+    });
+
+    it('should uncheck default protocol if link (without protocol) exists', () => {
+      range.createFromNode($editable.find('a')[2]).normalize().select();
+      context.invoke('editor.setLastRange');
+      dialog.show();
+
+      var checked = dialog.$dialog
+        .find('.sn-checkbox-use-protocol input[type=checkbox]')
+        .is(':checked');
+      expect(checked).to.be.false;
+    });
+
+    it('should check default protocol if link not exists', () => {
+      range.createFromNode($editable.find('p')[3]).normalize().select();
+      context.invoke('editor.setLastRange');
+      dialog.show();
+
+      var checked = dialog.$dialog
+        .find('.sn-checkbox-use-protocol input[type=checkbox]')
+        .is(':checked');
+      expect(checked).to.be.true;
+    });
+
+    it('should check default protocol if link not exists although it has protocol', () => {
+      range.createFromNode($editable.find('p')[4]).normalize().select();
+      context.invoke('editor.setLastRange');
+      dialog.show();
+
+      var checked = dialog.$dialog
+        .find('.sn-checkbox-use-protocol input[type=checkbox]')
+        .is(':checked');
+      expect(checked).to.be.true;
     });
   });
 });


### PR DESCRIPTION
the original setting that add protocol automatically is usually comfortable.
But this checkbox can allow to use url not including protocol for some cases.

#### What does this PR do?

- add checkbox that allows  to use url not including protocol


#### Where should the reviewer start?

- start on the src/summernote-en-US.js : add label text
- settings.js : add 'useProtocol' option value
- lite/ui.js and src/LinkDialog.js : add checkbox to check 'useProtocol'
- Editor.js : add default protocol only if 'checkProtocol' is 'true'


#### What are the relevant tickets?

- #3313

#### Screenshot (if for frontend)

- [insert link modal](https://ibb.co/C12xVmz)
- [result](https://ibb.co/Y02qKX9)

### Checklist
- [ ] added relevant tests
- [x] didn't break anything