### PR TITLE
Fix airMode Menu from appearing when disabled.

### DIFF
--- a/src/js/base/Context.js
+++ b/src/js/base/Context.js
@@ -110,6 +110,7 @@ export default class Context {
     this.layoutInfo.editable.attr('contenteditable', true);
     this.invoke('toolbar.activate', true);
     this.triggerEvent('disable', false);
+    this.options.editing = true;
   }
 
   disable() {
@@ -118,6 +119,7 @@ export default class Context {
       this.invoke('codeview.deactivate');
     }
     this.layoutInfo.editable.attr('contenteditable', false);
+    this.options.editing = false;
     this.invoke('toolbar.deactivate', true);
 
     this.triggerEvent('disable', true);

--- a/src/js/base/module/AirPopover.js
+++ b/src/js/base/module/AirPopover.js
@@ -13,7 +13,9 @@ export default class AirPopover {
     this.options = context.options;
     this.events = {
       'summernote.keyup summernote.mouseup summernote.scroll': () => {
-        this.update();
+        if (this.options.editing == true) {
+          this.update();
+        }
       },
       'summernote.disable summernote.change summernote.dialog.shown summernote.blur': () => {
         this.hide();

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -38,6 +38,7 @@ $.summernote = $.extend($.summernote, {
   options: {
     langInfo: $.summernote.lang['en-US'],
     id: $.now(),
+    editing: true,
     modules: {
       'editor': Editor,
       'clipboard': Clipboard,


### PR DESCRIPTION
#### What does this PR do?

Adds a togglable option `options.editing' true|false to indicate the editing mode easily without having to resort to complicated code to determine the editing mode. This enabled me to fix issue #3305 where when editing was disabled in airMode the menu would still appear and it's button functions could still be used.

#### Where should the reviewer start?

- src/js/base/settings.js - options - editing: true|false
- src/js/base/Context.js - enable() - disable()
- src/js/base/Module/AirPopover.js - Add check if `options.editing` equals true events.

#### What are the relevant tickets?

#3305 

### Checklist
- [ ] added relevant tests
- [ ] didn't break anything
- [ ] ...
