### PR TITLE
The accepted image extensions have been made customizable.

### DIFF
--- a/src/js/base/module/ImageDialog.js
+++ b/src/js/base/module/ImageDialog.js
@@ -26,7 +26,7 @@ export default class ImageDialog {
       '<div class="form-group note-form-group note-group-select-from-files">',
         '<label for="note-dialog-image-file-' + this.options.id + '" class="note-form-label">' + this.lang.image.selectFromFiles + '</label>',
         '<input id="note-dialog-image-file-' + this.options.id + '" class="note-image-input form-control-file note-form-control note-input" ',
-        ' type="file" name="files" accept="image/*" multiple="multiple"/>',
+        ' type="file" name="files" accept="'+this.options.acceptImageFileTypes+'" multiple="multiple"/>',
         imageLimitation,
       '</div>',
       '<div class="form-group note-group-image-url">',

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -204,6 +204,7 @@ $.summernote = $.extend($.summernote, {
     dialogsFade: false,
 
     maximumImageFileSize: null,
+    acceptImageFileTypes: "image/*",
 
     callbacks: {
       onBeforeCommand: null,


### PR DESCRIPTION
#### What does this PR do?

- Custom image extension support added by parameter.

#### How should this be manually tested?

- The "acceptImageFileTypes" property should be given ".jpg" value and try to select a file from the image upload popup.

#### Any background context you want to provide?

- No, not.

#### What are the relevant tickets?

- No, no relevant.

#### Screenshot (if for frontend)

![resim](https://user-images.githubusercontent.com/15706050/96853473-10235180-1463-11eb-965e-80e9621af46d.png)

### Checklist
- [X] Custom image extension support added with "acceptImageFileTypes" parameter.
