### PR TITLE
Fix bs4 note-btn on popover

### DIFF
--- a/src/styles/summernote-bs4.scss
+++ b/src/styles/summernote-bs4.scss
@@ -2,7 +2,7 @@
 @import "elements.scss";
 @import 'summernote-common.scss';
 
-.note-toolbar .note-btn {
+.note-btn-group .note-btn {
   background: #fff;
   border-color: #dae0e5;
   padding: 0.28rem 0.65rem;


### PR DESCRIPTION
#### What does this PR do?

- Fix button styles on popovers. (@lqez fixed the style on the toolbar's buttons but it didn't change the popovers' ones).

#### Where should the reviewer start?

- src/styles/summernote-bs4.scss

#### How should this be manually tested?

- check toolbar buttons
- check popover buttons (click on a link)

#### Screenshot (if for frontend)

Before : style change was not effective on popovers.
<img width="302" alt="Capture d’écran 2020-03-30 à 09 45 54" src="https://user-images.githubusercontent.com/7761386/77888125-09858080-726c-11ea-99cc-e6c9feffbac0.png">
After :
<img width="258" alt="Capture d’écran 2020-03-30 à 09 53 22" src="https://user-images.githubusercontent.com/7761386/77888295-4fdadf80-726c-11ea-8221-60bb3affc640.png">