### PR TITLE
Fix production version of webpack.externals issue

### DIFF
--- a/config/common/dev.common.config.js
+++ b/config/common/dev.common.config.js
@@ -18,117 +18,115 @@ fs.readdirSync(path.resolve(__dirname, '../../lang')).forEach(file => {
   entries[filename] = `./lang/${filename}`;
 });
 
-module.exports = function() {
-  return {
-    entries,
-    output: {
-      path: path.join(__dirname, 'dist'),
-      filename: (chunkData) => {
-        var isProduct = productList.includes(chunkData.chunk.name);
-        return isProduct ? '[name].js' : 'lang/[name].js';
+module.exports = {
+  entries,
+  output: {
+    path: path.join(__dirname, 'dist'),
+    filename: (chunkData) => {
+      var isProduct = productList.includes(chunkData.chunk.name);
+      return isProduct ? '[name].js' : 'lang/[name].js';
+    },
+  },
+  externals: {
+    jquery: 'jQuery', // dev includes jQuery by <script> tag
+  },
+  devServer: {
+    port: 3000,
+    contentBase: ['./dist'],
+  },
+  module: {
+    rules: [
+      {
+        enforce: 'pre',
+        test: /\.js$/,
+        exclude: /node_modules/,
+        loader: 'eslint-loader',
       },
-    },
-    externals: {
-      jquery: 'jQuery',
-    },
-    devServer: {
-      port: 3000,
-      contentBase: ['./dist'],
-    },
-    module: {
-      rules: [
-        {
-          enforce: 'pre',
-          test: /\.js$/,
-          exclude: /node_modules/,
-          loader: 'eslint-loader',
-        },
-        {
-          test: /\.js$/,
-          exclude: /node_modules/,
-          use: [
-            {
-              loader: 'string-replace-loader',
-              options: {
-                search: '@@VERSION@@',
-                replace: pkg.version,
-              },
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'string-replace-loader',
+            options: {
+              search: '@@VERSION@@',
+              replace: pkg.version,
             },
-            {
-              loader: 'babel-loader',
+          },
+          {
+            loader: 'babel-loader',
+          },
+        ],
+      },
+      {
+        test: /\.html$/,
+        use: [
+          {
+            loader: 'html-loader',
+            options: {
+              minimize: false,
             },
-          ],
-        },
-        {
-          test: /\.html$/,
-          use: [
-            {
-              loader: 'html-loader',
-              options: {
-                minimize: false,
-              },
+          },
+        ],
+      },
+      scssConfig,
+      {
+        test: /\.(png|jpe?g|gif|svg)$/,
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: '[name].[ext]',
+              outputPath: 'images',
             },
-          ],
-        },
-        scssConfig,
-        {
-          test: /\.(png|jpe?g|gif|svg)$/,
-          use: [
-            {
-              loader: 'file-loader',
-              options: {
-                name: '[name].[ext]',
-                outputPath: 'images',
-              },
+          },
+        ],
+      },
+      {
+        test: /\.(woff|woff2|ttf|otf|eot)$/,
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: '[name].[ext]',
+              outputPath: 'font',
             },
-          ],
-        },
-        {
-          test: /\.(woff|woff2|ttf|otf|eot)$/,
-          use: [
-            {
-              loader: 'file-loader',
-              options: {
-                name: '[name].[ext]',
-                outputPath: 'font',
-              },
-            },
-          ],
-        },
-      ],
-    },
-    plugins: [
-      new MiniCssExtractPlugin({
-        filename: '[name].css',
-      }),
-      new CopyPlugin([
-        {
-          from: 'examples',
-          to: 'examples',
-        },
-        {
-          from: 'plugin',
-          to: 'plugin',
-        },
-      ]),
-      new HtmlWebPackPlugin({
-        inject: true,
-        chunks: ['summernote'],
-        template: `./src/summernote-bs3.html`,
-        filename: 'index.html',
-      }),
-      new HtmlWebPackPlugin({
-        inject: true,
-        chunks: ['summernote-bs4'],
-        template: `./src/summernote-bs4.html`,
-        filename: 'bs4.html',
-      }),
-      new HtmlWebPackPlugin({
-        inject: true,
-        chunks: ['summernote-lite'],
-        template: `./src/summernote-lite.html`,
-        filename: 'lite.html',
-      }),
+          },
+        ],
+      },
     ],
-  };
+  },
+  plugins: [
+    new MiniCssExtractPlugin({
+      filename: '[name].css',
+    }),
+    new CopyPlugin([
+      {
+        from: 'examples',
+        to: 'examples',
+      },
+      {
+        from: 'plugin',
+        to: 'plugin',
+      },
+    ]),
+    new HtmlWebPackPlugin({
+      inject: true,
+      chunks: ['summernote'],
+      template: `./src/summernote-bs3.html`,
+      filename: 'index.html',
+    }),
+    new HtmlWebPackPlugin({
+      inject: true,
+      chunks: ['summernote-bs4'],
+      template: `./src/summernote-bs4.html`,
+      filename: 'bs4.html',
+    }),
+    new HtmlWebPackPlugin({
+      inject: true,
+      chunks: ['summernote-lite'],
+      template: `./src/summernote-lite.html`,
+      filename: 'lite.html',
+    }),
+  ],
 };

