### PR TITLE
Replace 'inherit' value with 'transparent' as per #3620

### DIFF
--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -118,7 +118,7 @@ export default class Buttons {
             '<div class="note-palette">',
               '<div class="note-palette-title">' + this.lang.color.background + '</div>',
               '<div>',
-                '<button type="button" class="note-color-reset btn btn-light" data-event="backColor" data-value="inherit">',
+                '<button type="button" class="note-color-reset btn btn-light" data-event="backColor" data-value="transparent">',
                   this.lang.color.transparent,
                 '</button>',
               '</div>',

--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -311,7 +311,7 @@ const colorDropdownButton = function(opt, type) {
             '<div class="note-btn-group btn-background-color">',
               '<div class="note-palette-title">' + opt.lang.color.background + '</div>',
             '<div>',
-            '<button type="button" class="note-color-reset note-btn note-btn-block" data-event="backColor" data-value="inherit">',
+            '<button type="button" class="note-color-reset note-btn note-btn-block" data-event="backColor" data-value="transparent">',
               opt.lang.color.transparent,
             '</button>',
           '</div>',


### PR DESCRIPTION
#### What does this PR do?

- Replace the `inherit` colour value with `transparent` is this is the correct default value as pointed out in issue #3620 with cited information from MOZ.

#### What are the relevant tickets?
#3620 
