### PR TITLE
Fix pasteHTML issue

### DIFF
--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -575,39 +575,25 @@ function prevPoint(point, isSkipInnerOffset) {
 function nextPoint(point, isSkipInnerOffset) {
   let node, offset;
 
-  if (isEmpty(point.node)) {
-    return null;
-  }
-
   if (nodeLength(point.node) === point.offset) {
     if (isEditable(point.node)) {
       return null;
     }
 
     let nextTextNode = getNextTextNode(point.node);
-    if(nextTextNode)
-    {
+    if (nextTextNode) {
       node = nextTextNode;
       offset = 0;
-    }
-    else
-    {
+    } else {
       node = point.node.parentNode;
       offset = position(point.node) + 1;
     }
   } else if (hasChildren(point.node)) {
     node = point.node.childNodes[point.offset];
     offset = 0;
-    if (isEmpty(node)) {
-      return null;
-    }
   } else {
     node = point.node;
     offset = isSkipInnerOffset ? nodeLength(point.node) : point.offset + 1;
-
-    if (isEmpty(node)) {
-      return null;
-    }
   }
 
   return {

--- a/src/js/base/core/range.js
+++ b/src/js/base/core/range.js
@@ -139,8 +139,8 @@ class WrappedRange {
   nativeRange() {
     if (env.isW3CRangeSupport) {
       const w3cRange = document.createRange();
-      w3cRange.setStart(this.sc, this.sc.data && this.so > this.sc.data.length ? 0 : this.so);
-      w3cRange.setEnd(this.ec, this.sc.data ? Math.min(this.eo, this.sc.data.length) : this.eo);
+      w3cRange.setStart(this.sc, this.so);
+      w3cRange.setEnd(this.ec, this.eo);
 
       return w3cRange;
     } else {
@@ -554,6 +554,9 @@ class WrappedRange {
     const info = dom.splitPoint(rng.getStartPoint(), dom.isInline(node));
     if (info.rightNode) {
       info.rightNode.parentNode.insertBefore(node, info.rightNode);
+      if (dom.isEmpty(info.rightNode) && dom.isPara(node)) {
+        info.rightNode.parentNode.removeChild(info.rightNode);
+      }
     } else {
       info.container.appendChild(node);
     }
@@ -572,14 +575,18 @@ class WrappedRange {
 
     // const rng = this.wrapBodyInlineWithPara().deleteContents();
     const rng = this;
+    let reversed = false;
 
     if (rng.so >= 0) {
       childNodes = childNodes.reverse();
+      reversed = true;
     }
+
     childNodes = childNodes.map(function(childNode) {
       return rng.insertNode(childNode);
     });
-    if (rng.so > 0) {
+
+    if (reversed) {
       childNodes = childNodes.reverse();
     }
     return childNodes;

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -292,7 +292,12 @@ describe('Editor', () => {
       expectContentsAwait(context, '<p>hello<span> world</span></p>', done);
     });
 
-    it('should not call change change event more than once per paste event', () => {
+    it('should not add empty paragraph', (done) => {
+      editor.pasteHTML('<p><span>whatever</span><br></p><p><span>it has</span><br></p>');
+      expectContentsAwait(context, '<p>hello</p><p><span>whatever</span><br></p><p><span>it has</span><br></p>', done);
+    });
+
+    it('should not call change event more than once per paste event', () => {
       var generateLargeHtml = () => {
         var html = '<div>';
         for (var i = 0; i < 1000; i++) {
@@ -384,6 +389,25 @@ describe('Editor', () => {
         editor.formatBlock('h1');
         expectContentsAwait(context, '<h1>hello</h1>', done);
       }, 10);
+    });
+
+    it('should toggle all paragraph even with empty paragraph', (done) => {
+      var codes = [
+        '<p><br></p>',
+        '<p>endpoint</p>',
+      ];
+
+      context.invoke('code', codes.join(''));
+      $editable.appendTo('body');
+
+      var startNode = $editable.find('p').first()[0];
+      var endNode = $editable.find('p').last()[0];
+
+      // all p tags is wrapped
+      range.create(startNode, 0, endNode, 1).normalize().select();
+
+      editor.insertUnorderedList();
+      expectContentsAwait(context, '<ul><li><br></li><li>endpoint</li></ul>', done);
     });
 
     it('should apply multi formatBlock', (done) => {


### PR DESCRIPTION
#### What does this PR do?

- #3113 and #3498 fixed paste-related issue for some cases. But they causes another problem.
- When we insert new nodes, `dom.splitPoint` is called and it creates empty node(`<p><br></p>`). Actually, we don't need to create it but the empty node is needed for placing the caret. Without an empty node, user cannot place their caret where they would be.
- But `dom.splitPoint` creates a lot of empty paragraph while processing nodes. So #3498 added checking logic for empty nodes but it causes another issue which is described on #3678.
- This patch removes the empty paragraph which was created by `dom.splitPoint` after inserting new nodes when it should be deleted.

#### What are the relevant tickets?

- #3113
- #3678 
- #3498 

### Checklist
- [x] added relevant tests
- [x] didn't break anything
