### PR TITLE
Better handling blur events on popovers

### DIFF
--- a/src/js/base/module/ImagePopover.js
+++ b/src/js/base/module/ImagePopover.js
@@ -16,8 +16,17 @@ export default class ImagePopover {
     this.options = context.options;
 
     this.events = {
-      'summernote.disable summernote.blur': () => {
+      'summernote.disable summernote.dialog.shown': () => {
         this.hide();
+      },
+      'summernote.blur': (we, e) => {
+        if (e.originalEvent && e.originalEvent.relatedTarget) {
+          if (!this.$popover[0].contains(e.originalEvent.relatedTarget)) {
+            this.hide();
+          }
+        } else {
+          this.hide();
+        }
       },
     };
   }

--- a/src/js/base/module/LinkPopover.js
+++ b/src/js/base/module/LinkPopover.js
@@ -12,8 +12,17 @@ export default class LinkPopover {
       'summernote.keyup summernote.mouseup summernote.change summernote.scroll': () => {
         this.update();
       },
-      'summernote.disable summernote.dialog.shown summernote.blur': () => {
+      'summernote.disable summernote.dialog.shown': () => {
         this.hide();
+      },
+      'summernote.blur': (we, e) => {
+        if (e.originalEvent && e.originalEvent.relatedTarget) {
+          if (!this.$popover[0].contains(e.originalEvent.relatedTarget)) {
+            this.hide();
+          }
+        } else {
+          this.hide();
+        }
       },
     };
   }

--- a/src/js/base/module/TablePopover.js
+++ b/src/js/base/module/TablePopover.js
@@ -16,8 +16,17 @@ export default class TablePopover {
       'summernote.keyup summernote.scroll summernote.change': () => {
         this.update();
       },
-      'summernote.disable summernote.blur': () => {
+      'summernote.disable summernote.dialog.shown': () => {
         this.hide();
+      },
+      'summernote.blur': (we, e) => {
+        if (e.originalEvent && e.originalEvent.relatedTarget) {
+          if (!this.$popover[0].contains(e.originalEvent.relatedTarget)) {
+            this.hide();
+          }
+        } else {
+          this.hide();
+        }
       },
     };
   }


### PR DESCRIPTION
#### What does this PR do?

- Provides better event handling for popovers.
- Ignore `summernote.blur` event when it comes from inside the popover.

#### How should this be manually tested?

- Add a popover plugin and click the custom button on the popover.
- Check whether the popover is hided or not after clicking.

#### Any background context you want to provide?

- I got an issue about custom popover button plugin and noticed this issue while debugging it.

#### What are the relevant tickets?

- https://github.com/summernote/django-summernote/issues/385