### PR TITLE
Update dom.js

### DIFF
--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -178,7 +178,7 @@ function withClosestSiblings(node, pred) {
  * - [workaround] old IE only works with &nbsp;
  * - [workaround] IE11 and other browser works with bogus br
  */
-const blankHTML = env.isMSIE && env.browserVersion < 11 ? '&nbsp;' : '<br>';
+const blankHTML = env.isMSIE && env.browserVersion < 11 ? '&nbsp;' : '<br />';
 
 /**
  * @method nodeLength
@@ -224,8 +224,8 @@ function isEmpty(node) {
 
   if (len === 0) {
     return true;
-  } else if (!isText(node) && len === 1 && node.innerHTML === blankHTML) {
-    // ex) <p><br></p>, <span><br></span>
+  } else if (!isText(node) && len === 1 && (node.innerHTML === '<br>' || node.innerHTML === '<br/>' || node.innerHTML === '<br />')) {
+    // ex) <p><br></p>, <span><br></span>, <p><br/></p>, <span><br/></span>, <p><br /></p>, <span><br /></span>
     return true;
   } else if (lists.all(node.childNodes, isText) && node.innerHTML === '') {
     // ex) <p></p>, <span></span>

--- a/src/js/base/core/dom.js
+++ b/src/js/base/core/dom.js
@@ -224,7 +224,7 @@ function isEmpty(node) {
 
   if (len === 0) {
     return true;
-  } else if (!isText(node) && len === 1 && (node.innerHTML === '<br>' || node.innerHTML === '<br/>' || node.innerHTML === '<br />')) {
+  } else if (!isText(node) && len === 1 && (node.innerHTML === blankHTML || node.innerHTML === '<br>' || node.innerHTML === '<br/>' || node.innerHTML === '<br />')) {
     // ex) <p><br></p>, <span><br></span>, <p><br/></p>, <span><br/></span>, <p><br /></p>, <span><br /></span>
     return true;
   } else if (lists.all(node.childNodes, isText) && node.innerHTML === '') {


### PR DESCRIPTION
Default tag should be `<br />` instead of `<br>` to conform to html syntax, but still recognize all variants `<br> <br/> <br />` as empty as to be backward compatible.

<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

- awesome stuff
- really cool feature
- refactor X

#### Where should the reviewer start?

- start on the src/summernote.js

#### How should this be manually tested?

- click here and here

#### Any background context you want to provide?

- the gem needed to be updated...

#### What are the relevant tickets?


#### Screenshot (if for frontend)


### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
