### PR TITLE
Add summernote id from context to color picker ids for uniqueness

### DIFF
--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -124,12 +124,12 @@ export default class Buttons {
               '</div>',
               '<div class="note-holder" data-event="backColor"><!-- back colors --></div>',
               '<div>',
-                '<button type="button" class="note-color-select btn btn-light btn-default" data-event="openPalette" data-value="backColorPicker">',
+                '<button type="button" class="note-color-select btn btn-light btn-default" data-event="openPalette" data-value="backColorPicker-'+this.options.id+'">',
                   this.lang.color.cpSelect,
                 '</button>',
-                '<input type="color" id="backColorPicker" class="note-btn note-color-select-btn" value="' + this.options.colorButton.backColor + '" data-event="backColorPalette">',
+                '<input type="color" id="backColorPicker-'+this.options.id+'" class="note-btn note-color-select-btn" value="' + this.options.colorButton.backColor + '" data-event="backColorPalette-'+this.options.id+'">',
               '</div>',
-              '<div class="note-holder-custom" id="backColorPalette" data-event="backColor"></div>',
+              '<div class="note-holder-custom" id="backColorPalette-'+this.options.id+'" data-event="backColor"></div>',
             '</div>',
           ].join('') : '') +
           (foreColor ? [
@@ -142,12 +142,12 @@ export default class Buttons {
               '</div>',
               '<div class="note-holder" data-event="foreColor"><!-- fore colors --></div>',
               '<div>',
-                '<button type="button" class="note-color-select btn btn-light btn-default" data-event="openPalette" data-value="foreColorPicker">',
+                '<button type="button" class="note-color-select btn btn-light btn-default" data-event="openPalette" data-value="foreColorPicker-'+this.options.id+'">',
                   this.lang.color.cpSelect,
                 '</button>',
-                '<input type="color" id="foreColorPicker" class="note-btn note-color-select-btn" value="' + this.options.colorButton.foreColor + '" data-event="foreColorPalette">',
+                '<input type="color" id="foreColorPicker-'+this.options.id+'" class="note-btn note-color-select-btn" value="' + this.options.colorButton.foreColor + '" data-event="foreColorPalette-'+this.options.id+'">',
               '</div>', // Fix missing Div, Commented to find easily if it's wrong
-              '<div class="note-holder-custom" id="foreColorPalette" data-event="foreColor"></div>',
+              '<div class="note-holder-custom" id="foreColorPalette-'+this.options.id+'" data-event="foreColor"></div>',
             '</div>',
           ].join('') : ''),
           callback: ($dropdown) => {


### PR DESCRIPTION
#### What does this PR do?

Fixes a colour selection issues caused by non unique ids when there are multiple summernote instances on the page.

#### Where should the reviewer start?

- The only change is adding the already existing id from the summernote context to the relevant id fields in the html to make them unique.

#### How should this be manually tested?

Test the colour picker with more than one summernote instance on the page.

#### What are the relevant tickets?

https://github.com/summernote/summernote/issues/3908
