### PR TITLE
fix cliboard paste image two times bug

### DIFF
--- a/src/js/base/module/Clipboard.js
+++ b/src/js/base/module/Clipboard.js
@@ -22,6 +22,8 @@ export default class Clipboard {
       if (item.kind === 'file' && item.type.indexOf('image/') !== -1) {
         // paste img file
         this.context.invoke('editor.insertImagesOrCallback', [item.getAsFile()]);
+        event.preventDefault();
+
         this.context.invoke('editor.afterCommand');
       } else if (item.kind === 'string') {
         // paste text with maxTextLength check


### PR DESCRIPTION
#### What does this PR do?

- fix bug of 'copy image' 

#### Where should the reviewer start?

- start on the src/js/base/module/Clipboard.js

#### How should this be manually tested?

- search any image
- mouse right-click
- copy image
- paste summernote editor

#### What are the relevant tickets?

- [#3294 ](https://github.com/summernote/summernote/issues/3294)
- [#2717](https://github.com/summernote/summernote/issues/2717)

### Checklist
- [ ] added relevant tests
- [ ] didn't break anything
- [ ] ...
