### PR TITLE
Update qq video url pattern in VideoDialog.js and VideoDialog.spec.js

### DIFF
--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -136,7 +136,7 @@ export default class VideoDialog {
         .attr('frameborder', 0)
         .attr('height', '310')
         .attr('width', '500')
-        .attr('src', 'https://v.qq.com/iframe/player.html?vid=' + vid + '&amp;auto=0');
+        .attr('src', 'https://v.qq.com/txp/iframe/player.html?vid=' + vid + '&amp;auto=0');
     } else if (mp4Match || oggMatch || webmMatch) {
       $video = $('<video controls>')
         .attr('src', url)

--- a/test/base/module/VideoDialog.spec.js
+++ b/test/base/module/VideoDialog.spec.js
@@ -48,9 +48,9 @@ describe('VideoDialog', () => {
         '//instagram.com/p/Bi9cbsxjn-F/embed/');
       // v.qq.com
       expectUrl('http://v.qq.com/cover/6/640ewqy2v071ppd.html?vid=f0196y2b2cx',
-        '//v.qq.com/iframe/player.html?vid=f0196y2b2cx&amp;auto=0');
+        '//v.qq.com/txp/iframe/player.html?vid=f0196y2b2cx&amp;auto=0');
       expectUrl('http://v.qq.com/x/page/p0330y279lm.html',
-        '//v.qq.com/iframe/player.html?vid=p0330y279lm&amp;auto=0');
+        '//v.qq.com/txp/iframe/player.html?vid=p0330y279lm&amp;auto=0');
       // Facebook
       expectUrl('https://www.facebook.com/Engineering/videos/631826881803/',
         '//www.facebook.com/plugins/video.php?href=www.facebook.com%2FEngineering%2Fvideos%2F631826881803');


### PR DESCRIPTION
The qq video url pattern has been changed from 'https://v.qq.com/iframe/player.html?vid=' to 'https://v.qq.com/txp/iframe/player.html?vid=', insert '/txp' in the path.