### PR TITLE
Fix

### DIFF
--- a/plugin/specialchars/summernote-ext-specialchars.js
+++ b/plugin/specialchars/summernote-ext-specialchars.js
@@ -26,7 +26,7 @@
         RIGHT: 39,
         ENTER: 13,
       };
-      var COLUMN_LENGTH = 15;
+      var COLUMN_LENGTH = 12;
       var COLUMN_WIDTH = 35;
 
       var currentColumn = 0;
@@ -294,7 +294,7 @@
           ui.onDialogHidden(self.$dialog, function() {
             $specialCharNode.off('click');
 
-            self.$dialog.find('button').tooltip('destroy');
+            self.$dialog.find('button').tooltip();
 
             $(document).off('keydown', keyDownEventHandler);
 


### PR DESCRIPTION
Uncaught TypeError: No method named "destroy"
.tooltip('destroy') Only available in Bootstrap 3. This method removes the tooltip from the element and deletes it.
https://github.com/summernote/summernote/issues/3811#issue-653281715

