### PR TITLE
Revert "fix dropdownButtonContents function. Add options params"

### DIFF
--- a/src/js/bs4/ui.js
+++ b/src/js/bs4/ui.js
@@ -43,8 +43,8 @@ const dropdown = renderer.create('<div class="note-dropdown-menu dropdown-menu" 
   }
 });
 
-const dropdownButtonContents = function(contents, options) {
-  return contents + ' ' + icon(options.icons.caret, 'span');
+const dropdownButtonContents = function(contents) {
+  return contents;
 };
 
 const dropdownCheck = renderer.create('<div class="note-dropdown-menu dropdown-menu note-check" role="list">', function($node, options) {


### PR DESCRIPTION
Reverts summernote/summernote#3898

Bootstrap4 does not need to add a caret explicitly.
As you can see https://getbootstrap.com/docs/4.5/components/dropdowns/ and https://getbootstrap.com/docs/4.5/getting-started/theming/#sass-options , BS4 creates a caret for dropdowns by default.

#3898 creates double-caret as like as the picture attached.
I'm reverting this issue. #3893 must be caused by another issue.
![image](https://user-images.githubusercontent.com/579366/104357275-4f3bdd00-5550-11eb-8b9e-3a6861469bb9.png)
