### PR TITLE
Replace deprecated styleWithSpan with styleWithCSS

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -273,7 +273,6 @@ export default class Editor {
      * @param {String} colorCode foreground color code
      */
     this.foreColor = this.wrapCommand((colorInfo) => {
-      document.execCommand('styleWithCSS', false, true);
       document.execCommand('foreColor', false, colorInfo);
     });
 
@@ -619,6 +618,10 @@ export default class Editor {
    */
   beforeCommand() {
     this.context.triggerEvent('before.command', this.$editable.html());
+
+    // Set styleWithCSS before run a command
+    document.execCommand('styleWithCSS', false, this.options.styleWithCSS);
+
     // keep focus on editable before command execution
     this.focus();
   }

--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -404,7 +404,7 @@ export default class Editor {
       this.context.triggerEvent('change', this.$editable.html(), this.$editable);
     }, 10));
 
-    this.$editor.on('focusin', (event) => {
+    this.$editable.on('focusin', (event) => {
       this.context.triggerEvent('focusin', event);
     }).on('focusout', (event) => {
       this.context.triggerEvent('focusout', event);

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -123,7 +123,7 @@ $.summernote = $.extend($.summernote, {
     focus: false,
     tabDisabled: false,
     tabSize: 4,
-    styleWithSpan: true,
+    styleWithCSS: false,
     shortcuts: true,
     textareaAutoSync: true,
     tooltip: 'auto',

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -45,11 +45,9 @@ describe('Editor', () => {
 
   beforeEach(function() {
     $('body').empty(); // important !
-    var $note = $('<div><p>hello</p></div>');
-
     var options = $.extend({}, $.summernote.options);
     options.historyLimit = 5;
-    context = new Context($note, options);
+    context = new Context($('<div><p>hello</p></div>'), options);
 
     editor = context.modules.editor;
     $editable = context.layoutInfo.editable;
@@ -64,8 +62,7 @@ describe('Editor', () => {
   describe('initialize', () => {
     it('should bind custom events', (done) => {
       [
-        'keydown', 'keyup', 'blur', 'mousedown', 'mouseup',
-        'scroll', 'focusin', 'focusout',
+        'keydown', 'keyup', 'blur', 'mousedown', 'mouseup', 'scroll', 'focusin', 'focusout',
       ].forEach((eventName) => {
         expectToHaveBeenCalled(context, 'summernote.' + eventName, () => {
           $editable.trigger(eventName);
@@ -349,6 +346,30 @@ describe('Editor', () => {
     it('should make contents empty', (done) => {
       editor.empty();
       expect(editor.isEmpty()).await(done).to.be.true;
+    });
+  });
+
+  describe('styleWithCSS', () => {
+    it('should style with tag when it is false (default)', (done) => {
+      $editable.appendTo('body');
+      range.createFromNode($editable.find('p')[0]).normalize().select();
+      editor.bold();
+      expectContentsAwait(context, '<p><b>hello</b></p>', done);
+    });
+
+    it('should style with CSS when it is true', (done) => {
+      var options = $.extend({}, $.summernote.options);
+      options.styleWithCSS = true;
+
+      $('body').empty();
+      context = new Context($('<div><p>hello</p></div>').appendTo('body'), options);
+      editor = context.modules.editor;
+      $editable = context.layoutInfo.editable;
+      $editable.appendTo('body');
+
+      range.createFromNode($editable.find('p')[0]).normalize().select();
+      editor.bold();
+      expectContentsAwait(context, '<p><span style="font-weight: bold;">hello</span></p>', done);
     });
   });
 


### PR DESCRIPTION
#### What does this PR do?

- Once upon a time (lol), we'd had an option `styleWithSpan` which affects on `styleWithCss` of `execCommand`. I don't know when and why we removed this option.
- `styleWithSpan` could be confused with `styleWithCSS` so I renamed it as same as its property name of content editable.

#### How should this be manually tested?

- Set `styleWithCSS` as true or false. And apply a format to text.

#### What are the relevant tickets?

- #727
- #3025
- #2643

### Checklist
- [x] added relevant tests
- [x] didn't break anything
