### PR TITLE
Security Fix for Cross Site Scripting - huntr.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Summernote 
+# Summernote  
 
 Super simple WYSIWYG Editor.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Super simple WYSIWYG Editor.
 
+Just testing things xo
+
 [![Build Status](https://travis-ci.org/summernote/summernote.svg?branch=develop)](http://travis-ci.org/summernote/summernote)
 [![npm version](https://badge.fury.io/js/summernote.svg)](http://badge.fury.io/js/summernote)
 [![Coverage Status](https://coveralls.io/repos/summernote/summernote/badge.svg?branch=develop&service=github)](https://coveralls.io/github/summernote/summernote?branch=develop)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# Summernote
+# Summernote 
 
 Super simple WYSIWYG Editor.
-
-Just testing things xo
 
 [![Build Status](https://travis-ci.org/summernote/summernote.svg?branch=develop)](http://travis-ci.org/summernote/summernote)
 [![npm version](https://badge.fury.io/js/summernote.svg)](http://badge.fury.io/js/summernote)

--- a/dist/summernote-bs4.js
+++ b/dist/summernote-bs4.js
@@ -1988,7 +1988,7 @@ function dom_value($node, stripLinebreaks) {
         '<': '&lt;',
         '>': '&gt;'
     };
-    return this.replace(/[&<>]/g, function(tag) {
+    return this.replace(/(?:&(?!amp;|gt;|lt;)|>|<)/g, function(tag) {
         return tagsToReplace[tag] || tag;
     });
   };

--- a/dist/summernote-bs4.js
+++ b/dist/summernote-bs4.js
@@ -1980,19 +1980,7 @@ var isTextarea = makePredByNodeName('TEXTAREA');
 
 function dom_value($node, stripLinebreaks) {
   var val = isTextarea($node[0]) ? $node.val() : $node.html();
-  
-  // Cross Site Scripting Mitigation
-  String.prototype.escape = function() {
-    var tagsToReplace = {
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;'
-    };
-    return this.replace(/(?:&(?!amp;|gt;|lt;)|>|<)/g, function(tag) {
-        return tagsToReplace[tag] || tag;
-    });
-  };
-  val = val.escape();
+
   if (stripLinebreaks) {
     return val.replace(/[\n\r]/g, '');
   }

--- a/dist/summernote-bs4.js
+++ b/dist/summernote-bs4.js
@@ -1980,7 +1980,19 @@ var isTextarea = makePredByNodeName('TEXTAREA');
 
 function dom_value($node, stripLinebreaks) {
   var val = isTextarea($node[0]) ? $node.val() : $node.html();
-
+  
+  // Cross Site Scripting Mitigation
+  String.prototype.escape = function() {
+    var tagsToReplace = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;'
+    };
+    return this.replace(/[&<>]/g, function(tag) {
+        return tagsToReplace[tag] || tag;
+    });
+  };
+  val = val.escape();
   if (stripLinebreaks) {
     return val.replace(/[\n\r]/g, '');
   }

--- a/dist/summernote-lite.js
+++ b/dist/summernote-lite.js
@@ -1980,20 +1980,7 @@ var isTextarea = makePredByNodeName('TEXTAREA');
 
 function dom_value($node, stripLinebreaks) {
   var val = isTextarea($node[0]) ? $node.val() : $node.html();
-  
-  // Cross Site Scripting Mitigation
-  String.prototype.escape = function() {
-    var tagsToReplace = {
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;'
-    };
-    return this.replace(/(?:&(?!amp;|gt;|lt;)|>|<)/g, function(tag) {
-        return tagsToReplace[tag] || tag;
-    });
-  };
-  val = val.escape();
-  
+
   if (stripLinebreaks) {
     return val.replace(/[\n\r]/g, '');
   }

--- a/dist/summernote-lite.js
+++ b/dist/summernote-lite.js
@@ -1988,7 +1988,7 @@ function dom_value($node, stripLinebreaks) {
         '<': '&lt;',
         '>': '&gt;'
     };
-    return this.replace(/[&<>]/g, function(tag) {
+    return this.replace(/(?:&(?!amp;|gt;|lt;)|>|<)/g, function(tag) {
         return tagsToReplace[tag] || tag;
     });
   };

--- a/dist/summernote-lite.js
+++ b/dist/summernote-lite.js
@@ -1980,7 +1980,20 @@ var isTextarea = makePredByNodeName('TEXTAREA');
 
 function dom_value($node, stripLinebreaks) {
   var val = isTextarea($node[0]) ? $node.val() : $node.html();
-
+  
+  // Cross Site Scripting Mitigation
+  String.prototype.escape = function() {
+    var tagsToReplace = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;'
+    };
+    return this.replace(/[&<>]/g, function(tag) {
+        return tagsToReplace[tag] || tag;
+    });
+  };
+  val = val.escape();
+  
   if (stripLinebreaks) {
     return val.replace(/[\n\r]/g, '');
   }

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -1988,7 +1988,7 @@ function dom_value($node, stripLinebreaks) {
         '<': '&lt;',
         '>': '&gt;'
     };
-    return this.replace(/[&<>]/g, function(tag) {
+    return this.replace(/(?:&(?!amp;|gt;|lt;)|>|<)/g, function(tag) {
         return tagsToReplace[tag] || tag;
     });
   };

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -1980,19 +1980,7 @@ var isTextarea = makePredByNodeName('TEXTAREA');
 
 function dom_value($node, stripLinebreaks) {
   var val = isTextarea($node[0]) ? $node.val() : $node.html();
-  
-  // Cross Site Scripting Mitigation
-  String.prototype.escape = function() {
-    var tagsToReplace = {
-        '&': '&amp;',
-        '<': '&lt;',
-        '>': '&gt;'
-    };
-    return this.replace(/(?:&(?!amp;|gt;|lt;)|>|<)/g, function(tag) {
-        return tagsToReplace[tag] || tag;
-    });
-  };
-  val = val.escape();
+
   if (stripLinebreaks) {
     return val.replace(/[\n\r]/g, '');
   }

--- a/dist/summernote.js
+++ b/dist/summernote.js
@@ -1980,7 +1980,19 @@ var isTextarea = makePredByNodeName('TEXTAREA');
 
 function dom_value($node, stripLinebreaks) {
   var val = isTextarea($node[0]) ? $node.val() : $node.html();
-
+  
+  // Cross Site Scripting Mitigation
+  String.prototype.escape = function() {
+    var tagsToReplace = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;'
+    };
+    return this.replace(/[&<>]/g, function(tag) {
+        return tagsToReplace[tag] || tag;
+    });
+  };
+  val = val.escape();
   if (stripLinebreaks) {
     return val.replace(/[\n\r]/g, '');
   }

--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -1047,7 +1047,7 @@ const isTextarea = makePredByNodeName('TEXTAREA');
 function value($node, stripLinebreaks) {
   const val = isTextarea($node[0]) ? $node.val() : $node.html();
   
-    // Cross Site Scripting Mitigation
+  // Cross Site Scripting Mitigation
   String.prototype.escape = function() {
     var tagsToReplace = {
         '&': '&amp;',

--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -1046,6 +1046,20 @@ const isTextarea = makePredByNodeName('TEXTAREA');
  */
 function value($node, stripLinebreaks) {
   const val = isTextarea($node[0]) ? $node.val() : $node.html();
+  
+    // Cross Site Scripting Mitigation
+  String.prototype.escape = function() {
+    var tagsToReplace = {
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;'
+    };
+    return this.replace(/(?:&(?!amp;|gt;|lt;)|>|<)/g, function(tag) {
+        return tagsToReplace[tag] || tag;
+    });
+  };
+  val = val.escape();
+  
   if (stripLinebreaks) {
     return val.replace(/[\n\r]/g, '');
   }


### PR DESCRIPTION
https://huntr.dev/app/users/Asjidkalam has fixed the Cross Site Scripting vulnerability 🔨. Asjidkalam has been awarded $25 for fixing the vulnerability through the huntr bug bounty program 💵. Think you could fix a vulnerability like this?

Get involved at https://huntr.dev/

Q | A
Version Affected | ALL
Bug Fix | YES
Original Pull Request | https://github.com/418sec/summernote/pull/1
GitHub Issue URL | https://github.com/summernote/summernote/issues/3719
Vulnerability README | https://github.com/418sec/huntr/blob/master/bounties/npm/summernote/1/README.md

### User Comments:

### 📊 Metadata *

_Please enter the direct URL for this bounty on huntr.dev. This is compulsory and will help us process your bounty submission quicker._

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-summernote

### ⚙️ Abstract

Affected versions of this package are vulnerable to Cross-site Scripting (XSS). It is possible to inject JavaScript with object decoding such as `<script>alert(1)</script>` resulting in XSS. The fix is to sanitize the input on the package before further processing/executing.

### ❓ Technical description

Issue: https://github.com/summernote/summernote/issues/3719
From the issue, the package doesn't sanitize any HTML entities thrown at it. It is unsafe and causes reflected XSS in all cases. However, filtering out the tags which causes XSS from the DOM input can mitigate the issue.
The Fix is implemented in the `dom_value` function, which returns the input value (`val`) from the DOM. `val` variable is sanitized by replacing tags like `&`, `>`, `<` with `&amp;`, `&lt;` and `&gt;` respectively. So i made a callback prototype function to achieve this:
```js
String.prototype.escape = function() {
    var tagsToReplace = {
        '&': '&amp;',
        '<': '&lt;',
        '>': '&gt;'
    };
    return this.replace(/[&<>]/g, function(tag) {
        return tagsToReplace[tag] || tag;
    });
};
```

### 🐛 Proof of Vulnerability (PoV)

Open the editor, go to the `Code View` section and enter the following payload:
`<script>alert(1)</script>`, now deactivate the `Code View` to trigger the XSS.

_Before patch:_
![before-patch](https://user-images.githubusercontent.com/16708391/82661648-08f4df00-9c4a-11ea-8f64-1c86fe523eb0.PNG)


### 🔥 Proof of Fix (PoF)

_After patch:_
![after-patch](https://user-images.githubusercontent.com/16708391/82662137-f4fdad00-9c4a-11ea-8e53-28c341b4733d.PNG)

It successfully sanitizes the input and deactivates from the `Code View` without triggering XSS.
The debug messages in the console shows the actual input and filtered input. 

**index.html** file used in the POC:
```html
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
    <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/css/bootstrap.min.css" />
    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.4.1/js/bootstrap.min.js"></script>

    <link href="summernote.css" rel="stylesheet">
    <script src="summernote.js"></script>
    
    <title>Summernote - XSS Fix POC</title>
</head>
<body>
    <div id="summernote">Hello summernote</div>
    <script>
        $(document).ready(function() {
            $('#summernote').summernote();
        });
    </script>
</body>
</html>
```