--- a/config/common/production.common.config.js
+++ b/config/common/production.common.config.js
@@ -42,135 +42,138 @@ fs.readdirSync(path.resolve(__dirname, '../../lang')).forEach(file => {
   entries[filename] = `./lang/${filename}`;
 });
 
-module.exports = function() {
-  return {
-    entries,
-    output: {
-      path: path.join(__dirname, '../../dist'),
-      libraryTarget: 'umd',
-      filename: (chunkData) => {
-        var isProduct = productList.includes(chunkData.chunk.name);
-        return isProduct ? '[name].js' : 'lang/[name].js';
-      },
+module.exports = {
+  entries,
+  output: {
+    path: path.join(__dirname, '../../dist'),
+    libraryTarget: 'umd',
+    filename: (chunkData) => {
+      var isProduct = productList.includes(chunkData.chunk.name);
+      return isProduct ? '[name].js' : 'lang/[name].js';
     },
-    externals: {
-      jquery: 'jQuery',
+  },
+  externals: {
+    jquery: {
+      root: 'jQuery',
+      commonjs2: 'jquery',
+      commonjs: 'jquery',
+      amd: 'jquery',
     },
-    devtool: false,
-    optimization: {
-      minimizer: [
-        new TerserPlugin({
-          chunkFilter: (chunk) => {
-            // xxx.min file is minified
-            if (chunk.name.includes('min')) {
-              return true;
-            }
-            return false;
-          },
-          parallel: 3,
-          cache: true,
+  },
+  devtool: false,
+  optimization: {
+    minimizer: [
+      new TerserPlugin({
+        chunkFilter: (chunk) => {
+          // xxx.min file is minified
+          if (chunk.name.includes('min')) {
+            return true;
+          }
+          return false;
+        },
+        parallel: 3,
+        cache: true,
+        sourceMap: true,
+        terserOptions: {
           sourceMap: true,
-          terserOptions: {
-            sourceMap: true,
-            ecma: 8,
-            compress: {
-              warnings: false,
-            },
+          ecma: 8,
+          compress: {
+            warnings: false,
           },
-        }),
-        new OptimizeCssAssetsPlugin({
-          assetNameRegExp: /\min\.css$/g,
-          sourceMap: true,
-          cssProcessor: require('cssnano'),
-          cssProcessorPluginOptions: {
-            preset: ['default', {
-              discardComments: {
-                removeAll: true,
-              },
-            }],
-          },
-          canPrint: true,
-        }),
-      ],
-    },
-    module: {
-      rules: [
-        {
-          test: /\.js$/,
-          exclude: /node_modules/,
-          use: [
-            {
-              loader: 'string-replace-loader',
-              options: {
-                search: '@@VERSION@@',
-                replace: pkg.version,
-              },
-            }, {
-              loader: 'babel-loader',
-            },
-          ],
-        },
-        {
-          test: /\.html$/,
-          use: [
-            {
-              loader: 'html-loader',
-              options: {
-                minimize: true,
-              },
-            },
-          ],
-        },
-        scssConfig,
-        {
-          test: /\.(png|jpe?g|gif|svg)$/,
-          use: [
-            {
-              loader: 'file-loader',
-              options: {
-                name: '[name].[ext]',
-                outputPath: 'images',
-              },
-            },
-          ],
-        },
-        {
-          test: /\.(woff|woff2|ttf|otf|eot)$/,
-          use: [
-            {
-              loader: 'file-loader',
-              options: {
-                name: '[name].[ext]',
-                outputPath: 'font',
-              },
-            },
-          ],
-        },
-      ],
-    },
-    plugins: [
-      new CleanPlugin(),
-      new webpack.BannerPlugin({
-        banner: ({ basename }) => {
-          return basename.includes('min') ? minBanner : banner;
         },
       }),
-      new MiniCssExtractPlugin({
-        filename: `[name].css`,
-      }),
-      new CopyPlugin([
-        {
-          from: 'plugin',
-          to: 'plugin',
+      new OptimizeCssAssetsPlugin({
+        assetNameRegExp: /\min\.css$/g,
+        sourceMap: true,
+        cssProcessor: require('cssnano'),
+        cssProcessorPluginOptions: {
+          preset: ['default', {
+            discardComments: {
+              removeAll: true,
+            },
+          }],
         },
-      ]),
-      new webpack.SourceMapDevToolPlugin({
-        test: /(summernote|summernote\-bs4|summernote\-lite)(\.min)?\.js$/g,
-        filename: '[name].js.map',
-      }),
-      new ZipPlugin({
-        filename: `summernote-${pkg.version}-dist.zip`,
+        canPrint: true,
       }),
     ],
-  };
+  },
+  module: {
+    rules: [
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'string-replace-loader',
+            options: {
+              search: '@@VERSION@@',
+              replace: pkg.version,
+            },
+          }, {
+            loader: 'babel-loader',
+          },
+        ],
+      },
+      {
+        test: /\.html$/,
+        use: [
+          {
+            loader: 'html-loader',
+            options: {
+              minimize: true,
+            },
+          },
+        ],
+      },
+      scssConfig,
+      {
+        test: /\.(png|jpe?g|gif|svg)$/,
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: '[name].[ext]',
+              outputPath: 'images',
+            },
+          },
+        ],
+      },
+      {
+        test: /\.(woff|woff2|ttf|otf|eot)$/,
+        use: [
+          {
+            loader: 'file-loader',
+            options: {
+              name: '[name].[ext]',
+              outputPath: 'font',
+            },
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new CleanPlugin(),
+    new webpack.BannerPlugin({
+      banner: ({ basename }) => {
+        return basename.includes('min') ? minBanner : banner;
+      },
+    }),
+    new MiniCssExtractPlugin({
+      filename: `[name].css`,
+    }),
+    new CopyPlugin([
+      {
+        from: 'plugin',
+        to: 'plugin',
+      },
+    ]),
+    new webpack.SourceMapDevToolPlugin({
+      test: /(summernote|summernote\-bs4|summernote\-lite)(\.min)?\.js$/g,
+      filename: '[name].js.map',
+    }),
+    new ZipPlugin({
+      filename: `summernote-${pkg.version}-dist.zip`,
+    }),
+  ],
 };

--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -1,4 +1,4 @@
-const config = require('./common/dev.common.config')('bs3');
+const config = require('./common/dev.common.config');
 module.exports = {
   entry: {
     'summernote': './src/js/bs3/settings',

--- a/config/webpack.config.production.js
+++ b/config/webpack.config.production.js
@@ -1,4 +1,4 @@
-const config = require('./common/production.common.config')('bs3');
+const config = require('./common/production.common.config');
 module.exports = {
   entry: {
     'summernote': './src/js/bs3/settings',


### PR DESCRIPTION
#### What does this PR do?

- This fixes `webpack.externals` issue of the production build. #3537

#### Where should the reviewer start?

- See files in`config`.

#### Any background context you want to provide?

- jQuery exports its name as `$` and `jQuery` by default. So we'd set `webpack.externals` as `jquery: 'jQuery'`. It means it will run `module.exports = jQuery;` instead of importing real `jquery` module which installed in `node_modules` while executing `import $ from 'jquery'`.
 - This causes problem #3537, but this cannot be solved by just replacing `jQuery` to `jquery`. This could be a solution for who uses jQuery by importing as a module, not by `<script>` tag.
 - Thus I decided to use more complex `webpack.externals` settings for each module system.

```javascript
externals: {
    jquery: {
      root: 'jQuery',
      commonjs2: 'jquery',
      commonjs: 'jquery',
      amd: 'jquery',
    },
}
...
```

XRef: https://github.com/itsjavi/bootstrap-colorpicker/issues/272