### PR TITLE
Support external codemirror constructor

### DIFF
--- a/examples/external-codemirror.html
+++ b/examples/external-codemirror.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>Summernote - CodeMirror</title>
+
+  <!-- include jquery -->
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.js"></script>
+
+  <!-- include libs stylesheets -->
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.css" />
+  <script src="//cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.5/umd/popper.js"></script>
+  <script src="//maxcdn.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.js"></script>
+
+  <!-- include codemirror (codemirror.css, codemirror.js, xml.js, formatting.js)-->
+  <link rel="stylesheet" type="text/css" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.41.0/codemirror.min.css" />
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.41.0/theme/blackboard.min.css">
+  <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.41.0/theme/monokai.min.css">
+  <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.41.0/codemirror.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/codemirror/5.41.0/mode/xml/xml.min.js"></script>
+
+  <!-- include summernote -->
+  <link rel="stylesheet" href="../summernote-bs4.css">
+  <script type="text/javascript" src="../summernote-bs4.js"></script>
+
+  <link rel="stylesheet" href="example.css">
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $('.summernote').summernote({
+        height: 200,
+        tabsize: 2,
+        codemirror: {
+          CodeMirrorConstructor: window.CodeMirror,
+          mode: 'text/html',
+          htmlMode: true,
+          lineNumbers: true,
+          theme: 'monokai'
+        }
+      });
+    });
+  </script>
+</head>
+<body>
+<div class="container">
+  <h1>Summernote with CodeMirror</h1>
+  <p><a href="https://summernote.org/examples/#codemirror-as-codeview">https://summernote.org/examples/#codemirror-as-codeview</a></p>
+  <textarea class="summernote"><p>Seasons <b>coming up</b></p></textarea>
+  <p>&nbsp;</p>
+  <pre>
+    $(document).ready(function() {
+      $('.summernote').summernote({
+        height: 200,
+        tabsize: 2,
+        codemirror: {
+          CodeMirrorConstructor: window.CodeMirror,
+          mode: 'text/html',
+          htmlMode: true,
+          lineNumbers: true,
+          theme: 'monokai'
+        }
+      });
+    });
+
+
+  </pre>
+</div>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -55,6 +55,7 @@
       { title: 'Mode Switcher', link : 'mode-switcher.html', description: 'Change mode between Default and Air', support: 'bs3, bs4, lite'},      
       { title: 'Air Mode', link : 'airmode.html', description: 'run as airmode', support: 'bs3, bs4, lite'},      
       { title: 'Air Mode with scroll', link : 'airmode-scroll.html', description: 'run as airmode with scroll', support: 'bs3, bs4, lite'},      
+      { title: 'External CodeMirror Constructor', link : 'external-codemirror.html', description: 'support external codemirror', support: 'bs3, bs4, lite'},            
     ]
     function generate_sample_pages() {
       var html = samples.map(it => {

--- a/src/js/base/core/env.js
+++ b/src/js/base/core/env.js
@@ -46,8 +46,6 @@ if (isMSIE) {
 
 const isEdge = /Edge\/\d+/.test(userAgent);
 
-let hasCodeMirror = !!window.CodeMirror;
-
 const isSupportTouch =
   (('ontouchstart' in window) ||
    (navigator.MaxTouchPoints > 0) ||
@@ -78,7 +76,6 @@ export default {
   jqueryVersion: parseFloat($.fn.jquery),
   isSupportAmd,
   isSupportTouch,
-  hasCodeMirror,
   isFontInstalled,
   isW3CRangeSupport: !!document.createRange,
   inputEventName,

--- a/src/js/base/module/Codeview.js
+++ b/src/js/base/module/Codeview.js
@@ -1,10 +1,4 @@
-import env from '../core/env';
 import dom from '../core/dom';
-
-let CodeMirror;
-if (env.hasCodeMirror) {
-  CodeMirror = window.CodeMirror;
-}
 
 /**
  * @class Codeview
@@ -16,7 +10,7 @@ export default class CodeView {
     this.$editable = context.layoutInfo.editable;
     this.$codable = context.layoutInfo.codable;
     this.options = context.options;
-    this.CodeMirrorConstructor = CodeMirror; 
+    this.CodeMirrorConstructor = window.CodeMirror; 
 
     if (this.options.codemirror.CodeMirrorConstructor) {
       this.CodeMirrorConstructor = this.options.codemirror.CodeMirrorConstructor;

--- a/src/js/base/module/Codeview.js
+++ b/src/js/base/module/Codeview.js
@@ -16,11 +16,17 @@ export default class CodeView {
     this.$editable = context.layoutInfo.editable;
     this.$codable = context.layoutInfo.codable;
     this.options = context.options;
+    this.CodeMirrorConstructor = CodeMirror; 
+
+    if (this.options.codemirror.CodeMirrorConstructor) {
+      this.CodeMirrorConstructor = this.options.codemirror.CodeMirrorConstructor;
+    }
   }
 
   sync() {
     const isCodeview = this.isActivated();
-    if (isCodeview && env.hasCodeMirror) {
+    const CodeMirror = this.CodeMirrorConstructor;
+    if (isCodeview && CodeMirror) {
       this.$codable.data('cmEditor').save();
     }
   }
@@ -78,6 +84,7 @@ export default class CodeView {
    * activate code view
    */
   activate() {
+    const CodeMirror = this.CodeMirrorConstructor;    
     this.$codable.val(dom.html(this.$editable, this.options.prettifyHtml));
     this.$codable.height(this.$editable.height());
 
@@ -86,7 +93,7 @@ export default class CodeView {
     this.$codable.focus();
 
     // activate CodeMirror as codable
-    if (env.hasCodeMirror) {
+    if (CodeMirror) {
       const cmEditor = CodeMirror.fromTextArea(this.$codable[0], this.options.codemirror);
 
       // CodeMirror TernServer
@@ -122,8 +129,9 @@ export default class CodeView {
    * deactivate code view
    */
   deactivate() {
+    const CodeMirror = this.CodeMirrorConstructor;    
     // deactivate CodeMirror as codable
-    if (env.hasCodeMirror) {
+    if (CodeMirror) {
       const cmEditor = this.$codable.data('cmEditor');
       this.$codable.val(cmEditor.getValue());
       cmEditor.toTextArea();


### PR DESCRIPTION
Allows you to apply codemirror when building webpack.

#### What does this PR do?

- Inject the CodeMirror constructor.

#### Where should the reviewer start?

- start on the src/js/base/module/Codeview.js

#### How should this be manually tested?

```
npm run dev 

open http://localhost:3000/examples/external-codemirror.html
```

#### Any background context you want to provide?

* webpack4 build code - https://github.com/summernote/summernote-webpack-example 


#### What are the relevant tickets?


#### Screenshot (if for frontend)


### Checklist
- [ ] added relevant tests
- [ ] didn't break anything
- [ ] ...
