### PR TITLE
Add disable TAB/Shift+TAB option.

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -416,13 +416,15 @@ export default class Editor {
       keys.push(keyName);
     }
 
-    const eventName = keyMap[keys.join('+')];
-    if (eventName) {
-      if (this.context.invoke(eventName) !== false) {
-        event.preventDefault();
+    if (keyName == 'TAB' && !this.options.tabDisable){
+      const eventName = keyMap[keys.join('+')];
+      if (eventName) {
+        if (this.context.invoke(eventName) !== false) {
+          event.preventDefault();
+        }
+      } else if (key.isEdit(event.keyCode)) {
+        this.afterCommand();
       }
-    } else if (key.isEdit(event.keyCode)) {
-      this.afterCommand();
     }
   }
 

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -118,6 +118,7 @@ $.summernote = $.extend($.summernote, {
     defaultProtocol: 'http://',
 
     focus: false,
+    tabDisabled: false,
     tabSize: 4,
     styleWithSpan: true,
     shortcuts: true,


### PR DESCRIPTION
#### What does this PR do?

Add `tabDisabled: false/true;` option to settings, and modify `handleKeyMap();` function to handle set option.

#### Where should the reviewer start?

- src/js/base/settings.js
- src/js/base/modules/Editor.js

#### Any background context you want to provide?

Modification was made due Issue request asking how to disable TAB interaction with Summernote for use in Forms.

#### What are the relevant tickets?

#1317 #615 #324
