### PR TITLE
Allow airpopover on contextmenu

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -404,7 +404,14 @@ export default class Editor {
       this.context.triggerEvent('focusout', event);
     });
 
-    if (!this.options.airMode) {
+    if (this.options.airMode) {
+      if (this.options.overrideContextMenu) {
+        this.$editor.on('contextmenu', (event) => {
+          this.context.triggerEvent('contextmenu', event);
+          return false;
+        });
+      }
+    } else {
       if (this.options.width) {
         this.$editor.outerWidth(this.options.width);
       }

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -112,6 +112,7 @@ $.summernote = $.extend($.summernote, {
 
     // air mode: inline editor
     airMode: false,
+    overrideContextMenu: true, // TBD
 
     width: null,
     height: null,

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -112,7 +112,7 @@ $.summernote = $.extend($.summernote, {
 
     // air mode: inline editor
     airMode: false,
-    overrideContextMenu: true, // TBD
+    overrideContextMenu: false, // TBD
 
     width: null,
     height: null,


### PR DESCRIPTION
#### What does this PR do?

- This allows Summernote to show Airpopover on right-click.

#### Where should the reviewer start?

- `src/js/base/module/AirPopover.js`

#### How should this be manually tested?

- Set `overrideContextMenu` as true and test on airmode editor.

#### What are the relevant tickets?

- #2569 

#### Screenshot (if for frontend)

<img width="1175" alt="Screen Shot 2020-01-07 at 11 13 27 PM" src="https://user-images.githubusercontent.com/579366/71901456-54c75000-31a3-11ea-9282-48ecfb8db5fb.png">