### PR TITLE
Dropzone should be target for pointer events,

### DIFF
--- a/src/styles/summernote-common.scss
+++ b/src/styles/summernote-common.scss
@@ -21,7 +21,6 @@ $img-margin-right: 10px;
     color: $dropzone-color;
     background-color: #fff;
     opacity: 0.95;
-    pointer-events: none;
 
     .note-dropzone-message {
       display: table-cell;


### PR DESCRIPTION
otherwise the dropzone is not activated when dropping image files.

#### What does this PR do?

- fix issue #3326 

#### Where should the reviewer start?

- start on the src/styles/summernote-common.scss

#### How should this be manually tested?

- test the lite version, and see that image files can be dropped

#### What are the relevant tickets?

#3326 

### Checklist
- [x] added relevant tests => cannot be unit tested.
