### PR TITLE
add babel preset for ecma2015+

### DIFF
--- a/config/common/dev.common.config.js
+++ b/config/common/dev.common.config.js
@@ -55,6 +55,9 @@ module.exports = {
           },
           {
             loader: 'babel-loader',
+            options: {
+              presets: ['@babel/preset-env'],
+            },
           },
         ],
       },

--- a/config/common/production.common.config.js
+++ b/config/common/production.common.config.js
@@ -111,6 +111,9 @@ module.exports = {
             },
           }, {
             loader: 'babel-loader',
+            options: {
+              presets: ['@babel/preset-env'],
+            },
           },
         ],
       },


### PR DESCRIPTION

#### What does this PR do?

- add `@babel/preset-env` setting of babel-loader 
- fixed running for ie11

#### Where should the reviewer start?

- config/common/dev.common.config.js
- config/common/production.common.config.js

#### How should this be manually tested?

- npm run dev
- open ie11 
- move localhost:3000 

#### Any background context you want to provide?

- ie11 don't support `Class` keyword
- After summernote changed config for webpack (v0.8.14) ,  preset of babel-loader did not applied.

#### What are the relevant tickets?

#3555 

#### Screenshot (if for frontend)


### Checklist
- [x] added relevant tests
- [x] didn't break anything
