### PR TITLE
add missing french translation for link.useProtocol

### DIFF
--- a/lang/summernote-fr-FR.js
+++ b/lang/summernote-fr-FR.js
@@ -50,6 +50,7 @@
         textToDisplay: 'Texte à afficher',
         url: 'URL du lien',
         openInNewWindow: 'Ouvrir dans une nouvelle fenêtre',
+        useProtocol: 'Utiliser le protocole par défaut',
       },
       table: {
         table: 'Tableau',


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

- add missing fr-FR translation for the link.useProtocol key

#### Where should the reviewer start?

- lang/summernote-fr-FR.js

#### How should this be manually tested?

- Change language used in examples/lang.html to fr-FR
- Start dev server
- Go to language example: http://localhost:3000/examples/lang.html
- From the language example, create a new link
- Validate that the last option 'Use default protocol' has been translated to 'Utiliser le protocole par défaut'

#### Any background context you want to provide?

- None

#### What are the relevant tickets?

- None but this key does not appear to be translated in all language files. Unfortunately, French is the only one I can provide.

#### Screenshot (if for frontend)

Before
<img width="499" alt="summernote-before" src="https://user-images.githubusercontent.com/2721747/106364959-632d6000-6300-11eb-90f3-74b40f68063e.png">

After
<img width="500" alt="summernote-after" src="https://user-images.githubusercontent.com/2721747/106364967-67597d80-6300-11eb-9bdd-05f39194d763.png">

### Checklist

- [X] Added relevant tests or not required
- [X] Didn't break anything
