### PR TITLE
Update qq video url pattern in VideoDialog.js

### DIFF
--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -136,7 +136,7 @@ export default class VideoDialog {
         .attr('frameborder', 0)
         .attr('height', '310')
         .attr('width', '500')
-        .attr('src', 'https://v.qq.com/iframe/player.html?vid=' + vid + '&amp;auto=0');
+        .attr('src', 'https://v.qq.com/txp/iframe/player.html?vid=' + vid + '&amp;auto=0');
     } else if (mp4Match || oggMatch || webmMatch) {
       $video = $('<video controls>')
         .attr('src', url)


### PR DESCRIPTION
The qq video url pattern has been changed from 'https://v.qq.com/iframe/player.html?vid=' to 'https://v.qq.com/txp/iframe/player.html?vid=', insert '/txp' in the path.