### PR TITLE
Improve airmode focusout

### DIFF
--- a/src/js/base/module/AirPopover.js
+++ b/src/js/base/module/AirPopover.js
@@ -19,13 +19,7 @@ export default class AirPopover {
         this.hide();
       },
       'summernote.focusout': (we, e) => {
-        // [workaround] Firefox/Safari don't support relatedTarget on focusout
-        //  - Ignore hide action on focus out in FF/Safari.
-        if (env.isFF || env.isSafari) {
-          return;
-        }
-
-        if (!e.relatedTarget || !dom.ancestor(e.relatedTarget, func.eq(this.$popover[0]))) {
+        if (!this.$popover.is(':active,:focus')) {
           this.hide();
         }
       },


### PR DESCRIPTION
This change checks if the airpopover is active or has focus before hiding it on a focusout event. This is a more compatible check than the previous one and works in all browsers.

An improvement of #3316.