### PR TITLE
Add an option for limiting history stack

### DIFF
--- a/examples/history-limit.html
+++ b/examples/history-limit.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>Summernote - Bootstrap 4</title>
+  <!-- include jquery -->
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js"></script>
+
+  <!-- include libs stylesheets -->
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.css" />
+  <script src="//cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.5/umd/popper.js"></script>
+  <script src="//maxcdn.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.js"></script>
+
+  <!-- include summernote -->
+  <link rel="stylesheet" href="../summernote-bs4.css">
+  <script type="text/javascript" src="../summernote-bs4.js"></script>
+
+  <link rel="stylesheet" href="example.css">
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $('.summernote').summernote({
+        height: 300,
+        tabsize: 2,
+        followingToolbar: true,
+        historyLimit: 5
+      });
+    });
+  </script>
+</head>
+<body>
+<div class="container">
+  <h1>Test history limited count </h1>
+  <p>
+    <span class="badge badge-primary">jQuery v3.3.1</span>
+    <span class="badge badge-info">Bootstrap v4.1.3</span>
+  </p>
+  <div class="summernote"><p>Hello World</p></div>
+  <pre>
+
+    $(document).ready(function() {
+      $('.summernote').summernote({
+        height: 300,
+        tabsize: 2,
+        followingToolbar: true,
+        historyLimit: 5
+      });
+    });
+  </pre>
+</div>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -49,6 +49,7 @@
       { title: 'hint-symbol', link : 'hint-symbols_mathematical-symbols_Greek-letters.html', description: 'test hint symbol ', support: 'bs3, bs4, lite'},
       { title: 'jQuery custom event', link : 'jquery-custom-event.html', description: 'test jQuery custom event ', support: 'bs3, bs4, lite'},
       { title: 'Plugin : Hello', link : 'plugin-hello.html', description: 'Plugin sample - Hello', support: 'bs3, bs4, lite'},
+      { title: 'Limited history stack', link : 'history-limit.html', description: 'Limited history stack', support: 'bs3, bs4, lite'},
     ]
     function generate_sample_pages() {
       var html = samples.map(it => {

--- a/src/js/base/editing/History.js
+++ b/src/js/base/editing/History.js
@@ -1,11 +1,12 @@
 import range from '../core/range';
 
 export default class History {
-  constructor($editable) {
+  constructor(context) {
     this.stack = [];
     this.stackOffset = -1;
-    this.$editable = $editable;
-    this.editable = $editable[0];
+    this.context = context;
+    this.$editable = context.layoutInfo.editable;
+    this.editable = this.$editable[0];
   }
 
   makeSnapshot() {
@@ -116,5 +117,11 @@ export default class History {
 
     // Create new snapshot and push it to the end
     this.stack.push(this.makeSnapshot());
+
+    // If the stack size reachs to the limit, then slice it
+    if (this.stack.length > this.context.options.historyLimit) {
+      this.stack.shift();
+      this.stackOffset -= 1;
+    }
   }
 }

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -35,7 +35,7 @@ export default class Editor {
     this.table = new Table();
     this.typing = new Typing(context);
     this.bullet = new Bullet();
-    this.history = new History(this.$editable);
+    this.history = new History(context);
 
     this.context.memo('help.undo', this.lang.help.undo);
     this.context.memo('help.redo', this.lang.help.redo);

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -133,6 +133,8 @@ $.summernote = $.extend($.summernote, {
     disableGrammar: false,
     placeholder: null,
     inheritPlaceholder: false,
+    // TODO: need to be documented
+    historyLimit: 200,
 
     // TODO: need to be documented
     hintMode: 'word',

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -48,6 +48,7 @@ describe('Editor', () => {
     var $note = $('<div><p>hello</p></div>');
 
     var options = $.extend({}, $.summernote.options);
+    options.historyLimit = 5;
     context = new Context($note, options);
 
     editor = context.modules.editor;
@@ -87,6 +88,30 @@ describe('Editor', () => {
         setTimeout(() => {
           expectContents(context, '<p>hello</p>');
           editor.redo();
+          setTimeout(() => {
+            expectContents(context, '<p>hello world</p>');
+            done();
+          }, 10);
+        }, 10);
+      }, 10);
+    });
+
+    it('should be limited by option.historyLimit value', (done) => {
+      editor.insertText(' world');
+      editor.insertText(' world');
+      editor.insertText(' world');
+      editor.insertText(' world');
+      editor.insertText(' world');
+      setTimeout(() => {
+        expectContents(context, '<p>hello world world world world world</p>');
+        editor.undo();
+        editor.undo();
+        editor.undo();
+        setTimeout(() => {
+          expectContents(context, '<p>hello world world</p>');
+          editor.undo();
+          editor.undo();
+          editor.undo();
           setTimeout(() => {
             expectContents(context, '<p>hello world</p>');
             done();


### PR DESCRIPTION
#### What does this PR do?

- This introduces `options.historyLimit` for limiting history stack size.

#### Where should the reviewer start?

- `src/js/base/editing/History.js`

#### How should this be manually tested?

- Set `options.historyLimit` as a low value and test undo actions.

#### Any background context you want to provide?

- We never limit the size of the history stack and it may cause a memory problem.

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/3476 (maybe)