### PR TITLE
fixed jquery migrate bug

### DIFF
--- a/examples/bs4-with-jquery-migrate.html
+++ b/examples/bs4-with-jquery-migrate.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>Summernote - Bootstrap 4</title>
+  <!-- include jquery -->
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery-migrate/3.3.0/jquery-migrate.min.js"></script>
+
+  <!-- include libs stylesheets -->
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.css" />
+  <script src="//cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.5/umd/popper.js"></script>
+  <script src="//maxcdn.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.js"></script>
+
+  <!-- include summernote -->
+  <link rel="stylesheet" href="../summernote-bs4.css">
+  <script type="text/javascript" src="../summernote-bs4.js"></script>
+
+  <link rel="stylesheet" href="example.css">
+  <script type="text/javascript">
+    $(document).ready(function() {
+      $('.summernote').summernote({
+        height: 300,
+        tabsize: 2,
+        followingToolbar: true,
+      });
+    });
+  </script>
+</head>
+<body>
+<div class="container">
+  <h1>Summernote with Bootstrap 4</h1>
+  <p>
+    <span class="badge badge-primary">jQuery v3.3.1</span>
+    <span class="badge badge-info">Bootstrap v4.1.3</span>
+  </p>
+  <div class="summernote"><p>Hello World</p></div>
+  <pre>
+  Scroll page to see sticky toolbar.
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  
+  End of document.
+  </pre>
+</div>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -56,6 +56,7 @@
       { title: 'Air Mode', link : 'airmode.html', description: 'run as airmode', support: 'bs3, bs4, lite'},      
       { title: 'Air Mode with scroll', link : 'airmode-scroll.html', description: 'run as airmode with scroll', support: 'bs3, bs4, lite'},      
       { title: 'External CodeMirror Constructor', link : 'external-codemirror.html', description: 'support external codemirror', support: 'bs3, bs4, lite'},            
+      { title: 'With jQuery Migrate', link : 'bs4-with-jquery-migrate.html', description: 'support jquery-migrate', support: 'bs3, bs4, lite'},
     ]
     function generate_sample_pages() {
       var html = samples.map(it => {

--- a/src/js/base/editing/Style.js
+++ b/src/js/base/editing/Style.js
@@ -1,5 +1,5 @@
 import $ from 'jquery';
-import env from '../core/env';
+// import env from '../core/env';
 import func from '../core/func';
 import lists from '../core/lists';
 import dom from '../core/dom';
@@ -19,14 +19,11 @@ export default class Style {
    * @return {Object}
    */
   jQueryCSS($obj, propertyNames) {
-    if (env.jqueryVersion < 1.9) {
-      const result = {};
-      $.each(propertyNames, (idx, propertyName) => {
-        result[propertyName] = $obj.css(propertyName);
-      });
-      return result;
-    }
-    return $obj.css(propertyNames);
+    const result = {};
+    $.each(propertyNames, (idx, propertyName) => {
+      result[propertyName] = $obj.css(propertyName);
+    });
+    return result;
   }
 
   /**

--- a/src/js/base/editing/Style.js
+++ b/src/js/base/editing/Style.js
@@ -1,5 +1,4 @@
 import $ from 'jquery';
-// import env from '../core/env';
 import func from '../core/func';
 import lists from '../core/lists';
 import dom from '../core/dom';


### PR DESCRIPTION

#### What does this PR do?

- fixed jquery.css method use way 

#### Where should the reviewer start?

- start on the src/js/base/editing/Style.js

#### How should this be manually tested?

- npm run dev 
- open http://localhost:3000/examples/bs4-with-jquery-migrate.html 

#### Any background context you want to provide?

- jQuery.css method is not support  parameters with propertyNames. when using to jquery-migrate library 
- refer to https://github.com/jquery/jquery-migrate/blob/master/src/jquery/css.js#L101

#### What are the relevant tickets?

#3739

#### Screenshot (if for frontend)


### Checklist
- [x] added relevant tests
- [x] didn't break anything
