### PR TITLE
Use same pipeline while debugging with test:debug script

### DIFF
--- a/karma.debug.conf.js
+++ b/karma.debug.conf.js
@@ -1,48 +1,36 @@
+var webpackConfig = require('./config/webpack.config.dev.js');
+
 module.exports = function (config) {
   config.set({
-    frameworks: ['mocha', 'karma-typescript'],
+    frameworks: ['mocha'],
     colors: true,
     logLevel: config.LOG_INFO,
-    files: [
-      { pattern: 'src/js/**/*.js' },
-      { pattern: 'test/**/*.spec.js' }
-    ],
+
+    browsers: ['ChromeDebug'],
     customLaunchers: {
       ChromeDebug: {
         base: "Chrome",
         flags: ["--remote-debugging-port=9333"]
       }
     },
-    // Chrome, ChromeCanary, Firefox, Opera, Safari, IE
-    browsers: ['ChromeDebug'],
+
+    files: [
+      'node_modules/jquery/dist/jquery.js',
+      { pattern: 'src/js/**/*.js' },
+      { pattern: 'test/**/*.spec.js' }
+    ],
+
     preprocessors: {
-      'src/js/**/*.js': ['karma-typescript'],
-      'test/**/*.spec.js': ['karma-typescript']
+      'src/js/**/*.js': ['webpack', ],
+      'test/**/*.spec.js': ['webpack', ],
     },
-    reporters: ['dots', 'karma-typescript'],
-    coverageReporter: {
-      type: 'lcov',
-      dir: 'coverage/',
-      includeAllSources: true
+
+    webpack: webpackConfig,
+    webpackMiddleware: {
+      stats: 'errors-only',
     },
+
+    reporters: ['dots'],
     browserNoActivityTimeout: 60000,
-    karmaTypescriptConfig: {
-      tsconfig: './tsconfig.json',
-      include: [
-        'test/**/*.spec.js'
-      ],
-      bundlerOptions: {
-        entrypoints: /\.spec\.js$/,
-        transforms: [require("karma-typescript-es6-transform")()],
-        exclude: [
-          'node_modules'
-        ],
-        sourceMap: true,
-        addNodeGlobals: false
-      },
-      compilerOptions: {
-        "module": "commonjs"
-      }
-    }
   });
 };


### PR DESCRIPTION
@reinaldocoelho introduced(https://github.com/summernote/summernote/pull/3636) `test:debug` to make easier debugging by running Chrome with a custom parameter. But its karma configuration uses `karma-typescript` (what we had used before) plugins so I made it to use same webpack configuration as like as others.