### PR TITLE
Revert "Fix Lite Styling, and namespace some classes."

### DIFF
--- a/src/js/base/module/HelpDialog.js
+++ b/src/js/base/module/HelpDialog.js
@@ -48,7 +48,7 @@ export default class HelpDialog {
       const command = keyMap[key];
       const $row = $('<div><div class="help-list-item"/></div>');
       $row.append($('<label><kbd>' + key + '</kdb></label>').css({
-        'width': 170,
+        'width': 180,
         'margin-right': 10,
       })).append($('<span/>').html(this.context.memo('help.' + command) || command));
       return $row.html();

--- a/src/js/base/summernote-en-US.js
+++ b/src/js/base/summernote-en-US.js
@@ -140,7 +140,7 @@ $.extend($.summernote.lang, {
       'insertOrderedList': 'Toggle ordered list',
       'outdent': 'Outdent on current paragraph',
       'indent': 'Indent on current paragraph',
-      'formatPara': 'Change current block\'s format as a Paragraph',
+      'formatPara': 'Change current block\'s format as a paragraph(P tag)',
       'formatH1': 'Change current block\'s format as H1',
       'formatH2': 'Change current block\'s format as H2',
       'formatH3': 'Change current block\'s format as H3',

--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -401,7 +401,7 @@ const dialog = renderer.create('<div class="note-modal" aria-hidden="false" tabi
   });
   $node.html([
     '<div class="note-modal-content">',
-      (options.title ? '<div class="note-modal-header"><button type="button" class="note-close" aria-label="Close" aria-hidden="true"><i class="note-icon-close"></i></button><h4 class="note-modal-title">' + options.title + '</h4></div>' : ''),
+      (options.title ? '<div class="note-modal-header"><button type="button" class="close" aria-label="Close" aria-hidden="true"><i class="note-icon-close"></i></button><h4 class="note-modal-title">' + options.title + '</h4></div>' : ''),
       '<div class="note-modal-body">' + options.body + '</div>',
       (options.footer ? '<div class="note-modal-footer">' + options.footer + '</div>' : ''),
     '</div>',

--- a/src/js/lite/ui/DropdownUI.js
+++ b/src/js/lite/ui/DropdownUI.js
@@ -60,11 +60,13 @@ class DropdownUI {
 $(document).on('click', function(e) {
   if (!$(e.target).closest('.note-btn-group').length) {
     $('.note-btn-group.open').removeClass('open');
+    $('.note-btn-group .note-btn.active').removeClass('active');
   }
 });
 
 $(document).on('click.note-dropdown-menu', function(e) {
   $(e.target).closest('.note-dropdown-menu').parent().removeClass('open');
+  $(e.target).closest('.note-dropdown-menu').parent().find('.note-btn.active').removeClass('active');
 });
 
 export default DropdownUI;

--- a/src/js/lite/ui/ModalUI.js
+++ b/src/js/lite/ui/ModalUI.js
@@ -23,7 +23,7 @@ class ModalUI {
     this.$modal.appendTo(this.options.target).addClass('open').show();
 
     this.$modal.trigger('note.modal.show');
-    this.$modal.off('click', '.note-close').on('click', '.note-close', this.hide.bind(this));
+    this.$modal.off('click', '.close').on('click', '.close', this.hide.bind(this));
   }
 
   hide() {

--- a/src/styles/lite/buttons.scss
+++ b/src/styles/lite/buttons.scss
@@ -47,22 +47,14 @@
     @include box-shadow(none);
   }
 
-}
+  & > span.note-icon-caret:first-child {
+    margin-left: -1px;
+  }
 
-.note-icon-caret {
-  padding: 3px 5px 3px 0;
-}
-
-.note-icon-caret::before {
-  padding: 3px 2px 2px 0;
-}
-
-.note-btn .note-icon-caret:before {
-  padding: 3px 2px 3px 4px;
-}
-
-.note-btn.dropdown-toggle {
-  padding: 1px 1px 1px 10px;
+  & > span.note-icon-caret:nth-child(2) {
+    padding-left: 3px;
+    margin-right: -5px;
+  }
 }
 
 .note-btn-primary {

--- a/src/styles/lite/buttons.scss
+++ b/src/styles/lite/buttons.scss
@@ -1,6 +1,5 @@
 .note-btn {
   display: inline-block;
-  height: 30px;
   font-weight: 400;
   margin-bottom: 0;
   text-align: center;
@@ -50,67 +49,29 @@
 
 }
 
-.note-toolbar .note-btn {
-  padding-right: $padding-base-horizontal !important;
-  padding-left: $padding-base-horizontal !important;
+.note-icon-caret {
+  padding: 3px 5px 3px 0;
 }
 
-.note-air-popover .note-btn {
-  padding-top: 9px!important;
-  padding-right: 10px!important;
-  padding-bottom: 9px!important;
-  padding-left: 10px!important;
-}
-
-.note-toolbar .note-icon-caret {
-  padding: 3px 0 3px 5px;
-}
-
-.note-air-popover .note-icon-caret {
-  padding: 3px 0 3px 5px;
-}
-
-.note-toolbar .note-icon-caret::before {
+.note-icon-caret::before {
   padding: 3px 2px 2px 0;
 }
 
-.note-air-popover .note-icon-caret::before {
-  padding: 3px 2px 2px 0;
+.note-btn .note-icon-caret:before {
+  padding: 3px 2px 3px 4px;
 }
 
-.note-toolbar .note-btn .note-icon-caret:before {
-  padding: 3px 0 3px 5px;
-}
-
-.note-air-popover .note-btn .note-icon-caret:before {
-  padding: 3px 0 3px 5px;
-}
-
-.note-toolbar .note-btn.dropdown-toggle {
-  padding: 5px 1px 5px 10px;
-}
-
-.note-air-popover .note-btn.dropdown-toggle {
-  padding-top: 5px!important;
-  padding-right: 1px!important;
-  padding-bottom: 5px!important;
-  padding-left: 10px!important;
+.note-btn.dropdown-toggle {
+  padding: 1px 1px 1px 10px;
 }
 
 .note-btn-primary {
+  background: #fa6362;
   color: #fff;
-  background-color: #007bff;
-  border-color: #007bff;
 
-  &:hover {
-    color: #fff;
-    background-color: #0069d9;
-    border-color: #0062cc;
-  }
-
+  &:hover,
   &:focus,
   &.focus {
-    box-shadow: 0 0 0 .2rem rgba(38,143,255,.5);
     color: #fff;
     text-decoration: none;
     border: 1px solid $btn-default-border;
@@ -138,7 +99,7 @@ input[type="button"] {
   }
 }
 
-button.note-close {
+button.close {
   padding: 0;
   cursor: pointer;
   background: transparent;
@@ -146,16 +107,15 @@ button.note-close {
   -webkit-appearance: none;
 }
 
-.note-close {
+.close {
   float: right;
   font-size: 21px;
-  font-weight: 700;
   line-height: 1;
   color: #000;
   opacity: .2;
 }
 
-.note-close:hover {
+.close:hover {
   -webkit-opacity: 1;
    -khtml-opacity: 1;
      -moz-opacity: 1;

--- a/src/styles/lite/common.scss
+++ b/src/styles/lite/common.scss
@@ -1,4 +1,6 @@
 .note-frame {
   @include box-sizing(border-box);
   color: #000;
+  font-family: $font-family;
+  border-radius: 4px;
 }

--- a/src/styles/lite/dropdown.scss
+++ b/src/styles/lite/dropdown.scss
@@ -36,10 +36,6 @@
   @include box-shadow(0 1px 1px rgba(0,0,0,.06));
 }
 
-.note-air-popover .note-btn.dropdown-toggle {
-    padding: 5px 1px 5px 10px;
-}
-
 .note-btn-group.open .note-dropdown-menu {
   display: block;
 }
@@ -57,8 +53,4 @@ a.note-dropdown-item:hover {
   margin: 5px 0;
   color: #000;
   text-decoration: none;
-}
-.dropdown-toggle:after{
-  content:'';
-  display:none;
 }

--- a/src/styles/lite/dropdown.scss
+++ b/src/styles/lite/dropdown.scss
@@ -2,22 +2,10 @@
   position: relative;
 
 }
-.dropdown-toggle .note-icon-caret {
-  padding: 3px 5px 3px 0;
-}
-.dropdown-toggle .note-icon-caret:before {
-  padding: 3px 2px 2px 0;
-}
 .note-color {
   .dropdown-toggle {
     width: 30px;
     padding-left: 5px;
-  }
-  .dropdown-toggle .note-icon-caret {
-    padding: 3px 5px 3px 0;
-  }
-  .dropdown-toggle .note-icon-caret:before {
-    padding: 3px 2px 2px 0;
   }
 }
 .note-dropdown-menu {

--- a/src/styles/lite/form.scss
+++ b/src/styles/lite/form.scss
@@ -9,7 +9,6 @@
 .note-form-label {
   display: block;
   width: 100%;
-  font-family: sans-serif;
   font-size: 16px;
   color: #42515f;
   margin-bottom: 10px;
@@ -17,73 +16,29 @@
 }
 
 .note-input {
-  display: block;
   width: 100%;
-  height: calc(1.5em + .75rem + 2px);
-  padding: .375rem .75rem;
-  font-family: sans-serif;
-  font-size: 1rem;
-  font-weight: 400;
-  line-height: 1.5;
-  color: #495057;
-  background-color: #fff;
-  background-clip: padding-box;
-  border: 1px solid #ced4da;
-  border-radius: .25rem;
-  transition: border-color .15s ease-in-out, box-shadow .15s ease-in-out;
-}
-
-@media (prefers-reduced-motion:reduce) {
-  .note-input {
-    transition: none;
-  }
-}
-
-.note-input::-ms-expand {
-  background-color: transparent;
-  border: 0
-}
-
-.note-input:focus {
-  color: #495057;
-  background-color: #fff;
-  border-color: #80bdff;
+  display: block;
+  border: 1px solid #ededef;
+  background: #fff;
   outline: 0;
-  box-shadow: 0 0 0 .2rem rgba(0, 123, 255, .25)
+  padding: 6px 4px;
+  font-size: 14px;
+  @include box-sizing();
 }
+
 
 .note-input::-webkit-input-placeholder {
-  color: #6c757d;
-  opacity: 1;
+  color: $gray-lighter;
 }
 
 .note-input:-moz-placeholder { /* Firefox 18- */
-  color: #6c757d;
-  opacity: 1;
+  color: $gray-lighter;
 }
 
-.note-input::-moz-placeholder { /* Firefox 19- */
-  color: #6c757d;
-  opacity: 1;
+.note-input::-moz-placeholder {  /* Firefox 19+ */
+  color: $gray-lighter;
 }
 
 .note-input:-ms-input-placeholder {
-  color: #6c757d;
-  opacity: 1;
-}
-
-.note-input::-ms-input-placeholder {
-  color: #6c757d;
-  opacity: 1;
-}
-
-.note-input::placeholder {
-  color: #6c757d;
-  opacity: 1;
-}
-
-.note-input:disabled,
-.note-input[readonly] {
-  background-color: #e9ecef;
-  opacity: 1;
+  color: $gray-lighter;
 }

--- a/src/styles/lite/modal.scss
+++ b/src/styles/lite/modal.scss
@@ -12,24 +12,6 @@
   &.open {
     display:block;
   }
-
-}
-
-.note-modal.fade .note-modal-content {
-  transition: -webkit-transform .3s ease-out;
-  transition: transform .3s ease-out, -webkit-transform .3s ease-out;
-  transition: transform .3s ease-out;
-}
-
-/* This is needed if Lite is used with Bootstrap 3/4, possible also other CSS Frameworks */
-.note-modal.fade:not(.show){
-  opacity: 1;
-}
-
-@media (prefers-reduced-motion:reduce) {
-  .note-modal.fade .note-modal-content {
-    transition: none;
-  }
 }
 
 .note-modal-content {
@@ -39,24 +21,21 @@
   border: 1px solid $modal-content-border-color;
   background: $modal-content-bg;
   background-clip: border-box;
-  outline: 0;
-  border-radius: .3rem;
+  outline:0;
 }
 
 .note-modal-header {
   padding: 30px 20px 20px 20px;
   border: 1px solid #ededef;
-  border-top-right-radius: .3rem;
-  border-top-left-radius: .3rem;
 
-  .note-close {
+  .close {
     margin-top: -10px;
   }
+
 }
 
 .note-modal-body {
   position: relative;
-  font-family: sans-serif;
   padding: 20px 30px;
 
   // shortcut text style
@@ -64,68 +43,39 @@
     border-radius: 2px;
     background-color: #000;
     color: #fff;
-    padding: 1px 3px;
-    font-family: sans-serif;
+    padding: 3px 5px;
     font-weight: 700;
     @include box-sizing();
-  }
-
-  label {
-    font-family: sans-serif;
-    font-size: .75em;
-    display: inline-block;
-    margin-bottom: .5rem;
   }
 }
 
 .note-modal-footer {
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-align: center;
-  align-items: center;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
-  font-family: sans-serif;
-  font-size: .75em;
-  padding: 1rem;
-  border-top: 1px solid #dee2e6;
-  border-bottom-right-radius: .3rem;
-  border-bottom-left-radius: .3rem;
-}
+  height: 40px;
+  padding: 10px;
+  text-align: center;
 
-.note-modal-footer > :not(:first-child) {
-  margin-left: .25rem;
-}
-
-.note-modal-footer > :not(:last-child) {
-  margin-right: .25rem;
 }
 
 .note-modal-footer a {
-  font-size: inherit;
-  font-weight: inherit;
   color: #337ab7;
-  text-decoration: none;
+  text-decoration: none
 }
 
 .note-modal-footer a:hover,
 .note-modal-footer a:focus {
   color: #23527c;
-  text-decoration: underline;
+  text-decoration: underline
 }
 
 .note-modal-footer .note-btn {
-  float: right;
-  height: auto;
+  float: right
 }
 
 .note-modal-title {
-  font-family: sans-serif;
-  font-size: 1.5rem;
-  font-weight: 500;
+  font-size: 26px;
   color: #42515f;
-  margin: 0 0 .5rem 0;
-  line-height: 1.2;
+  margin: 0;
+  line-height: 1.4;
 }
 
 .note-modal-backdrop {

--- a/src/styles/lite/toolbar.scss
+++ b/src/styles/lite/toolbar.scss
@@ -1,8 +1,9 @@
 .note-toolbar {
   padding: 10px 5px;
-  border-top: 1px solid #e2e2e2;
   border-bottom: 1px solid #e2e2e2;
   color: #333;
   background-color: #f5f5f5;
   border-color: #ddd;
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
 }

--- a/src/styles/lite/tooltip.scss
+++ b/src/styles/lite/tooltip.scss
@@ -59,6 +59,7 @@
 
 .note-tooltip-content {
   max-width: $tooltip-max-width;
+  font-family: $font-family;
   padding: 3px 8px;
   color: $tooltip-color;
   text-align: center;

--- a/src/styles/lite/variables.scss
+++ b/src/styles/lite/variables.scss
@@ -6,6 +6,7 @@ $gray:        lighten($gray-base, 33.5%); // #555
 $gray-light:  lighten($gray-base, 46.7%); // #777
 $gray-lighter:lighten($gray-base, 93.5%); // #eee
 
+$font-family: sans-serif;
 $font-size: 14px;
 $font-size-large: ceil(($font-size * 1.25));
 $font-size-small: ceil(($font-size * 0.85));

--- a/src/styles/lite/variables.scss
+++ b/src/styles/lite/variables.scss
@@ -13,7 +13,7 @@ $font-size-small: ceil(($font-size * 0.85));
 $line-height: 1.4;
 $line-height-computed: floor(($line-height * $font-size));
 
-$padding-base-vertical: 9px;
+$padding-base-vertical: 5px;
 $padding-base-horizontal: 10px;
 
 $border-radius-base: 3px;


### PR DESCRIPTION
Reverts summernote/summernote#3424
I and @easylogic had tried to figure out how to get the correct layout of Lite theme, but it was not easy to figure it out. So I decided to revert it.

Screenshots: (before reverting)
<img width="938" alt="Screen Shot 2019-12-14 at 2 36 38 PM" src="https://user-images.githubusercontent.com/579366/70844087-352c5880-1e7f-11ea-889d-bb6fa40ec4a1.png">
<img width="634" alt="Screen Shot 2019-12-14 at 2 36 43 PM" src="https://user-images.githubusercontent.com/579366/70844088-352c5880-1e7f-11ea-8013-3be957ebf57d.png">
<img width="453" alt="Screen Shot 2019-12-14 at 2 36 51 PM" src="https://user-images.githubusercontent.com/579366/70844089-352c5880-1e7f-11ea-9f58-5f58ea6832e6.png">
