### PR TITLE
Remove existing class on format block

### DIFF
--- a/src/js/base/module/Editor.js
+++ b/src/js/base/module/Editor.js
@@ -801,11 +801,12 @@ export default class Editor {
       }
 
       if ($target && $target.length) {
+        const currentRange = this.createRange();
+        const $parent = $([currentRange.sc, currentRange.ec]).closest(tagName);
+        // remove class added for current block
+        $parent.removeClass();
         const className = $target[0].className || '';
         if (className) {
-          const currentRange = this.createRange();
-
-          const $parent = $([currentRange.sc, currentRange.ec]).closest(tagName);
           $parent.addClass(className);
         }
       }

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -455,6 +455,30 @@ describe('Editor', () => {
       expectContentsAwait(context, '<h6 class="customH6Class">hello</h6>', done);
     });
 
+    it('should replace existing class in formatBlock if target has class', (done) => {
+      const $target1 = $('<p class="old" />');
+      $editable.appendTo('body');
+      range.createFromNode($editable.find('p')[0]).normalize().select();
+      editor.formatBlock('p', $target1);
+      const $target2 = $('<p class="new" />');
+      editor.formatBlock('p', $target2);
+
+      // start <p class="old">hello</p> => <p class="new">hello</p>
+      expectContentsAwait(context, '<p class="new">hello</p>', done);
+    });
+
+    it('should remove existing class in formatBlock if target has no class', (done) => {
+      const $target1 = $('<p class="customClass" />');
+      $editable.appendTo('body');
+      range.createFromNode($editable.find('p')[0]).normalize().select();
+      editor.formatBlock('p', $target1);
+      const $target2 = $('<p />');
+      editor.formatBlock('p', $target2);
+
+      // start <p class="customClass">hello</p> => <p>hello</p>
+      expectContentsAwait(context, '<p class="">hello</p>', done);
+    });
+
     it('should add fontSize to block', (done) => {
       $editable.appendTo('body');
       context.invoke('editor.focus');


### PR DESCRIPTION
#### What does this PR do?

If you have added styles to the styles menu using the styleTags option that use css classes and you have more than one style that uses the same tag (e.g. two styles that both use p) then when changing the style of a block from one to another, the class names of both styles are added to the block instead of the class from the new style replacing the class from the old one.

This fixes the issue by removing any classes from a block in formatBlock.

#### Where should the reviewer start?

- start with src/js/base/module/Editor.js onFormatBlock

#### How should this be manually tested?
- Add the following styles to the page:
```
  <style type="text/css">
    .red { color: red; }
    .blue { color: blue; }
  </style>
```

- Add the following styleTags to summernote:
```

     $('.summernote').summernote({
        styleTags: [
          'p',
          {title: 'Red', tag: 'p', className: 'red', value: 'p'},
          {title: 'Blue', tag: 'p', className: 'blue', value: 'p'},
        ]
      });
```

- Set style to "Red" and type a paragraph.
- Change style to "Blue".
- Switch to code view - note that the class of the block has both class names i.e. `<p class="red blue">`.

Additionaly if you now set the style back to normal the block is still blue since the class="blue" is not removed.

#### Any background context you want to provide?


#### What are the relevant tickets?

This fixes #3159.

### Checklist
- [X ] added relevant tests
- [X ] didn't break anything
- [ ] ...
