### PR TITLE
fix bug #3740

### DIFF
--- a/src/js/base/module/HintPopover.js
+++ b/src/js/base/module/HintPopover.js
@@ -1,7 +1,6 @@
 import $ from 'jquery';
 import func from '../core/func';
 import lists from '../core/lists';
-import dom from '../core/dom';
 import range from '../core/range';
 import key from '../core/key';
 

--- a/src/js/base/module/HintPopover.js
+++ b/src/js/base/module/HintPopover.js
@@ -117,16 +117,21 @@ export default class HintPopover {
           this.lastWordRange.so += rangeCompute;
         }
       }
-      this.lastWordRange.insertNode(node);
-
-      if (this.options.hintSelect === 'next') {
-        var blank = document.createTextNode('');
-        $(node).after(blank);
-        range.createFromNodeBefore(blank).select();
+      // Insert text in existing span or tag to keep style
+      if (typeof node === 'string') {
+        this.lastWordRange.select();
+        document.execCommand( 'insertText', false, node); 
+      // Classic insert Node
       } else {
-        range.createFromNodeAfter(node).select();
+        this.lastWordRange.insertNode(node);
+        if (this.options.hintSelect === 'next') {
+          var blank = document.createTextNode('');
+          $(node).after(blank);
+          range.createFromNodeBefore(blank).select();
+        } else {
+          range.createFromNodeAfter(node).select();
+        }
       }
-
       this.lastWordRange = null;
       this.hide();
       this.context.invoke('editor.focus');
@@ -137,9 +142,6 @@ export default class HintPopover {
     const hint = this.hints[$item.data('index')];
     const item = $item.data('item');
     let node = hint.content ? hint.content(item) : item;
-    if (typeof node === 'string') {
-      node = dom.createText(node);
-    }
     return node;
   }
 


### PR DESCRIPTION

#### What does this PR do?

This PR fix the bug #3740 
The initial code "add" a node outside of current style.
The new code, if text item -> insert in current node (replace) and so keep style.

#### Where should the reviewer start?

- start on the HintPopover.js

#### How should this be manually tested?

As explain in bug : 
- Choose font-size 24 (not the default)
- Use Hint
- font-size jump to "default" font-size (before the patch -> now it works)


#### What are the relevant tickets?

#3740 

