### PR TITLE
[#3660] Fix: change event is not called in hints

### DIFF
--- a/src/js/base/module/HintPopover.js
+++ b/src/js/base/module/HintPopover.js
@@ -130,6 +130,7 @@ export default class HintPopover {
       this.lastWordRange = null;
       this.hide();
       this.context.invoke('editor.focus');
+      this.context.triggerEvent('change', this.$editable.html(), this.$editable);
     }
   }
 

--- a/test/base/module/HintPopover.spec.js
+++ b/test/base/module/HintPopover.spec.js
@@ -11,8 +11,10 @@ import range from 'src/js/base/core/range';
 import env from 'src/js/base/core/env';
 import key from 'src/js/base/core/key';
 import 'src/js/bs4/settings';
+import spies from "chai-spies";
 
 chai.use(chaidom);
+chai.use(spies);
 
 describe('HintPopover', () => {
   var expect = chai.expect;
@@ -93,6 +95,9 @@ describe('HintPopover', () => {
       editor.insertText(' #');
       $editable.keyup();
 
+      var onChange = chai.spy();
+      $note.on('summernote.change', onChange);
+
       setTimeout(() => {
         var e = $.Event('keydown');
         e.keyCode = key.code.ENTER;
@@ -100,6 +105,7 @@ describe('HintPopover', () => {
 
         setTimeout(() => {
           expectContents(context, '<p>hello #jayden world</p>');
+          expect(onChange).to.have.been.called.once;
           done();
         }, 10);
       }, 10);


### PR DESCRIPTION
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.

#### What does this PR do?

- This PR solves #3660 issue, a [patch](https://github.com/summernote/summernote/pull/3747) was already submitted by @jokamax. It was approved, but it was closed at the end, therefore I'm resubmitting the patch proposed by @jokamax and I added a unit test. 

#### Where should the reviewer start?

- start on the src/js/base/module/HintPopover.js

#### How should this be manually tested?

- There is a unit test

#### What are the relevant tickets?
- Issue #3660 


### Checklist
- [x] added relevant tests
