### PR TITLE
fixed self closed div tags to add end tag

### DIFF
--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -129,7 +129,7 @@ export default class Buttons {
                 '</button>',
                 '<input type="color" id="backColorPicker" class="note-btn note-color-select-btn" value="' + this.options.colorButton.backColor + '" data-event="backColorPalette">',
               '</div>',
-              '<div class="note-holder-custom" id="backColorPalette" data-event="backColor"/>',
+              '<div class="note-holder-custom" id="backColorPalette" data-event="backColor"></div>',
             '</div>',
           ].join('') : '') +
           (foreColor ? [
@@ -147,7 +147,7 @@ export default class Buttons {
                 '</button>',
                 '<input type="color" id="foreColorPicker" class="note-btn note-color-select-btn" value="' + this.options.colorButton.foreColor + '" data-event="foreColorPalette">',
               '</div>', // Fix missing Div, Commented to find easily if it's wrong
-              '<div class="note-holder-custom" id="foreColorPalette" data-event="foreColor"/>',
+              '<div class="note-holder-custom" id="foreColorPalette" data-event="foreColor"></div>',
             '</div>',
           ].join('') : ''),
           callback: ($dropdown) => {
@@ -548,9 +548,9 @@ export default class Buttons {
           className: 'note-table',
           items: [
             '<div class="note-dimension-picker">',
-              '<div class="note-dimension-picker-mousecatcher" data-event="insertTable" data-value="1x1"/>',
-              '<div class="note-dimension-picker-highlighted"/>',
-              '<div class="note-dimension-picker-unhighlighted"/>',
+              '<div class="note-dimension-picker-mousecatcher" data-event="insertTable" data-value="1x1"></div>',
+              '<div class="note-dimension-picker-highlighted"></div>',
+              '<div class="note-dimension-picker-unhighlighted"></div>',
             '</div>',
             '<div class="note-dimension-display">1 x 1</div>',
           ].join(''),

--- a/src/js/base/module/Dropzone.js
+++ b/src/js/base/module/Dropzone.js
@@ -12,7 +12,7 @@ export default class Dropzone {
 
     this.$dropzone = $([
       '<div class="note-dropzone">',
-        '<div class="note-dropzone-message"/>',
+        '<div class="note-dropzone-message"></div>',
       '</div>',
     ].join('')).prependTo(this.$editor);
   }

--- a/src/js/base/module/HelpDialog.js
+++ b/src/js/base/module/HelpDialog.js
@@ -45,7 +45,7 @@ export default class HelpDialog {
     const keyMap = this.options.keyMap[env.isMac ? 'mac' : 'pc'];
     return Object.keys(keyMap).map((key) => {
       const command = keyMap[key];
-      const $row = $('<div><div class="help-list-item"/></div>');
+      const $row = $('<div><div class="help-list-item"></div></div>');
       $row.append($('<label><kbd>' + key + '</kdb></label>').css({
         'width': 180,
         'margin-right': 10,

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -2,7 +2,7 @@ import $ from 'jquery';
 import renderer from '../base/renderer';
 
 const editor = renderer.create('<div class="note-editor note-frame panel panel-default"/>');
-const toolbar = renderer.create('<div class="panel-heading note-toolbar" role="toolbar"></div></div>');
+const toolbar = renderer.create('<div class="panel-heading note-toolbar" role="toolbar"></div>');
 const editingArea = renderer.create('<div class="note-editing-area"/>');
 const codable = renderer.create('<textarea class="note-codable" aria-multiline="true"/>');
 const editable = renderer.create('<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>');
@@ -10,9 +10,9 @@ const statusbar = renderer.create([
   '<output class="note-status-output" role="status" aria-live="polite"/>',
   '<div class="note-statusbar" role="status">',
     '<div class="note-resizebar" aria-label="Resize">',
-      '<div class="note-icon-bar"/>',
-      '<div class="note-icon-bar"/>',
-      '<div class="note-icon-bar"/>',
+      '<div class="note-icon-bar"></div>',
+      '<div class="note-icon-bar"></div>',
+      '<div class="note-icon-bar"></div>',
     '</div>',
   '</div>',
 ].join(''));
@@ -83,8 +83,8 @@ const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false
 
 const popover = renderer.create([
   '<div class="note-popover popover in">',
-    '<div class="arrow"/>',
-    '<div class="popover-content note-children-container"/>',
+    '<div class="arrow"></div>',
+    '<div class="popover-content note-children-container"></div>',
   '</div>',
 ].join(''), function($node, options) {
   const direction = typeof options.direction !== 'undefined' ? options.direction : 'bottom';

--- a/src/js/bs4/ui.js
+++ b/src/js/bs4/ui.js
@@ -10,16 +10,16 @@ const statusbar = renderer.create([
   '<output class="note-status-output" role="status" aria-live="polite"/>',
   '<div class="note-statusbar" role="status">',
     '<div class="note-resizebar" aria-label="Resize">',
-      '<div class="note-icon-bar"/>',
-      '<div class="note-icon-bar"/>',
-      '<div class="note-icon-bar"/>',
+      '<div class="note-icon-bar"></div>',
+      '<div class="note-icon-bar"></div>',
+      '<div class="note-icon-bar"></div>',
     '</div>',
   '</div>',
 ].join(''));
 
 const airEditor = renderer.create('<div class="note-editor note-airframe"/>');
 const airEditable = renderer.create([
-  '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>',
+  '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"></div>',
   '<output class="note-status-output" role="status" aria-live="polite"/>',
 ].join(''));
 
@@ -83,8 +83,8 @@ const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false
 
 const popover = renderer.create([
   '<div class="note-popover popover in">',
-    '<div class="arrow"/>',
-    '<div class="popover-content note-children-container"/>',
+    '<div class="arrow"></div>',
+    '<div class="popover-content note-children-container"></div>',
   '</div>',
 ].join(''), function($node, options) {
   const direction = typeof options.direction !== 'undefined' ? options.direction : 'bottom';

--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -13,16 +13,16 @@ const statusbar = renderer.create([
   '<output class="note-status-output" role="status" aria-live="polite"/>',
   '<div class="note-statusbar" role="status">',
     '<div class="note-resizebar" aria-label="resize">',
-      '<div class="note-icon-bar"/>',
-      '<div class="note-icon-bar"/>',
-      '<div class="note-icon-bar"/>',
+      '<div class="note-icon-bar"></div>',
+      '<div class="note-icon-bar"></div>',
+      '<div class="note-icon-bar"></div>',
     '</div>',
   '</div>',
 ].join(''));
 
 const airEditor = renderer.create('<div class="note-editor note-airframe"/>');
 const airEditable = renderer.create([
-  '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>',
+  '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"></div>',
   '<output class="note-status-output" role="status" aria-live="polite"/>',
 ].join(''));
 
@@ -236,9 +236,9 @@ const tableDropdownButton = function(opt) {
       className: 'note-table',
       items: [
         '<div class="note-dimension-picker">',
-          '<div class="note-dimension-picker-mousecatcher" data-event="insertTable" data-value="1x1"/>',
-          '<div class="note-dimension-picker-highlighted"/>',
-          '<div class="note-dimension-picker-unhighlighted"/>',
+          '<div class="note-dimension-picker-mousecatcher" data-event="insertTable" data-value="1x1"></div>',
+          '<div class="note-dimension-picker-highlighted"></div>',
+          '<div class="note-dimension-picker-unhighlighted"></div>',
         '</div>',
         '<div class="note-dimension-display">1 x 1</div>',
       ].join(''),
@@ -325,7 +325,7 @@ const colorDropdownButton = function(opt, type) {
               opt.lang.color.transparent,
             '</button>',
           '</div>',
-          '<div class="note-holder" data-event="backColor"/>',
+          '<div class="note-holder" data-event="backColor"></div>',
             '<div class="btn-sm">',
               '<input type="color" id="html5bcp" class="note-btn btn-default" value="#21104A" style="width:100%;" data-value="cp">',
               '<button type="button" class="note-color-reset btn" data-event="backColor" data-value="cpbackColor">',
@@ -340,7 +340,7 @@ const colorDropdownButton = function(opt, type) {
                 opt.lang.color.resetToDefault,
               '</button>',
             '</div>',
-            '<div class="note-holder" data-event="foreColor"/>',
+            '<div class="note-holder" data-event="foreColor"></div>',
               '<div class="btn-sm">',
                 '<input type="color" id="html5fcp" class="note-btn btn-default" value="#21104A" style="width:100%;" data-value="cp">',
                 '<button type="button" class="note-color-reset btn" data-event="foreColor" data-value="cpforeColor">',
@@ -492,8 +492,8 @@ const linkDialog = function(opt) {
 
 const popover = renderer.create([
   '<div class="note-popover bottom">',
-    '<div class="note-popover-arrow"/>',
-    '<div class="popover-content note-children-container"/>',
+    '<div class="note-popover-arrow"></div>',
+    '<div class="popover-content note-children-container"></div>',
   '</div>',
 ].join(''), function($node, options) {
   const direction = typeof options.direction !== 'undefined' ? options.direction : 'bottom';

--- a/src/js/lite/ui/TooltipUI.js
+++ b/src/js/lite/ui/TooltipUI.js
@@ -13,8 +13,8 @@ class TooltipUI {
     // create tooltip node
     this.$tooltip = $([
       '<div class="note-tooltip">',
-        '<div class="note-tooltip-arrow"/>',
-        '<div class="note-tooltip-content"/>',
+        '<div class="note-tooltip-arrow"></div>',
+        '<div class="note-tooltip-content"></div>',
       '</div>',
     ].join(''));
 


### PR DESCRIPTION

#### What does this PR do?

- fixed self closed div tags to add end tag
- lite version can running on jQuery v3.5.0 

#### Where should the reviewer start?

- start on the src/js/lite/ui/TooltipUI.js 

#### How should this be manually tested?



#### Any background context you want to provide?

-  https://jquery.com/upgrade-guide/3.5/
- browser dom parser problem(?)
  - Self close does not work for non-empty tags(refer to https://developer.mozilla.org/ko/docs/Glossary/Empty_element) 

wanted 
```html
<div /><div /> 
```
actually
```html
<div>
    <div></div>
</div>
```

<img width="494" alt="스크린샷 2020-04-30 오후 5 52 52" src="https://user-images.githubusercontent.com/591983/80703842-7cf60880-8b1e-11ea-9664-4e3bcfe4d2d6.png">


#### What are the relevant tickets?

#3700

#### Screenshot (if for frontend)


### Checklist
- [x] added relevant tests
- [x] didn't break anything
