### PR TITLE
Add test:grep command to package.json

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,6 +50,20 @@ $ npm run test -- --browsers Safari,Firefox
 You can use `Chrome`, `ChromeCanary`, `Firefox`, `Opera`, `Safari`, `PhantomJS` and `IE` beside `PhantomJS`.
 Once you run `npm test`, it will watch all javascript file. Therefore karma run tests every time you change code.
 
+## Test a part of test
+
+If you would like to run some part of your test codes, use the watch mode.
+
+```bash
+$ npm run test:watch
+```
+
+`karma` will run test and keep waiting other test requests. And then, run `test:grep` in another terminal. Below shows how to run `LinkDialog` related tests only.
+
+```bash
+$ npm run test:grep LinkDialog
+```
+
 ## Prepush Hooks
 As part of this repo, we use the NPM package husky to implement git hooks. We leverage the prepush hook to prevent bad commits.
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build": "webpack --mode=production --config=./config/webpack.config.production.js --progress",
     "lint": "eslint src/js plugin lang test config",
     "test": "karma start karma.conf.js --single-run",
+    "test:grep": "karma run karma.conf.js -- --grep",
     "test:watch": "karma start karma.conf.js",
     "test:ci": "karma start karma.ci.conf.js --single-run"
   },


### PR DESCRIPTION
#### What does this PR do?

- Add `test:grep` command to test a part of the test suite.

#### How should this be manually tested?

- Run karma server by `npm run test:watch` and `npm run test:grep <some-test-name>` in another terminal.

#### Any background context you want to provide?

- While developing some cases, we usually need to test the speicifc items, not entire tests.

### Checklist
- [ ] added relevant tests
- [x] didn't break anything