### PR TITLE
fixed not using p-br tag

### DIFF
--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -575,6 +575,10 @@ function prevPoint(point, isSkipInnerOffset) {
 function nextPoint(point, isSkipInnerOffset) {
   let node, offset;
 
+  if (isEmpty(point.node)) {
+    return null;
+  }
+
   if (nodeLength(point.node) === point.offset) {
     if (isEditable(point.node)) {
       return null;
@@ -585,9 +589,16 @@ function nextPoint(point, isSkipInnerOffset) {
   } else if (hasChildren(point.node)) {
     node = point.node.childNodes[point.offset];
     offset = 0;
+    if (isEmpty(node)) {
+      return null;
+    }
   } else {
     node = point.node;
     offset = isSkipInnerOffset ? nodeLength(point.node) : point.offset + 1;
+
+    if (isEmpty(node)) {
+      return null;
+    }
   }
 
   return {

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -660,7 +660,7 @@ export default class Editor {
       }
 
       $image.show();
-      range.create(this.editable).insertNode($image[0]);
+      this.getLastRange().insertNode($image[0]);
       range.createFromNodeAfter($image[0]).select();
       this.setLastRange();
       this.afterCommand();

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -244,9 +244,17 @@ describe('Editor', () => {
   });
 
   describe('insertHorizontalRule', () => {
-    it('should insert horizontal rule', () => {
+    it('should insert horizontal rule without splitting tag', () => {
       editor.insertHorizontalRule();
       expectContents(context, '<p>hello</p><hr>');
+    });
+
+    it('should insert horizontal rule with splitting tag', () => {
+      var textNode = $editable.find('p')[0].firstChild;
+      var rng = range.create(textNode, 5, textNode, 5).normalize().select();
+      editor.lastRange = rng;
+      editor.insertHorizontalRule();
+      expectContents(context, '<p>hello</p><hr><p><br></p>');
     });
   });
 

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -246,7 +246,7 @@ describe('Editor', () => {
   describe('insertHorizontalRule', () => {
     it('should insert horizontal rule', () => {
       editor.insertHorizontalRule();
-      expectContents(context, '<p>hello</p><hr><p><br></p>');
+      expectContents(context, '<p>hello</p><hr>');
     });
   });
 
@@ -258,7 +258,6 @@ describe('Editor', () => {
         '<tr><td><br></td><td><br></td></tr>',
         '<tr><td><br></td><td><br></td></tr>',
         '</tbody></table>',
-        '<p><br></p>',
       ].join('');
       editor.insertTable('2x2');
       expectContents(context, markup);
@@ -315,7 +314,7 @@ describe('Editor', () => {
       var endNode = $editable.find('p').last()[0];
 
       // all p tags is wrapped
-      range.create(startNode, 1, endNode, 1).normalize().select();
+      range.create(startNode, 0, endNode, 1).normalize().select();
 
       editor.formatBlock('blockquote');
 


### PR DESCRIPTION
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.

#### What does this PR do?

- fixed not using p-br bug 
- Do not force `<p> <br> </p>` tags when insertNode, pasteHTML is executed on the block element.

#### Where should the reviewer start?

- start on the src/js/base/core/dom.js 
- src/js/base/core/range.js
  * normalize () 
  * insertNode()
  * pasteHTML()
-  

#### How should this be manually tested?

- $("#summernote").summernote("pasteHTML",  "`<p>aaaa</p>`") 

#### Any background context you want to provide?

* Prevents `<p> <br> </ p>` from entering block elements automatically.
* The range.insertNode () function is fixed by default.
* The range.insertNode () function is used to insert most elements, so the result may be different from the ones already applied.
* More browser-specific testing may be required 

#### What are the relevant tickets?

* #3495
* #3370 
* #3378 
* #3196 
* #2007
* #1879
* #3478 

#### Screenshot (if for frontend)


### Checklist
- [x] added relevant tests
- [x] didn't break anything
