### PR TITLE
Modify fontStyling()

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -744,8 +744,9 @@ export default class Editor {
   fontStyling(target, value) {
     const rng = this.getLastRange();
 
-    if (rng) {
+    if (rng != '') {
       const spans = this.style.styleNodes(rng);
+      this.$editor.find('.note-status-output').html('');
       $(spans).css(target, value);
 
       // [workaround] added styled bogus span for style
@@ -759,6 +760,10 @@ export default class Editor {
           this.$editable.data(KEY_BOGUS, firstSpan);
         }
       }
+    } else {
+      const noteStatusOutput = $.now();
+      this.$editor.find('.note-status-output').html('<div id="note-status-output-' + noteStatusOutput + '" class="alert alert-info">' + this.lang.output.noSelection + '</div>');
+      setTimeout(function(){$('#note-status-output-' + noteStatusOutput).remove();}, 5000);
     }
   }
 

--- a/src/js/base/summernote-en-US.js
+++ b/src/js/base/summernote-en-US.js
@@ -158,5 +158,8 @@ $.extend($.summernote.lang, {
       specialChar: 'SPECIAL CHARACTERS',
       select: 'Select Special characters',
     },
+    output: {
+      noSelection: 'No Selection Made!',
+    }
   },
 });


### PR DESCRIPTION
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.

#### What does this PR do?

This PR modifies the fontStyling() function to stop it adding styling to unselected areas, it also displays an error in the Status Area, and adds a new lang.output area in the language file. Essentially I've added a check on the range to make sure it contains data to eliminate inserting an empty span with the font option. I would prefer for the function to check if the caret is within a word, then wrap that word in the span, but I couldn't work out how to make that work.

#### Where should the reviewer start?

- src/js/base/module/Editor.js
- src/js/base/summernote-en-US.js

#### What are the relevant tickets?

#2363 

#### Screenshot (if for frontend)


### Checklist
- [ ] added relevant tests
- [ ] didn't break anything
- [ ] ...
