### PR TITLE
Fix ui container

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Include the following code in the `<head>` tag of your HTML:
 
 ```html
 <!-- include libraries(jQuery, bootstrap) -->
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script> 
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap.min.css" />
-<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/js/bootstrap.min.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/css/bootstrap.min.css" />
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>
 
 <!-- include summernote css/js-->
 <link href="summernote.css" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -6,12 +6,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <title>Summernote - Bootstrap 4</title>
   <!-- include jquery -->
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.js"></script>
 
   <!-- include libs stylesheets -->
-  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.css" />
-  <script src="//cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.5/umd/popper.js"></script>
-  <script src="//maxcdn.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.js"></script>
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.css" />
+  <script src="//cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.0/umd/popper.js"></script>
+  <script src="//maxcdn.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.js"></script>
 
   <!-- include summernote -->
   <link rel="stylesheet" href="dist/summernote-bs4.css">
@@ -31,8 +31,8 @@
 <div class="container">
   <h1>Summernote with Bootstrap 4</h1>
   <p>
-    <span class="badge badge-primary">jQuery v3.3.1</span>
-    <span class="badge badge-info">Bootstrap v4.1.3</span>
+    <span class="badge badge-primary">jQuery v3.4.1</span>
+    <span class="badge badge-info">Bootstrap v4.4.1</span>
   </p>
   <div class="summernote"><p>Hello World</p></div>
 </div>

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^3.2.0",
     "husky": "^1.2.1",
-    "jquery": "^3.3.1",
+    "jquery": "^3.4.1",
     "karma": "^3.1.4",
     "karma-chrome-launcher": "^2.2.0",
     "karma-coverage": "^1.1.2",

--- a/src/js/base/Context.js
+++ b/src/js/base/Context.js
@@ -9,13 +9,16 @@ export default class Context {
    * @param {Object} options
    */
   constructor($note, options) {
-    this.ui = $.summernote.ui;
     this.$note = $note;
 
     this.memos = {};
     this.modules = {};
     this.layoutInfo = {};
     this.options = $.extend(true, {}, options);
+
+    // init ui with options
+    $.summernote.ui = $.summernote.ui_template(this.options);
+    this.ui = $.summernote.ui;
 
     this.initialize();
   }
@@ -24,7 +27,7 @@ export default class Context {
    * create layout and initialize modules and other resources
    */
   initialize() {
-    this.layoutInfo = this.ui.createLayout(this.$note, this.options);
+    this.layoutInfo = this.ui.createLayout(this.$note);
     this._initialize();
     this.$note.hide();
     return this;

--- a/src/js/bs3/settings.js
+++ b/src/js/bs3/settings.js
@@ -5,6 +5,6 @@ import '../base/settings.js';
 import '../../styles/summernote-bs3.scss';
 
 $.summernote = $.extend($.summernote, {
-  ui: ui,
+  ui_template: ui,
   interface: 'bs3',
 });

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -52,39 +52,6 @@ const dropdownCheck = renderer.create('<ul class="note-dropdown-menu dropdown-me
   $node.html(markup).attr({ 'aria-label': options.title });
 });
 
-const palette = renderer.create('<div class="note-color-palette"/>', function($node, options) {
-  const contents = [];
-  for (let row = 0, rowSize = options.colors.length; row < rowSize; row++) {
-    const eventName = options.eventName;
-    const colors = options.colors[row];
-    const colorsName = options.colorsName[row];
-    const buttons = [];
-    for (let col = 0, colSize = colors.length; col < colSize; col++) {
-      const color = colors[col];
-      const colorName = colorsName[col];
-      buttons.push([
-        '<button type="button" class="note-color-btn"',
-        'style="background-color:', color, '" ',
-        'data-event="', eventName, '" ',
-        'data-value="', color, '" ',
-        'title="', colorName, '" ',
-        'aria-label="', colorName, '" ',
-        'data-toggle="button" tabindex="-1"></button>',
-      ].join(''));
-    }
-    contents.push('<div class="note-color-row">' + buttons.join('') + '</div>');
-  }
-  $node.html(contents.join(''));
-
-  if (options.tooltip) {
-    $node.find('.note-color-btn').tooltip({
-      container: options.container,
-      trigger: 'hover',
-      placement: 'bottom',
-    });
-  }
-});
-
 const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false" tabindex="-1" role="dialog"/>', function($node, options) {
   if (options.fade) {
     $node.addClass('fade');
@@ -136,111 +103,148 @@ const icon = function(iconClassName, tagName) {
   tagName = tagName || 'i';
   return '<' + tagName + ' class="' + iconClassName + '"/>';
 };
-const ui = {
-  editor: editor,
-  toolbar: toolbar,
-  editingArea: editingArea,
-  codable: codable,
-  editable: editable,
-  statusbar: statusbar,
-  airEditor: airEditor,
-  airEditable: airEditable,
-  buttonGroup: buttonGroup,
-  dropdown: dropdown,
-  dropdownButtonContents: dropdownButtonContents,
-  dropdownCheck: dropdownCheck,
-  palette: palette,
-  dialog: dialog,
-  popover: popover,
-  checkbox: checkbox,
-  icon: icon,
-  options: {},
 
-  button: function($node, options) {
-    return renderer.create('<button type="button" class="note-btn btn btn-default btn-sm" tabindex="-1">', function($node, options) {
-      if (options && options.tooltip) {
-        $node.attr({
-          title: options.tooltip,
-          'aria-label': options.tooltip,
-        }).tooltip({
-          container: options.container,
-          trigger: 'hover',
-          placement: 'bottom',
-        }).on('click', (e) => {
-          $(e.currentTarget).tooltip('hide');
-        });
-      }
-    })($node, options);
-  },
+const ui = function(editorOptions) {
+  return {
+    editor: editor,
+    toolbar: toolbar,
+    editingArea: editingArea,
+    codable: codable,
+    editable: editable,
+    statusbar: statusbar,
+    airEditor: airEditor,
+    airEditable: airEditable,
+    buttonGroup: buttonGroup,
+    dropdown: dropdown,
+    dropdownButtonContents: dropdownButtonContents,
+    dropdownCheck: dropdownCheck,
+    dialog: dialog,
+    popover: popover,
+    checkbox: checkbox,
+    icon: icon,
+    options: editorOptions,
 
-  toggleBtn: function($btn, isEnable) {
-    $btn.toggleClass('disabled', !isEnable);
-    $btn.attr('disabled', !isEnable);
-  },
+    palette: function($node, options) {
+      return renderer.create('<div class="note-color-palette"/>', function($node, options) {
+        const contents = [];
+        for (let row = 0, rowSize = options.colors.length; row < rowSize; row++) {
+          const eventName = options.eventName;
+          const colors = options.colors[row];
+          const colorsName = options.colorsName[row];
+          const buttons = [];
+          for (let col = 0, colSize = colors.length; col < colSize; col++) {
+            const color = colors[col];
+            const colorName = colorsName[col];
+            buttons.push([
+              '<button type="button" class="note-color-btn"',
+              'style="background-color:', color, '" ',
+              'data-event="', eventName, '" ',
+              'data-value="', color, '" ',
+              'title="', colorName, '" ',
+              'aria-label="', colorName, '" ',
+              'data-toggle="button" tabindex="-1"></button>',
+            ].join(''));
+          }
+          contents.push('<div class="note-color-row">' + buttons.join('') + '</div>');
+        }
+        $node.html(contents.join(''));
 
-  toggleBtnActive: function($btn, isActive) {
-    $btn.toggleClass('active', isActive);
-  },
+        if (options.tooltip) {
+          $node.find('.note-color-btn').tooltip({
+            container: options.container || editorOptions.container,
+            trigger: 'hover',
+            placement: 'bottom',
+          });
+        }
+      })($node, options);
+    },
 
-  onDialogShown: function($dialog, handler) {
-    $dialog.one('shown.bs.modal', handler);
-  },
+    button: function($node, options) {
+      return renderer.create('<button type="button" class="note-btn btn btn-default btn-sm" tabindex="-1">', function($node, options) {
+        if (options && options.tooltip) {
+          $node.attr({
+            title: options.tooltip,
+            'aria-label': options.tooltip,
+          }).tooltip({
+            container: options.container || editorOptions.container,
+            trigger: 'hover',
+            placement: 'bottom',
+          }).on('click', (e) => {
+            $(e.currentTarget).tooltip('hide');
+          });
+        }
+      })($node, options);
+    },
 
-  onDialogHidden: function($dialog, handler) {
-    $dialog.one('hidden.bs.modal', handler);
-  },
+    toggleBtn: function($btn, isEnable) {
+      $btn.toggleClass('disabled', !isEnable);
+      $btn.attr('disabled', !isEnable);
+    },
 
-  showDialog: function($dialog) {
-    $dialog.modal('show');
-  },
+    toggleBtnActive: function($btn, isActive) {
+      $btn.toggleClass('active', isActive);
+    },
 
-  hideDialog: function($dialog) {
-    $dialog.modal('hide');
-  },
+    onDialogShown: function($dialog, handler) {
+      $dialog.one('shown.bs.modal', handler);
+    },
 
-  createLayout: function($note, options) {
-    const $editor = (options.airMode ? ui.airEditor([
-      ui.editingArea([
-        ui.codable(),
-        ui.airEditable(),
-      ]),
-    ]) : (options.toolbarPosition === 'bottom'
-      ? ui.editor([
-        ui.editingArea([
-          ui.codable(),
-          ui.editable(),
+    onDialogHidden: function($dialog, handler) {
+      $dialog.one('hidden.bs.modal', handler);
+    },
+
+    showDialog: function($dialog) {
+      $dialog.modal('show');
+    },
+
+    hideDialog: function($dialog) {
+      $dialog.modal('hide');
+    },
+
+    createLayout: function($note) {
+      const $editor = (editorOptions.airMode ? airEditor([
+        editingArea([
+          codable(),
+          airEditable(),
         ]),
-        ui.toolbar(),
-        ui.statusbar(),
-      ])
-      : ui.editor([
-        ui.toolbar(),
-        ui.editingArea([
-          ui.codable(),
-          ui.editable(),
-        ]),
-        ui.statusbar(),
-      ])
-    )).render();
+      ]) : (editorOptions.toolbarPosition === 'bottom'
+        ? editor([
+          editingArea([
+            codable(),
+            editable(),
+          ]),
+          toolbar(),
+          statusbar(),
+        ])
+        : editor([
+          toolbar(),
+          editingArea([
+            codable(),
+            editable(),
+          ]),
+          statusbar(),
+        ])
+      )).render();
 
-    $editor.insertAfter($note);
+      $editor.insertAfter($note);
 
-    return {
-      note: $note,
-      editor: $editor,
-      toolbar: $editor.find('.note-toolbar'),
-      editingArea: $editor.find('.note-editing-area'),
-      editable: $editor.find('.note-editable'),
-      codable: $editor.find('.note-codable'),
-      statusbar: $editor.find('.note-statusbar'),
-    };
-  },
+      return {
+        note: $note,
+        editor: $editor,
+        toolbar: $editor.find('.note-toolbar'),
+        editingArea: $editor.find('.note-editing-area'),
+        editable: $editor.find('.note-editable'),
+        codable: $editor.find('.note-codable'),
+        statusbar: $editor.find('.note-statusbar'),
+      };
+    },
 
-  removeLayout: function($note, layoutInfo) {
-    $note.html(layoutInfo.editable.html());
-    layoutInfo.editor.remove();
-    $note.show();
-  },
+    removeLayout: function($note, layoutInfo) {
+      $note.html(layoutInfo.editable.html());
+      layoutInfo.editor.remove();
+      $note.show();
+    },
+  };
 };
 
 export default ui;

--- a/src/js/bs4/settings.js
+++ b/src/js/bs4/settings.js
@@ -5,7 +5,7 @@ import '../base/settings.js';
 import '../../styles/summernote-bs4.scss';
 
 $.summernote = $.extend($.summernote, {
-  ui: ui,
+  ui_template: ui,
   interface: 'bs4',
 });
 

--- a/src/js/bs4/ui.js
+++ b/src/js/bs4/ui.js
@@ -53,39 +53,6 @@ const dropdownCheck = renderer.create('<div class="note-dropdown-menu dropdown-m
   $node.html(markup).attr({ 'aria-label': options.title });
 });
 
-const palette = renderer.create('<div class="note-color-palette"/>', function($node, options) {
-  const contents = [];
-  for (let row = 0, rowSize = options.colors.length; row < rowSize; row++) {
-    const eventName = options.eventName;
-    const colors = options.colors[row];
-    const colorsName = options.colorsName[row];
-    const buttons = [];
-    for (let col = 0, colSize = colors.length; col < colSize; col++) {
-      const color = colors[col];
-      const colorName = colorsName[col];
-      buttons.push([
-        '<button type="button" class="note-color-btn"',
-        'style="background-color:', color, '" ',
-        'data-event="', eventName, '" ',
-        'data-value="', color, '" ',
-        'title="', colorName, '" ',
-        'aria-label="', colorName, '" ',
-        'data-toggle="button" tabindex="-1"></button>',
-      ].join(''));
-    }
-    contents.push('<div class="note-color-row">' + buttons.join('') + '</div>');
-  }
-  $node.html(contents.join(''));
-
-  if (options.tooltip) {
-    $node.find('.note-color-btn').tooltip({
-      container: options.container,
-      trigger: 'hover',
-      placement: 'bottom',
-    });
-  }
-});
-
 const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false" tabindex="-1" role="dialog"/>', function($node, options) {
   if (options.fade) {
     $node.addClass('fade');
@@ -139,111 +106,147 @@ const icon = function(iconClassName, tagName) {
   return '<' + tagName + ' class="' + iconClassName + '"/>';
 };
 
-const ui = {
-  editor: editor,
-  toolbar: toolbar,
-  editingArea: editingArea,
-  codable: codable,
-  editable: editable,
-  statusbar: statusbar,
-  airEditor: airEditor,
-  airEditable: airEditable,
-  buttonGroup: buttonGroup,
-  dropdown: dropdown,
-  dropdownButtonContents: dropdownButtonContents,
-  dropdownCheck: dropdownCheck,
-  palette: palette,
-  dialog: dialog,
-  popover: popover,
-  icon: icon,
-  checkbox: checkbox,
-  options: {},
+const ui = function(editorOptions) {
+  return {
+    editor: editor,
+    toolbar: toolbar,
+    editingArea: editingArea,
+    codable: codable,
+    editable: editable,
+    statusbar: statusbar,
+    airEditor: airEditor,
+    airEditable: airEditable,
+    buttonGroup: buttonGroup,
+    dropdown: dropdown,
+    dropdownButtonContents: dropdownButtonContents,
+    dropdownCheck: dropdownCheck,
+    dialog: dialog,
+    popover: popover,
+    icon: icon,
+    checkbox: checkbox,
+    options: editorOptions,
 
-  button: function($node, options) {
-    return renderer.create('<button type="button" class="note-btn btn btn-light btn-sm" tabindex="-1">', function($node, options) {
-      if (options && options.tooltip) {
-        $node.attr({
-          title: options.tooltip,
-          'aria-label': options.tooltip,
-        }).tooltip({
-          container: options.container,
-          trigger: 'hover',
-          placement: 'bottom',
-        }).on('click', (e) => {
-          $(e.currentTarget).tooltip('hide');
-        });
-      }
-    })($node, options);
-  },
+    palette: function($node, options) {
+      return renderer.create('<div class="note-color-palette"/>', function($node, options) {
+        const contents = [];
+        for (let row = 0, rowSize = options.colors.length; row < rowSize; row++) {
+          const eventName = options.eventName;
+          const colors = options.colors[row];
+          const colorsName = options.colorsName[row];
+          const buttons = [];
+          for (let col = 0, colSize = colors.length; col < colSize; col++) {
+            const color = colors[col];
+            const colorName = colorsName[col];
+            buttons.push([
+              '<button type="button" class="note-color-btn"',
+              'style="background-color:', color, '" ',
+              'data-event="', eventName, '" ',
+              'data-value="', color, '" ',
+              'title="', colorName, '" ',
+              'aria-label="', colorName, '" ',
+              'data-toggle="button" tabindex="-1"></button>',
+            ].join(''));
+          }
+          contents.push('<div class="note-color-row">' + buttons.join('') + '</div>');
+        }
+        $node.html(contents.join(''));
 
-  toggleBtn: function($btn, isEnable) {
-    $btn.toggleClass('disabled', !isEnable);
-    $btn.attr('disabled', !isEnable);
-  },
+        if (options.tooltip) {
+          $node.find('.note-color-btn').tooltip({
+            container: options.container || editorOptions.container,
+            trigger: 'hover',
+            placement: 'bottom',
+          });
+        }
+      })($node, options);
+    },
 
-  toggleBtnActive: function($btn, isActive) {
-    $btn.toggleClass('active', isActive);
-  },
+    button: function($node, options) {
+      return renderer.create('<button type="button" class="note-btn btn btn-light btn-sm" tabindex="-1">', function($node, options) {
+        if (options && options.tooltip) {
+          $node.attr({
+            title: options.tooltip,
+            'aria-label': options.tooltip,
+          }).tooltip({
+            container: options.container || editorOptions.container,
+            trigger: 'hover',
+            placement: 'bottom',
+          }).on('click', (e) => {
+            $(e.currentTarget).tooltip('hide');
+          });
+        }
+      })($node, options);
+    },
 
-  onDialogShown: function($dialog, handler) {
-    $dialog.one('shown.bs.modal', handler);
-  },
+    toggleBtn: function($btn, isEnable) {
+      $btn.toggleClass('disabled', !isEnable);
+      $btn.attr('disabled', !isEnable);
+    },
 
-  onDialogHidden: function($dialog, handler) {
-    $dialog.one('hidden.bs.modal', handler);
-  },
+    toggleBtnActive: function($btn, isActive) {
+      $btn.toggleClass('active', isActive);
+    },
 
-  showDialog: function($dialog) {
-    $dialog.modal('show');
-  },
+    onDialogShown: function($dialog, handler) {
+      $dialog.one('shown.bs.modal', handler);
+    },
 
-  hideDialog: function($dialog) {
-    $dialog.modal('hide');
-  },
+    onDialogHidden: function($dialog, handler) {
+      $dialog.one('hidden.bs.modal', handler);
+    },
 
-  createLayout: function($note, options) {
-    const $editor = (options.airMode ? ui.airEditor([
-      ui.editingArea([
-        ui.codable(),
-        ui.airEditable(),
-      ]),
-    ]) : (options.toolbarPosition === 'bottom'
-      ? ui.editor([
-        ui.editingArea([
-          ui.codable(),
-          ui.editable(),
+    showDialog: function($dialog) {
+      $dialog.modal('show');
+    },
+
+    hideDialog: function($dialog) {
+      $dialog.modal('hide');
+    },
+
+    createLayout: function($note) {
+      const $editor = (editorOptions.airMode ? airEditor([
+        editingArea([
+          codable(),
+          airEditable(),
         ]),
-        ui.toolbar(),
-        ui.statusbar(),
-      ])
-      : ui.editor([
-        ui.toolbar(),
-        ui.editingArea([
-          ui.codable(),
-          ui.editable(),
-        ]),
-        ui.statusbar(),
-      ])
-    )).render();
+      ]) : (editorOptions.toolbarPosition === 'bottom'
+        ? editor([
+          editingArea([
+            codable(),
+            editable(),
+          ]),
+          toolbar(),
+          statusbar(),
+        ])
+        : editor([
+          toolbar(),
+          editingArea([
+            codable(),
+            editable(),
+          ]),
+          statusbar(),
+        ])
+      )).render();
 
-    $editor.insertAfter($note);
+      $editor.insertAfter($note);
 
-    return {
-      note: $note,
-      editor: $editor,
-      toolbar: $editor.find('.note-toolbar'),
-      editingArea: $editor.find('.note-editing-area'),
-      editable: $editor.find('.note-editable'),
-      codable: $editor.find('.note-codable'),
-      statusbar: $editor.find('.note-statusbar'),
-    };
-  },
+      return {
+        note: $note,
+        editor: $editor,
+        toolbar: $editor.find('.note-toolbar'),
+        editingArea: $editor.find('.note-editing-area'),
+        editable: $editor.find('.note-editable'),
+        codable: $editor.find('.note-codable'),
+        statusbar: $editor.find('.note-statusbar'),
+      };
+    },
 
-  removeLayout: function($note, layoutInfo) {
-    $note.html(layoutInfo.editable.html());
-    layoutInfo.editor.remove();
-    $note.show();
-  },
+    removeLayout: function($note, layoutInfo) {
+      $note.html(layoutInfo.editable.html());
+      layoutInfo.editor.remove();
+      $note.show();
+    },
+  };
 };
 
 export default ui;

--- a/src/js/lite/settings.js
+++ b/src/js/lite/settings.js
@@ -5,6 +5,6 @@ import '../base/settings.js';
 import '../../styles/summernote-lite.scss';
 
 $.summernote = $.extend($.summernote, {
-  ui: ui,
+  ui_template: ui,
   interface: 'lite',
 });

--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -511,128 +511,131 @@ const icon = function(iconClassName, tagName) {
   return '<' + tagName + ' class="' + iconClassName + '"/>';
 };
 
-const ui = {
-  editor: editor,
-  toolbar: toolbar,
-  editingArea: editingArea,
-  codable: codable,
-  editable: editable,
-  statusbar: statusbar,
-  airEditor: airEditor,
-  airEditable: airEditable,
-  buttonGroup: buttonGroup,
-  button: button,
-  dropdown: dropdown,
-  dropdownCheck: dropdownCheck,
-  dropdownButton: dropdownButton,
-  dropdownButtonContents: dropdownButtonContents,
-  dropdownCheckButton: dropdownCheckButton,
-  paragraphDropdownButton: paragraphDropdownButton,
-  tableDropdownButton: tableDropdownButton,
-  colorDropdownButton: colorDropdownButton,
-  palette: palette,
-  dialog: dialog,
-  videoDialog: videoDialog,
-  imageDialog: imageDialog,
-  linkDialog: linkDialog,
-  popover: popover,
-  checkbox: checkbox,
-  icon: icon,
+const ui = function(editorOptions) {
+  return {
+    editor: editor,
+    toolbar: toolbar,
+    editingArea: editingArea,
+    codable: codable,
+    editable: editable,
+    statusbar: statusbar,
+    airEditor: airEditor,
+    airEditable: airEditable,
+    buttonGroup: buttonGroup,
+    button: button,
+    dropdown: dropdown,
+    dropdownCheck: dropdownCheck,
+    dropdownButton: dropdownButton,
+    dropdownButtonContents: dropdownButtonContents,
+    dropdownCheckButton: dropdownCheckButton,
+    paragraphDropdownButton: paragraphDropdownButton,
+    tableDropdownButton: tableDropdownButton,
+    colorDropdownButton: colorDropdownButton,
+    palette: palette,
+    dialog: dialog,
+    videoDialog: videoDialog,
+    imageDialog: imageDialog,
+    linkDialog: linkDialog,
+    popover: popover,
+    checkbox: checkbox,
+    icon: icon,
+    options: editorOptions,
 
-  toggleBtn: function($btn, isEnable) {
-    $btn.toggleClass('disabled', !isEnable);
-    $btn.attr('disabled', !isEnable);
-  },
+    toggleBtn: function($btn, isEnable) {
+      $btn.toggleClass('disabled', !isEnable);
+      $btn.attr('disabled', !isEnable);
+    },
 
-  toggleBtnActive: function($btn, isActive) {
-    $btn.toggleClass('active', isActive);
-  },
+    toggleBtnActive: function($btn, isActive) {
+      $btn.toggleClass('active', isActive);
+    },
 
-  check: function($dom, value) {
-    $dom.find('.checked').removeClass('checked');
-    $dom.find('[data-value="' + value + '"]').addClass('checked');
-  },
+    check: function($dom, value) {
+      $dom.find('.checked').removeClass('checked');
+      $dom.find('[data-value="' + value + '"]').addClass('checked');
+    },
 
-  onDialogShown: function($dialog, handler) {
-    $dialog.one('note.modal.show', handler);
-  },
+    onDialogShown: function($dialog, handler) {
+      $dialog.one('note.modal.show', handler);
+    },
 
-  onDialogHidden: function($dialog, handler) {
-    $dialog.one('note.modal.hide', handler);
-  },
+    onDialogHidden: function($dialog, handler) {
+      $dialog.one('note.modal.hide', handler);
+    },
 
-  showDialog: function($dialog) {
-    $dialog.data('modal').show();
-  },
+    showDialog: function($dialog) {
+      $dialog.data('modal').show();
+    },
 
-  hideDialog: function($dialog) {
-    $dialog.data('modal').hide();
-  },
+    hideDialog: function($dialog) {
+      $dialog.data('modal').hide();
+    },
 
-  /**
-   * get popover content area
-   *
-   * @param $popover
-   * @returns {*}
-   */
-  getPopoverContent: function($popover) {
-    return $popover.find('.note-popover-content');
-  },
+    /**
+     * get popover content area
+     *
+     * @param $popover
+     * @returns {*}
+     */
+    getPopoverContent: function($popover) {
+      return $popover.find('.note-popover-content');
+    },
 
-  /**
-   * get dialog's body area
-   *
-   * @param $dialog
-   * @returns {*}
-   */
-  getDialogBody: function($dialog) {
-    return $dialog.find('.note-modal-body');
-  },
+    /**
+     * get dialog's body area
+     *
+     * @param $dialog
+     * @returns {*}
+     */
+    getDialogBody: function($dialog) {
+      return $dialog.find('.note-modal-body');
+    },
 
-  createLayout: function($note, options) {
-    const $editor = (options.airMode ? ui.airEditor([
-      ui.editingArea([
-        ui.codable(),
-        ui.airEditable(),
-      ]),
-    ]) : (options.toolbarPosition === 'bottom'
-      ? ui.editor([
-        ui.editingArea([
-          ui.codable(),
-          ui.editable(),
+    createLayout: function($note) {
+      const $editor = (editorOptions.airMode ? airEditor([
+        editingArea([
+          codable(),
+          airEditable(),
         ]),
-        ui.toolbar(),
-        ui.statusbar(),
-      ])
-      : ui.editor([
-        ui.toolbar(),
-        ui.editingArea([
-          ui.codable(),
-          ui.editable(),
-        ]),
-        ui.statusbar(),
-      ])
-    )).render();
+      ]) : (editorOptions.toolbarPosition === 'bottom'
+        ? editor([
+          editingArea([
+            codable(),
+            editable(),
+          ]),
+          toolbar(),
+          statusbar(),
+        ])
+        : editor([
+          toolbar(),
+          editingArea([
+            codable(),
+            editable(),
+          ]),
+          statusbar(),
+        ])
+      )).render();
 
-    $editor.insertAfter($note);
+      $editor.insertAfter($note);
 
-    return {
-      note: $note,
-      editor: $editor,
-      toolbar: $editor.find('.note-toolbar'),
-      editingArea: $editor.find('.note-editing-area'),
-      editable: $editor.find('.note-editable'),
-      codable: $editor.find('.note-codable'),
-      statusbar: $editor.find('.note-statusbar'),
-    };
-  },
+      return {
+        note: $note,
+        editor: $editor,
+        toolbar: $editor.find('.note-toolbar'),
+        editingArea: $editor.find('.note-editing-area'),
+        editable: $editor.find('.note-editable'),
+        codable: $editor.find('.note-codable'),
+        statusbar: $editor.find('.note-statusbar'),
+      };
+    },
 
-  removeLayout: function($note, layoutInfo) {
-    $note.html(layoutInfo.editable.html());
-    layoutInfo.editor.remove();
-    $note.off('summernote'); // remove summernote custom event
-    $note.show();
-  },
+    removeLayout: function($note, layoutInfo) {
+      $note.html(layoutInfo.editable.html());
+      layoutInfo.editor.remove();
+      $note.off('summernote'); // remove summernote custom event
+      $note.show();
+    },
+  };
 };
 
 export default ui;

--- a/src/summernote-bs3.html
+++ b/src/summernote-bs3.html
@@ -9,14 +9,14 @@
     <title>Summernote - Bootstrap 3</title>
 
     <!-- include jquery -->
-    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.js"></script>
 
     <!-- include libs stylesheets -->
     <link
       rel="stylesheet"
-      href="//netdna.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.css"
+      href="//netdna.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.css"
     />
-    <script src="//netdna.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.js"></script>
+    <script src="//netdna.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.js"></script>
 
     <script type="text/javascript">
       $(document).ready(function() {
@@ -39,58 +39,58 @@
       </div>
       <h1>Summernote with Bootstrap 3 </h1>
       <p>
-        <span class="label label-primary">jQuery v3.3.1</span>
-        <span class="label label-info">Bootstrap v3.3.7</span>
+        <span class="label label-primary">jQuery v3.4.1</span>
+        <span class="label label-info">Bootstrap v3.4.1</span>
       </p>
       <div class="summernote"></div>
       <pre>
   Scroll page to see sticky toolbar.
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
-  
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
   End of document.
   </pre
       >

--- a/src/summernote-bs4.html
+++ b/src/summernote-bs4.html
@@ -6,12 +6,12 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <title>Summernote - Bootstrap 4</title>
   <!-- include jquery -->
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.js"></script>
 
   <!-- include libs stylesheets -->
-  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.css" />
-  <script src="//cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.5/umd/popper.js"></script>
-  <script src="//maxcdn.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.js"></script>
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.css" />
+  <script src="//cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.0/umd/popper.js"></script>
+  <script src="//maxcdn.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.js"></script>
 
   <!-- include summernote -->
   <script type="text/javascript">
@@ -26,16 +26,16 @@
 <body>
 <div class="container">
     <div style='float:right;'>
-      <a href='index.html'>Bootstrap 3</a> 
+      <a href='index.html'>Bootstrap 3</a>
       /
       <a href='lite.html'>Lite</a>
       /
       <a href="examples/">Example</a>
-    </div>  
+    </div>
   <h1>Summernote with Bootstrap 4</h1>
   <p>
-    <span class="badge badge-primary">jQuery v3.3.1</span>
-    <span class="badge badge-info">Bootstrap v4.1.3</span>
+    <span class="badge badge-primary">jQuery v3.4.1</span>
+    <span class="badge badge-info">Bootstrap v4.4.1</span>
   </p>
   <div class="summernote"><p>Hello World</p></div>
 </div>


### PR DESCRIPTION
#### What does this PR do?

- This serves the default `options.container` for custom buttons.
 
#### Where should the reviewer start?

- `ui.js` of each theme

#### Any background context you want to provide?

- Till `0.8.14`, Instances of summernote were sharing the same `$.summernote.ui` variable. But now we have to provide individual `ui` instance for contexts.

#### What are the relevant tickets?

- #3536 