### PR TITLE
Update HelpDialog.js

### DIFF
--- a/src/js/base/module/HelpDialog.js
+++ b/src/js/base/module/HelpDialog.js
@@ -16,9 +16,9 @@ export default class HelpDialog {
     const $container = this.options.dialogsInBody ? this.$body : this.options.container;
     const body = [
       '<p class="text-center">',
-        '<a href="http://summernote.org/" target="_blank">Summernote @@VERSION@@</a> · ',
-        '<a href="https://github.com/summernote/summernote" target="_blank">Project</a> · ',
-        '<a href="https://github.com/summernote/summernote/issues" target="_blank">Issues</a>',
+        '<a href="http://summernote.org/" target="_blank" rel="noopener noreferrer">Summernote @@VERSION@@</a> · ',
+        '<a href="https://github.com/summernote/summernote" target="_blank" rel="noopener noreferrer">Project</a> · ',
+        '<a href="https://github.com/summernote/summernote/issues" target="_blank" rel="noopener noreferrer">Issues</a>',
       '</p>',
     ].join('');
 


### PR DESCRIPTION
Add rel="noopener noreferrer" to links with target="_blank"

<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

When you link to a page on another site using the target="_blank" attribute, you can expose your site to performance and security issues:

The other page may run on the same process as your page. If the other page is running a lot of JavaScript, your page's performance may suffer.
The other page can access your window object with the window.opener property. This may allow the other page to redirect your page to a malicious URL.
Adding rel="noopener" or rel="noreferrer" to your target="_blank" links avoids these issues.

#### Where should the reviewer start?

- start on the src/js/base/module/HelpDialog.js

#### How should this be manually tested?

- when the HelpDialog is triggered

#### Any background context you want to provide?

- detected when doing a code scan

#### What are the relevant tickets?


#### Screenshot (if for frontend)


### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
