### PR TITLE
Correct following/fixed toolbar height

### DIFF
--- a/src/js/base/module/Toolbar.js
+++ b/src/js/base/module/Toolbar.js
@@ -80,14 +80,14 @@ export default class Toolbar {
     if (!this.isFollowing &&
       (currentOffset > activateOffset) && (currentOffset < deactivateOffsetBottom - toolbarHeight)) {
       this.isFollowing = true;
+      this.$editable.css({
+        marginTop: this.$toolbar.outerHeight(),
+      });
       this.$toolbar.css({
         position: 'fixed',
         top: otherBarHeight,
         width: editorWidth,
         zIndex: 1000,
-      });
-      this.$editable.css({
-        marginTop: this.$toolbar.height() + 5,
       });
     } else if (this.isFollowing &&
       ((currentOffset < activateOffset) || (currentOffset > deactivateOffsetBottom))) {


### PR DESCRIPTION
#### What does this PR do?

- Fixes this:

| ![Video_2020-02-03_153335 wmv](https://user-images.githubusercontent.com/6796369/73663647-42570e00-469e-11ea-9050-3cfb9280cfd3.gif) |
| ----------------- |

- Prevents editor jumping when scrolling with following (fixed) toolbar, which has different than default height.
- Different code order removes one slight tremble (not sure if easily reproducable)
- Improves readibility - removes magic number (5) in favor of correct height.

#### Where should the reviewer start?

- `src/js/base/module/Toolbar.js`

#### How should this be manually tested?

- Use `followingToolbar: true`. Change toolbar height (for example by changing button height in CSS).
- Scroll the page, observe editor content not jumping.

#### What are the relevant tickets?

- #3126; this PR is a fix of already fixed issue

