### PR TITLE
Add disableGrammar option.

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -367,6 +367,12 @@ export default class Editor {
 
     this.$editable.attr('spellcheck', this.options.spellCheck);
 
+    this.$editable.attr('autocorrect', this.options.spellCheck);
+
+    if (this.options.disableGrammar) {
+      this.$editable.attr('data-gramm', false);
+    }
+
     // init content before set event
     this.$editable.html(dom.html(this.$note) || dom.emptyPara);
 

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -129,6 +129,7 @@ $.summernote = $.extend($.summernote, {
     maxTextLength: 0,
     blockquoteBreakingLevel: 2,
     spellCheck: true,
+    disableGrammar: false,
     placeholder: null,
     inheritPlaceholder: false,
 


### PR DESCRIPTION
#### What does this PR do?

Added `disableGrammar` option, so far only Grammarly is disabled.

#### Where should the reviewer start?

- src/js/base/settings.js
- src/js/base/module/Editor.js

#### Any background context you want to provide?

- Noticed documentation was missing for `spellCheck` options, and had meaning to add ability to also disable Grammarly.

### Checklist
- [ ] added relevant tests
- [ ] didn't break anything
- [ ] ...
