### PR TITLE
Add setting to change font size unit

### DIFF
--- a/src/js/base/editing/Style.js
+++ b/src/js/base/editing/Style.js
@@ -38,7 +38,12 @@ export default class Style {
   fromNode($node) {
     const properties = ['font-family', 'font-size', 'text-align', 'list-style-type', 'line-height'];
     const styleInfo = this.jQueryCSS($node, properties) || {};
-    styleInfo['font-size'] = parseInt(styleInfo['font-size'], 10);
+
+    const fontSize = $node[0].style.fontSize || styleInfo['font-size'];
+
+    styleInfo['font-size'] = parseInt(fontSize, 10);
+    styleInfo['font-size-unit'] = fontSize.match(/[a-z%]+$/);
+
     return styleInfo;
   }
 

--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -393,6 +393,26 @@ export default class Buttons {
       ]).render();
     });
 
+    this.context.memo('button.fontsizeunit', () => {
+      return this.ui.buttonGroup([
+        this.button({
+          className: 'dropdown-toggle',
+          contents: this.ui.dropdownButtonContents('<span class="note-current-fontsizeunit"/>', this.options),
+          tooltip: this.lang.font.sizeunit,
+          data: {
+            toggle: 'dropdown',
+          },
+        }),
+        this.ui.dropdownCheck({
+          className: 'dropdown-fontsizeunit',
+          checkClassName: this.options.icons.menuCheck,
+          items: this.options.fontSizeUnits,
+          title: this.lang.font.sizeunit,
+          click: this.context.createInvokeHandlerAndUpdateState('editor.fontSizeUnit'),
+        }),
+      ]).render();
+    });
+
     this.context.memo('button.color', () => {
       return this.colorPalette('note-color-all', this.lang.color.recent, true, true);
     });
@@ -846,6 +866,14 @@ export default class Buttons {
         $item.toggleClass('checked', isChecked);
       });
       $cont.find('.note-current-fontsize').text(fontSize);
+
+      const fontSizeUnit = styleInfo['font-size-unit'];
+      $cont.find('.dropdown-fontsizeunit a').each((idx, item) => {
+        const $item = $(item);
+        const isChecked = ($item.data('value') + '') === (fontSizeUnit + '');
+        $item.toggleClass('checked', isChecked);
+      });
+      $cont.find('.note-current-fontsizeunit').text(fontSizeUnit);
     }
 
     if (styleInfo['line-height']) {

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -72,7 +72,8 @@ export default class Editor {
     });
 
     this.fontSize = this.wrapCommand((value) => {
-      return this.fontStyling('font-size', value + 'px');
+      let unit = this.options.fontSizeUnit || 'px';
+      return this.fontStyling('font-size', value + unit);
     });
 
     for (let idx = 1; idx <= 6; idx++) {

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -72,8 +72,13 @@ export default class Editor {
     });
 
     this.fontSize = this.wrapCommand((value) => {
-      let unit = this.options.fontSizeUnit || 'px';
+      const unit = this.currentStyle()['font-size-unit'];
       return this.fontStyling('font-size', value + unit);
+    });
+
+    this.fontSizeUnit = this.wrapCommand((value) => {
+      const size = this.currentStyle()['font-size'];
+      return this.fontStyling('font-size', size + value);
     });
 
     for (let idx = 1; idx <= 6; idx++) {

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -148,6 +148,8 @@ $.summernote = $.extend($.summernote, {
 
     fontSizes: ['8', '9', '10', '11', '12', '14', '18', '24', '36'],
 
+    fontSizeUnits: ['px', 'pt'],
+
     // pallete colors(n x n)
     colors: [
       ['#000000', '#424242', '#636363', '#9C9C94', '#CEC6CE', '#EFEFEF', '#F7F7F7', '#FFFFFF'],

--- a/src/js/base/summernote-en-US.js
+++ b/src/js/base/summernote-en-US.js
@@ -17,6 +17,7 @@ $.extend($.summernote.lang, {
       subscript: 'Subscript',
       superscript: 'Superscript',
       size: 'Font Size',
+      sizeunit: 'Font Size Unit',
     },
     image: {
       image: 'Picture',


### PR DESCRIPTION
#### What does this PR do?

Resolves: #2874

Adds new option 'fontSizeUnit' to change the font size unit to 'pt'.

#### Where should the reviewer start?

Start in src/js/base/module/Editor.js

#### How should this be manually tested?

Initialize summernote with fontSizeUnit option and change size of text.

```js
$editor.summernote({
  fontSizeUnit: 'pt',
});
```

#### Any background context you want to provide?

Documentation/Website might need to be updated.

(Available font sizes can also be modified (fontSizes), which I couldn't find in documentation)

#### What are the relevant tickets?

#2874