### PR TITLE
Don't disable Full Screen toggle when activating Code View

### DIFF
--- a/src/js/base/module/Toolbar.js
+++ b/src/js/base/module/Toolbar.js
@@ -133,7 +133,7 @@ export default class Toolbar {
   activate(isIncludeCodeview) {
     let $btn = this.$toolbar.find('button');
     if (!isIncludeCodeview) {
-      $btn = $btn.not('.btn-codeview');
+      $btn = $btn.not('.btn-codeview').not('.btn-fullscreen');
     }
     this.ui.toggleBtn($btn, true);
   }
@@ -141,7 +141,7 @@ export default class Toolbar {
   deactivate(isIncludeCodeview) {
     let $btn = this.$toolbar.find('button');
     if (!isIncludeCodeview) {
-      $btn = $btn.not('.btn-codeview');
+      $btn = $btn.not('.btn-codeview').not('.btn-fullscreen');
     }
     this.ui.toggleBtn($btn, false);
   }


### PR DESCRIPTION
#### What does this PR do?
Allows Full Screen to be toggled when in code view

Full Screen works fine with code view, but currently users must drop out of Code View in order to toggle Full Screen

#### Where should the reviewer start?

- start on src/js/base/module/Toolbar.js

#### How should this be manually tested?

- In an editor with code view and full screen views enabled.
- Toggle Code View on.
- Toggle Full Screen on, then off.

#### Any background context you want to provide?

Simple fix for a minor annoyance; why press 3 things when 1 will do?

#### What are the relevant tickets?

https://github.com/summernote/summernote/issues/3343

#### Screenshot (if for frontend)


### Checklist
- [ ] added relevant tests
- [x] didn't break anything
- [ ] ...
