### PR TITLE
ko_KR: fix color.cpSelect for better expression

### DIFF
--- a/lang/summernote-ko-KR.js
+++ b/lang/summernote-ko-KR.js
@@ -104,7 +104,7 @@
         setTransparent: '투명으로 설정',
         reset: '취소',
         resetToDefault: '기본값으로 설정',
-        cpSelect: '고르다',
+        cpSelect: '선택',
       },
       shortcut: {
         shortcuts: '키보드 단축키',


### PR DESCRIPTION
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.

#### What does this PR do?

Suggesting more better expression for internationalization of korean language.

Actually, '고르다' is a verb, it seems not to be natural for Korean people, so I'd like to suggest '선택' instead of it. 

#### Where should the reviewer start?

lang/summernote-ko-KR.js

#### How should this be manually tested?

just set lang option to `ko-KR` when you initialize summernote and open text color panel

#### Any background context you want to provide?

Nope!

#### What are the relevant tickets?

Nope!

#### Screenshot (if for frontend)
It's not good...
![image](https://user-images.githubusercontent.com/13935811/85739777-0d765100-b73c-11ea-8106-fe882f8efd1c.png)

I think it's better!
![image](https://user-images.githubusercontent.com/13935811/85739945-2f6fd380-b73c-11ea-8f75-070cb680c00f.png)


### Checklist
- [ ] added relevant tests -> ?
- [x] didn't break anything
- [x] works good at my production
