### PR TITLE
refs #3394 - Update to font selection error.

### DIFF
--- a/MAINTAIN.md
+++ b/MAINTAIN.md
@@ -1,3 +1,39 @@
+## Debug with VSCode
+
+
+You can debug unit tests with VSCode following the steps:
+(Based on [article](http://blog.mlewandowski.com/Debugging-Karma-tests-with-VSCode.html))
+
+1. Install [VsCode](https://code.visualstudio.com/docs/setup/setup-overview)
+2. Install [debugger-for-chrome](https://marketplace.visualstudio.com/items?itemName=msjsdiag.debugger-for-chrome) extension.
+3. Create launch.json file on ~/.vscode folder with follow config:
+```json
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "attach",
+      "name": "Attach Karma Chrome",
+      "address": "localhost",
+      "port": 9333,
+      "sourceMaps": true,
+      "pathMapping": {
+        "/": "${workspaceRoot}",
+        "/base/": "${workspaceRoot}/"
+      }
+    }
+  ]
+}
+```
+4. On terminal, run test with command:
+```
+npm run test:debug
+```
+4. Open vscode
+5. Set breakpoint on code
+6. Press F5 to run Debug and wait to stop on breakpoint
+
 ## Publish new version
 
 ### 1. `develop` to `master`

--- a/karma.debug.conf.js
+++ b/karma.debug.conf.js
@@ -1,0 +1,48 @@
+module.exports = function (config) {
+  config.set({
+    frameworks: ['mocha', 'karma-typescript'],
+    colors: true,
+    logLevel: config.LOG_INFO,
+    files: [
+      { pattern: 'src/js/**/*.js' },
+      { pattern: 'test/**/*.spec.js' }
+    ],
+    customLaunchers: {
+      ChromeDebug: {
+        base: "Chrome",
+        flags: ["--remote-debugging-port=9333"]
+      }
+    },
+    // Chrome, ChromeCanary, Firefox, Opera, Safari, IE
+    browsers: ['ChromeDebug'],
+    preprocessors: {
+      'src/js/**/*.js': ['karma-typescript'],
+      'test/**/*.spec.js': ['karma-typescript']
+    },
+    reporters: ['dots', 'karma-typescript'],
+    coverageReporter: {
+      type: 'lcov',
+      dir: 'coverage/',
+      includeAllSources: true
+    },
+    browserNoActivityTimeout: 60000,
+    karmaTypescriptConfig: {
+      tsconfig: './tsconfig.json',
+      include: [
+        'test/**/*.spec.js'
+      ],
+      bundlerOptions: {
+        entrypoints: /\.spec\.js$/,
+        transforms: [require("karma-typescript-es6-transform")()],
+        exclude: [
+          'node_modules'
+        ],
+        sourceMap: true,
+        addNodeGlobals: false
+      },
+      compilerOptions: {
+        "module": "commonjs"
+      }
+    }
+  });
+};

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint": "eslint src/js plugin lang test Gruntfile.js",
     "test": "karma start karma.conf.js --single-run",
     "test:watch": "karma start karma.conf.js",
-    "test:ci": "karma start karma.ci.conf.js --single-run"
+    "test:ci": "karma start karma.ci.conf.js --single-run",
+    "test:debug": "karma start karma.debug.conf.js"
   },
   "husky": {
     "hooks": {

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -68,7 +68,7 @@ export default class Editor {
     }
 
     this.fontName = this.wrapCommand((value) => {
-      return this.fontStyling('font-family', "\'" + value + "\'");
+      document.execCommand('fontName', false, value);
     });
 
     this.fontSize = this.wrapCommand((value) => {
@@ -438,8 +438,8 @@ export default class Editor {
 
     if (typeof event !== 'undefined') {
       if (key.isMove(event.keyCode) ||
-          (event.ctrlKey || event.metaKey) ||
-          lists.contains([key.code.BACKSPACE, key.code.DELETE], event.keyCode)) {
+        (event.ctrlKey || event.metaKey) ||
+        lists.contains([key.code.BACKSPACE, key.code.DELETE], event.keyCode)) {
         return false;
       }
     }
@@ -736,7 +736,12 @@ export default class Editor {
     const rng = this.getLastRange();
 
     if (rng) {
+      var previousEl = rng.sc.parentElement;
       const spans = this.style.styleNodes(rng);
+
+      if (previousEl && previousEl.style && previousEl.style.length > 0) {
+        $(spans).attr('style', previousEl.style.cssText);
+      }
       $(spans).css(target, value);
 
       // [workaround] added styled bogus span for style

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -68,7 +68,7 @@ export default class Editor {
     }
 
     this.fontName = this.wrapCommand((value) => {
-      document.execCommand('fontName', false, value);
+      return this.fontStyling('font-family', "\'" + value + "\'");
     });
 
     this.fontSize = this.wrapCommand((value) => {
@@ -736,12 +736,7 @@ export default class Editor {
     const rng = this.getLastRange();
 
     if (rng) {
-      var previousEl = rng.sc.parentElement;
       const spans = this.style.styleNodes(rng);
-
-      if (previousEl && previousEl.style && previousEl.style.length > 0) {
-        $(spans).attr('style', previousEl.style.cssText);
-      }
       $(spans).css(target, value);
 
       // [workaround] added styled bogus span for style
@@ -750,7 +745,7 @@ export default class Editor {
         const firstSpan = lists.head(spans);
         if (firstSpan && !dom.nodeLength(firstSpan)) {
           firstSpan.innerHTML = dom.ZERO_WIDTH_NBSP_CHAR;
-          range.createFromNodeAfter(firstSpan.firstChild).select();
+          range.createFromNode(firstSpan.firstChild).select();
           this.setLastRange();
           this.$editable.data(KEY_BOGUS, firstSpan);
         }

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -343,6 +343,13 @@ describe('Editor', () => {
       // start <p>hello</p> => <blockquote class="blockquote">hello</blockquote>
       expectContents(context, '<blockquote class="blockquote">hello</blockquote>');
     });
+
+    it('should add fontSize to block', () => {
+      $editable.appendTo('body');
+      editor.fontSize(20);
+
+      expectContents(context, '<p><span style="font-size: 20px;">﻿</span>hello</p>');
+    });
   });
 
   describe('createLink', () => {


### PR DESCRIPTION
Update to:
1 - Change font-family from execCommand instead of CSS.
2 - Update fontStyling method to recover previous element format before
apply new Style.

#### What does this PR do?

- Update the methods used to chande FontSize to avoid lost previous format.
- Change FontName method to use default execCommand and avoid lost previous format.

#### Where should the reviewer start?

- start on the src/js/base/module/Editor.js

#### How should this be manually tested?

- Follow the script on issue #3394, after this update no more error can be found.

#### What are the relevant tickets?

- #3394 

#### Notes

- The execCommand not apply changes direct to HTML and I can´t create specific tests to validade FontSize automatic.
- If has any form to do, I want to know.

### Checklist
- [ OK] added relevant tests
- [ OK] didn't break anything
