### PR TITLE
Remove duplicate tooltip on color palette for lite theme

### DIFF
--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -262,7 +262,7 @@ const palette = renderer.create('<div class="note-color-palette"/>', function($n
         'style="background-color:', color, '" ',
         'data-event="', eventName, '" ',
         'data-value="', color, '" ',
-        'title="', colorName, '" ',
+        'data-title="', colorName, '" ',
         'aria-label="', colorName, '" ',
         'data-toggle="button" tabindex="-1"></button>',
       ].join(''));


### PR DESCRIPTION
#### What does this PR do?

- Change `title` to `data-title` for lite/ui.js to prevent browser tooltip from appearing; 
- Only required for the lite version as Bootstrap already uses an alternative data attribute instead of the `title` attribute (`data-original-title`)

#### Where should the reviewer start?

- Very small change in `/src/js/lite/ui.js`

#### How should this be manually tested?

1. Open the sample page for Lite
2. Open the text color palette by clicking the arrow for More Color
3. Hover mouse over one of the color squares for 2 seconds
4. Confirm that there is only a single, stylized tooltip containing the color name

#### Any background context you want to provide?

- N/A

#### What are the relevant tickets?

* #3385 

#### Screenshot (if for frontend)
* ![image](https://user-images.githubusercontent.com/3075348/64218169-8dba8580-ce8e-11e9-8dcc-cb4d01af05e6.png)
   instead of
* ![image](https://user-images.githubusercontent.com/3075348/64218264-f9045780-ce8e-11e9-94f0-83c2228c609b.png)


### Checklist
- [ ] added relevant tests --- No tests to be added, manual confirmation only
- [X] didn't break anything
