### PR TITLE
fixed wrong last range

### DIFF
--- a/src/js/base/core/range.js
+++ b/src/js/base/core/range.js
@@ -674,12 +674,17 @@ export default {
       return new WrappedRange(sc, so, ec, eo);
     } else {
       let wrappedRange = this.createFromSelection();
+
       if (!wrappedRange && arguments.length === 1) {
-        wrappedRange = this.createFromNode(arguments[0]);
-        return wrappedRange.collapse(dom.emptyPara === arguments[0].innerHTML);
+        return this.createFromBodyElement(arguments[0], dom.emptyPara === arguments[0].innerHTML);
       }
       return wrappedRange;
     }
+  },
+
+  createFromBodyElement: function(bodyElement, isCollapseToStart = false) {
+    var wrappedRange = this.createFromNode(bodyElement);
+    return wrappedRange.collapse(isCollapseToStart);
   },
 
   createFromSelection: function() {

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -476,6 +476,10 @@ export default class Editor {
 
   setLastRange() {
     this.lastRange = range.create(this.editable);
+
+    if ($(this.lastRange.sc).closest('.note-editable').length === 0) {
+      this.lastRange = range.createFromBodyElement(this.editable);
+    }
   }
 
   getLastRange() {

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -153,6 +153,15 @@ describe('Editor', () => {
     });
   });
 
+  describe('setLastRange', () => {
+    it('should set last range', () => {
+      document.body.click();
+      editor.setLastRange();
+
+      expect(editor.lastRange.sc).to.equal(editor.editable);
+    });
+  })
+
   describe('insertNode', () => {
     it('should insert node', () => {
       editor.insertNode($('<span> world</span>')[0]);


### PR DESCRIPTION
When you click outside the editing area, you can correct the wrong part of the range that you have inside Summernote.

#### What does this PR do?

- fixed wrong last range 
- fix the default area of ​​range to `.note-editable`

#### Where should the reviewer start?

- start on the src/js/base/module/Editor.js 

#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?

#3488 
#2141

#### Screenshot (if for frontend)


### Checklist
- [x] added relevant tests
- [x] didn't break anything
