### PR TITLE
allowing CodeMirror to accept programmatic changes

### DIFF
--- a/src/js/base/Context.js
+++ b/src/js/base/Context.js
@@ -101,7 +101,7 @@ export default class Context {
       return isActivated ? this.layoutInfo.codable.val() : this.layoutInfo.editable.html();
     } else {
       if (isActivated) {
-        this.layoutInfo.codable.val(html);
+        this.invoke('codeview.sync', html);
       } else {
         this.layoutInfo.editable.html(html);
       }

--- a/src/js/base/module/Codeview.js
+++ b/src/js/base/module/Codeview.js
@@ -19,10 +19,19 @@ export default class CodeView {
     this.options = context.options;
   }
 
-  sync() {
-    const isCodeview = this.isActivated();
-    if (isCodeview && env.hasCodeMirror) {
-      this.$codable.data('cmEditor').save();
+  sync(html) {
+    if (this.isActivated()) {
+      if (html) {
+        if (env.hasCodeMirror) {
+          this.$codable.data('cmEditor').getDoc().setValue(html);
+        } else {
+          this.$codable.val(html);
+        }
+      } else {
+        if (env.hasCodeMirror) {
+          this.$codable.data('cmEditor').save();
+        }
+      }
     }
   }
 


### PR DESCRIPTION
#### What does this PR do?

- uses Context.code with an overloaded CodeView.sync to send html as well as retrieve it from CodeView. In particular, this allows us to send external html to the CodeMirror editor when it is visible.

#### Where should the reviewer start?

- Context.js

#### How should this be manually tested?

- `editor.summernote('code', '<div>new content</div>')` to modify the contents of an editor which was initialized with CodeMirror and has CodeView currently activated.

#### Any background context you want to provide?

- Currently the only way to get the CodeMirror editor to recognize that new content was added by the surrounding application is to toggle into wysiwyg mode, call 'code', and toggle back.

#### What are the relevant tickets?
None
#### Screenshot (if for frontend)

### Checklist
- [x] added relevant tests (no automated tests cover CodeMirror currently)
- [x] didn't break anything (ran the tests and nothing else broke) 


