### PR TITLE
refs #3394 - Update to font selection error.

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -802,7 +802,7 @@ export default class Editor {
         const firstSpan = lists.head(spans);
         if (firstSpan && !dom.nodeLength(firstSpan)) {
           firstSpan.innerHTML = dom.ZERO_WIDTH_NBSP_CHAR;
-          range.createFromNodeAfter(firstSpan.firstChild).select();
+          range.createFromNode(firstSpan.firstChild).select();
           this.setLastRange();
           this.$editable.data(KEY_BOGUS, firstSpan);
         }

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -430,6 +430,13 @@ describe('Editor', () => {
       // start <p>hello</p> => <h6 class="h6">hello</h6>
       expectContentsAwait(context, '<h6 class="customH6Class">hello</h6>', done);
     });
+
+    it('should add fontSize to block', () => {
+      $editable.appendTo('body');
+      editor.fontSize(20);
+
+      expectContents(context, '<p><span style="font-size: 20px;">﻿</span>hello</p>');
+    });
   });
 
   describe('createLink', () => {


### PR DESCRIPTION
1 - Change font-family from execCommand instead of CSS.
2 - Update fontStyling method to recover previous element format before
apply new Style.

#### What does this PR do?
Update the methods used to chande FontSize to avoid lost previous format.
Change FontName method to use default execCommand and avoid lost previous format.

#### Where should the reviewer start?

- start on the src/js/base/module/Editor.js

#### How should this be manually tested?

- Follow the script on issue #3394, after this update no more error can be found.

#### What are the relevant tickets?

#3394

#### Screenshot (if for frontend)


### Checklist
[ OK] added relevant tests
[ OK] didn't break anything

### Notes
The execCommand not apply changes direct to HTML and I can´t create specific tests to validade FontSize automatic.
If has any form to do, I want to know.