### PR TITLE
Add an option for enabling autolink behavior shows only domain names

### DIFF
--- a/src/js/base/module/AutoLink.js
+++ b/src/js/base/module/AutoLink.js
@@ -8,6 +8,7 @@ const linkPattern = /^([A-Za-z][A-Za-z0-9+-.]*\:[\/]{2}|tel:|mailto:[A-Z0-9._%+-
 export default class AutoLink {
   constructor(context) {
     this.context = context;
+    this.options = context.options;
     this.events = {
       'summernote.keyup': (we, e) => {
         if (!e.isDefaultPrevented()) {
@@ -38,7 +39,9 @@ export default class AutoLink {
 
     if (match && (match[1] || match[2])) {
       const link = match[1] ? keyword : defaultScheme + keyword;
-      const urlText = keyword.replace(/^(?:https?:\/\/)?(?:tel?:?)?(?:mailto?:?)?(?:www\.)?/i, '').split('/')[0];
+      const urlText = this.options.showDomainOnlyForAutolink ?
+        keyword.replace(/^(?:https?:\/\/)?(?:tel?:?)?(?:mailto?:?)?(?:www\.)?/i, '').split('/')[0]
+        : keyword;
       const node = $('<a />').html(urlText).attr('href', link)[0];
       if (this.context.options.linkTargetBlank) {
         $(node).attr('target', '_blank');

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -139,6 +139,9 @@ $.summernote = $.extend($.summernote, {
     historyLimit: 200,
 
     // TODO: need to be documented
+    showDomainOnlyForAutolink: false,
+
+    // TODO: need to be documented
     hintMode: 'word',
     hintSelect: 'after',
     hintDirection: 'bottom',


### PR DESCRIPTION
#### What does this PR do?

- Add an option for enabling AutoLink behavior shows only domain names.

#### Any background context you want to provide?

- Currently, AutoLink always shows only domain names of entered URLs. This might not be an intended behavior of WYSIWYG editors so I added an option for it and turn it off by default.

Before:
When you enter `https://github.com/summernote/summernote/pull/3653` and press space, then it will be replaced with just `github.com`.

After:
With `showDomainOnlyForAutolink: false`, it preserves original URLs or it works as like as it does currently.