### PR TITLE
Add ability to allow plugins to not have buttons disable when in codeview

### DIFF
--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -601,7 +601,7 @@ export default class Buttons {
 
     this.context.memo('button.fullscreen', () => {
       return this.button({
-        className: 'btn-fullscreen',
+        className: 'btn-fullscreen note-keep',
         contents: this.ui.icon(this.options.icons.arrowsAlt),
         tooltip: this.lang.options.fullscreen,
         click: this.context.createInvokeHandler('fullscreen.toggle'),
@@ -610,7 +610,7 @@ export default class Buttons {
 
     this.context.memo('button.codeview', () => {
       return this.button({
-        className: 'btn-codeview',
+        className: 'btn-codeview note-keep',
         contents: this.ui.icon(this.options.icons.code),
         tooltip: this.lang.options.codeview,
         click: this.context.createInvokeHandler('codeview.toggle'),

--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -536,7 +536,7 @@ export default class Buttons {
     this.context.memo('button.table', () => {
       return this.ui.buttonGroup([
         this.button({
-          className: 'dropdown-toggle',
+          className: 'dropdown-toggle note-codeview-keep',
           contents: this.ui.dropdownButtonContents(this.ui.icon(this.options.icons.table), this.options),
           tooltip: this.lang.table.table,
           data: {
@@ -601,7 +601,7 @@ export default class Buttons {
 
     this.context.memo('button.fullscreen', () => {
       return this.button({
-        className: 'btn-fullscreen note-keep',
+        className: 'btn-fullscreen note-codeview-keep',
         contents: this.ui.icon(this.options.icons.arrowsAlt),
         tooltip: this.lang.options.fullscreen,
         click: this.context.createInvokeHandler('fullscreen.toggle'),
@@ -610,7 +610,7 @@ export default class Buttons {
 
     this.context.memo('button.codeview', () => {
       return this.button({
-        className: 'btn-codeview note-keep',
+        className: 'btn-codeview note-codeview-keep',
         contents: this.ui.icon(this.options.icons.code),
         tooltip: this.lang.options.codeview,
         click: this.context.createInvokeHandler('codeview.toggle'),

--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -536,7 +536,7 @@ export default class Buttons {
     this.context.memo('button.table', () => {
       return this.ui.buttonGroup([
         this.button({
-          className: 'dropdown-toggle note-codeview-keep',
+          className: 'dropdown-toggle',
           contents: this.ui.dropdownButtonContents(this.ui.icon(this.options.icons.table), this.options),
           tooltip: this.lang.table.table,
           data: {

--- a/src/js/base/module/Toolbar.js
+++ b/src/js/base/module/Toolbar.js
@@ -135,7 +135,7 @@ export default class Toolbar {
   activate(isIncludeCodeview) {
     let $btn = this.$toolbar.find('button');
     if (!isIncludeCodeview) {
-      $btn = $btn.not('.btn-codeview').not('.btn-fullscreen');
+      $btn = $btn.not('.note-keep');
     }
     this.ui.toggleBtn($btn, true);
   }
@@ -143,7 +143,7 @@ export default class Toolbar {
   deactivate(isIncludeCodeview) {
     let $btn = this.$toolbar.find('button');
     if (!isIncludeCodeview) {
-      $btn = $btn.not('.btn-codeview').not('.btn-fullscreen');
+      $btn = $btn.not('.note-keep');
     }
     this.ui.toggleBtn($btn, false);
   }

--- a/src/js/base/module/Toolbar.js
+++ b/src/js/base/module/Toolbar.js
@@ -135,7 +135,7 @@ export default class Toolbar {
   activate(isIncludeCodeview) {
     let $btn = this.$toolbar.find('button');
     if (!isIncludeCodeview) {
-      $btn = $btn.not('.note-keep');
+      $btn = $btn.not('.note-codeview-keep');
     }
     this.ui.toggleBtn($btn, true);
   }
@@ -143,7 +143,7 @@ export default class Toolbar {
   deactivate(isIncludeCodeview) {
     let $btn = this.$toolbar.find('button');
     if (!isIncludeCodeview) {
-      $btn = $btn.not('.note-keep');
+      $btn = $btn.not('.note-codeview-keep');
     }
     this.ui.toggleBtn($btn, false);
   }

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -74,7 +74,7 @@ $.summernote = $.extend($.summernote, {
     otherStaticBar: '',
 
     // toolbar
-    codeviewButton: false,
+    codeviewKeepButton: false,
     toolbar: [
       ['style', ['style']],
       ['font', ['bold', 'underline', 'clear']],

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -74,6 +74,7 @@ $.summernote = $.extend($.summernote, {
     otherStaticBar: '',
 
     // toolbar
+    codeviewButton: false,
     toolbar: [
       ['style', ['style']],
       ['font', ['bold', 'underline', 'clear']],

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -173,6 +173,9 @@ const ui = function(editorOptions) {
             $(e.currentTarget).tooltip('hide');
           });
         }
+        if (options && options.codeviewButton) {
+          $node.addClass('note-keep');
+        }
       })($node, options);
     },
 

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -37,6 +37,10 @@ const dropdown = renderer.create('<ul class="note-dropdown-menu dropdown-menu">'
   }).join('') : options.items;
 
   $node.html(markup).attr({ 'aria-label': options.title });
+
+  if (options && options.codeviewKeepButton) {
+    $node.addClass('note-codeview-keep');
+  }
 });
 
 const dropdownButtonContents = function(contents, options) {
@@ -50,6 +54,10 @@ const dropdownCheck = renderer.create('<ul class="note-dropdown-menu dropdown-me
     return '<li aria-label="' + item + '"><a href="#" data-value="' + value + '">' + icon(options.checkClassName) + ' ' + content + '</a></li>';
   }).join('') : options.items;
   $node.html(markup).attr({ 'aria-label': options.title });
+  
+  if (options && options.codeviewKeepButton) {
+    $node.addClass('note-codeview-keep');
+  }
 });
 
 const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false" tabindex="-1" role="dialog"/>', function($node, options) {
@@ -174,7 +182,7 @@ const ui = function(editorOptions) {
           });
         }
         if (options && options.codeviewButton) {
-          $node.addClass('note-keep');
+          $node.addClass('note-codeview-keep');
         }
       })($node, options);
     },

--- a/src/js/bs4/ui.js
+++ b/src/js/bs4/ui.js
@@ -177,6 +177,9 @@ const ui = function(editorOptions) {
             $(e.currentTarget).tooltip('hide');
           });
         }
+        if (options && options.codeviewButton) {
+          $node.addClass('note-keep');
+        }
       })($node, options);
     },
 

--- a/src/js/bs4/ui.js
+++ b/src/js/bs4/ui.js
@@ -37,8 +37,9 @@ const dropdown = renderer.create('<div class="note-dropdown-menu dropdown-menu" 
   }).join('') : options.items;
 
   $node.html(markup).attr({ 'aria-label': options.title });
-  if (options && options.codeviewButton) {
-    $node.addClass('note-keep');
+
+  if (options && options.codeviewKeepButton) {
+    $node.addClass('note-codeview-keep');
   }
 });
 
@@ -53,6 +54,10 @@ const dropdownCheck = renderer.create('<div class="note-dropdown-menu dropdown-m
     return '<a class="dropdown-item" href="#" data-value="' + value + '" role="listitem" aria-label="' + item + '">' + icon(options.checkClassName) + ' ' + content + '</a>';
   }).join('') : options.items;
   $node.html(markup).attr({ 'aria-label': options.title });
+
+  if (options && options.codeviewKeepButton) {
+    $node.addClass('note-codeview-keep');
+  }
 });
 
 const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false" tabindex="-1" role="dialog"/>', function($node, options) {
@@ -178,7 +183,7 @@ const ui = function(editorOptions) {
           });
         }
         if (options && options.codeviewButton) {
-          $node.addClass('note-keep');
+          $node.addClass('note-codeview-keep');
         }
       })($node, options);
     },

--- a/src/js/bs4/ui.js
+++ b/src/js/bs4/ui.js
@@ -37,6 +37,9 @@ const dropdown = renderer.create('<div class="note-dropdown-menu dropdown-menu" 
   }).join('') : options.items;
 
   $node.html(markup).attr({ 'aria-label': options.title });
+  if (options && options.codeviewButton) {
+    $node.addClass('note-keep');
+  }
 });
 
 const dropdownButtonContents = function(contents) {

--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -49,6 +49,9 @@ const button = renderer.create('<button type="button" class="note-btn" tabindex=
       container: options.container,
     }));
   }
+  if (options && options.codeviewButton) {
+    $node.addClass('note-keep');
+  }
 });
 
 const dropdown = renderer.create('<div class="note-dropdown-menu" role="list">', function($node, options) {

--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -49,8 +49,9 @@ const button = renderer.create('<button type="button" class="note-btn" tabindex=
       container: options.container,
     }));
   }
-  if (options && options.codeviewButton) {
-    $node.addClass('note-keep');
+
+  if (options && options.codeviewKeepButton) {
+    $node.addClass('note-codeview-keep');
   }
 });
 
@@ -79,6 +80,9 @@ const dropdown = renderer.create('<div class="note-dropdown-menu" role="list">',
       options.itemClick(e, item, value);
     }
   });
+  if (options && options.codeviewKeepButton) {
+    $node.addClass('note-codeview-keep');
+  }
 });
 
 const dropdownCheck = renderer.create('<div class="note-dropdown-menu note-check" role="list">', function($node, options) {
@@ -105,6 +109,9 @@ const dropdownCheck = renderer.create('<div class="note-dropdown-menu note-check
       options.itemClick(e, item, value);
     }
   });
+  if (options && options.codeviewKeepButton) {
+    $node.addClass('note-codeview-keep');
+  }
 });
 
 const dropdownButtonContents = function(contents, options) {


### PR DESCRIPTION
#### What does this PR do?
This PR adds the ability to allow plugins to not have their buttons disabled when the editor is switched to CodeView.

#### Where should the reviewer start?

- src/js/settings.js added option `codeviewKeepButton: false|true`
- src/js/modules/Toolbar.js
- src/js/lite/ui.js
- src/js/bs3/ui.js
- src/js/bs4/ui.js

#### What are the relevant tickets?
#3662 

Users can use the `codeviewKeepButton: true` in their plugins when initialising buttons which will add the class '.note-keep' to the button, which the Toolbar.js module was altered to look for the class `.note-codeview-keep` on the codeview switching function rather than `.note-fullscreen` and `.note-codeview` classes allowing any button that contains the `.note-keep` class to not be disabled.

With the changes by @lqez Buttons as well as Dropdowns now have the above features.
