### PR TITLE
Add .blur to popover actions to hide popovers when losing focus.

### DIFF
--- a/src/js/base/module/AirPopover.js
+++ b/src/js/base/module/AirPopover.js
@@ -15,7 +15,7 @@ export default class AirPopover {
       'summernote.keyup summernote.mouseup summernote.scroll': () => {
         this.update();
       },
-      'summernote.disable summernote.change summernote.dialog.shown': () => {
+      'summernote.disable summernote.change summernote.dialog.shown summernote.blur': () => {
         this.hide();
       },
       'summernote.focusout': (we, e) => {

--- a/src/js/base/module/HintPopover.js
+++ b/src/js/base/module/HintPopover.js
@@ -27,7 +27,7 @@ export default class HintPopover {
       'summernote.keydown': (we, e) => {
         this.handleKeydown(e);
       },
-      'summernote.disable summernote.dialog.shown': () => {
+      'summernote.disable summernote.dialog.shown summernote.blur': () => {
         this.hide();
       },
     };

--- a/src/js/base/module/ImagePopover.js
+++ b/src/js/base/module/ImagePopover.js
@@ -16,7 +16,7 @@ export default class ImagePopover {
     this.options = context.options;
 
     this.events = {
-      'summernote.disable': () => {
+      'summernote.disable summernote.blur': () => {
         this.hide();
       },
     };

--- a/src/js/base/module/LinkPopover.js
+++ b/src/js/base/module/LinkPopover.js
@@ -12,7 +12,7 @@ export default class LinkPopover {
       'summernote.keyup summernote.mouseup summernote.change summernote.scroll': () => {
         this.update();
       },
-      'summernote.disable summernote.dialog.shown': () => {
+      'summernote.disable summernote.dialog.shown summernote.blur': () => {
         this.hide();
       },
     };

--- a/src/js/base/module/TablePopover.js
+++ b/src/js/base/module/TablePopover.js
@@ -16,7 +16,7 @@ export default class TablePopover {
       'summernote.keyup summernote.scroll summernote.change': () => {
         this.update();
       },
-      'summernote.disable': () => {
+      'summernote.disable summernote.blur': () => {
         this.hide();
       },
     };


### PR DESCRIPTION
#### What does this PR do?

Add `summernote.blur` to popover events so popovers get closed when editor loses focus.

#### What are the relevant tickets?

#2729 
