### PR TITLE
Add missing styles for summernote SVG font

### DIFF
--- a/src/icons/templates/summernote-icons.css
+++ b/src/icons/templates/summernote-icons.css
@@ -32,15 +32,22 @@
   {%- endif -%}
 }
 
+
 [class^="{{ className }}"]:before,
 [class*=" {{ className }}"]:before {
   display: inline-block;
-  font: normal normal normal 11px/1 {{ fontName }};
+  font-family: {{ fontName }};
+  font-style: normal;
+  font-size: inherit;
+  text-decoration: inherit;
   text-rendering: auto;
+  text-transform: none;
+  vertical-align: middle;
   -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
+  speak: none;
 }
- 
+
 
 .{{ className }}-fw {
   text-align: center;

--- a/src/styles/summernote-bs4.scss
+++ b/src/styles/summernote-bs4.scss
@@ -5,5 +5,6 @@
 .note-toolbar .note-btn {
   background: #fff;
   border-color: #dae0e5;
-  padding: 0.25rem 0.65rem;
+  padding: 0.28rem 0.65rem;
+  font-size: 13px;
 }


### PR DESCRIPTION
#### What does this PR do?

- Update Summernote SVG font by adding missing styles while refactoring

#### Any background context you want to provide?

- After refactoring(https://github.com/summernote/summernote/commit/1773e52361a68750ed2cf8fd4e14201787521693), fonts had been rendered a bit differently from the previous. So I tracked down to the original font styles and applied them to the current one.