### PR TITLE
Fix popover behavior when summernote has focus

### DIFF
--- a/src/js/base/module/AirPopover.js
+++ b/src/js/base/module/AirPopover.js
@@ -11,6 +11,9 @@ export default class AirPopover {
     this.context = context;
     this.ui = $.summernote.ui;
     this.options = context.options;
+
+    this.hidable = true;
+
     this.events = {
       'summernote.keyup summernote.mouseup summernote.scroll': () => {
         if (this.options.editing) {
@@ -45,6 +48,11 @@ export default class AirPopover {
     const $content = this.$popover.find('.popover-content');
 
     this.context.invoke('buttons.build', $content, this.options.popover.air);
+
+    // disable hiding this popover preemptively by 'summernote.blur' event.
+    this.$popover.on('mousedown', () => { this.hidable = false; });
+    // (re-)enable hiding after 'summernote.blur' has been handled (aka. ignored).
+    this.$popover.on('mouseup', () => { this.hidable = true; });
   }
 
   destroy() {
@@ -70,6 +78,8 @@ export default class AirPopover {
   }
 
   hide() {
-    this.$popover.hide();
+    if (this.hidable) {
+      this.$popover.hide();
+    }
   }
 }

--- a/src/js/base/module/Handle.js
+++ b/src/js/base/module/Handle.js
@@ -18,7 +18,7 @@ export default class Handle {
       'summernote.keyup summernote.scroll summernote.change summernote.dialog.shown': () => {
         this.update();
       },
-      'summernote.disable': () => {
+      'summernote.disable summernote.blur': () => {
         this.hide();
       },
       'summernote.codeview.toggled': () => {

--- a/src/js/base/module/HintPopover.js
+++ b/src/js/base/module/HintPopover.js
@@ -52,6 +52,8 @@ export default class HintPopover {
       $(e.currentTarget).addClass('active');
       this.replace();
     });
+
+    this.$popover.on('mousedown', (e) => { e.preventDefault(); });
   }
 
   destroy() {

--- a/src/js/base/module/ImagePopover.js
+++ b/src/js/base/module/ImagePopover.js
@@ -32,6 +32,8 @@ export default class ImagePopover {
     }).render().appendTo(this.options.container);
     const $content = this.$popover.find('.popover-content,.note-popover-content');
     this.context.invoke('buttons.build', $content, this.options.popover.image);
+
+    this.$popover.on('mousedown', (e) => { e.preventDefault(); });
   }
 
   destroy() {

--- a/src/js/base/module/LinkPopover.js
+++ b/src/js/base/module/LinkPopover.js
@@ -33,6 +33,8 @@ export default class LinkPopover {
     const $content = this.$popover.find('.popover-content,.note-popover-content');
 
     this.context.invoke('buttons.build', $content, this.options.popover.link);
+
+    this.$popover.on('mousedown', (e) => { e.preventDefault(); });
   }
 
   destroy() {

--- a/src/js/base/module/TablePopover.js
+++ b/src/js/base/module/TablePopover.js
@@ -38,6 +38,8 @@ export default class TablePopover {
     if (env.isFF) {
       document.execCommand('enableInlineTableEditing', false, false);
     }
+
+    this.$popover.on('mousedown', (e) => { e.preventDefault(); });
   }
 
   destroy() {


### PR DESCRIPTION
#### What does this PR do?

Fixes issue of various popovers (image, table, link) not properly working if summernote had focus before pop-up menu is made visible. Also fixes problem with image control selections not disappearing after blur event.

#### What are the relevant tickets?

Original issue: #3499 
Related issue: #2729

#### Where should the reviewer start?

Start in `src/js/base/module/AirPopover.js`, because I'm not entirely sure how clean the solution for the air popover really is. Drop-down buttons in air mode's popover didn't work if `preventDefault()` is called on `mousedown` event (like the solution for other popovers). There might be a better fix for this but I don't have enough time to look further into this. Drop-down buttons are handled by Bootstrap (except for lite of course) and a cleaner approach for `AirPopover.js` seemed to boil down to more fundamental changes.

#### How should this be manually tested?

Add tables, images and links and try to modify said components with focus inside/outside of summernote's editing area. Check drop-down buttons in air mode's popover (color, text size, ...).
