### PR TITLE
Changes to add support for Peertube hosted videos

### DIFF
--- a/src/js/base/module/VideoDialog.js
+++ b/src/js/base/module/VideoDialog.js
@@ -47,7 +47,7 @@ export default class VideoDialog {
   }
 
   createVideoNode(url) {
-    // video url patterns(youtube, instagram, vimeo, dailymotion, youku, mp4, ogg, webm)
+    // video url patterns(youtube, instagram, vimeo, dailymotion, youku, peertube, mp4, ogg, webm)
     const ytRegExp = /\/\/(?:(?:www|m)\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|v\/|watch\?v=|watch\?.+&v=))([\w|-]{11})(?:(?:[\?&]t=)(\S+))?$/;
     const ytRegExpForStart = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/;
     const ytMatch = url.match(ytRegExp);
@@ -69,6 +69,9 @@ export default class VideoDialog {
 
     const youkuRegExp = /\/\/v\.youku\.com\/v_show\/id_(\w+)=*\.html/;
     const youkuMatch = url.match(youkuRegExp);
+
+    const peerTubeRegExp =/\/\/(.*)\/videos\/watch\/([^?]*)(?:\?(?:start=(\w*))?(?:&stop=(\w*))?(?:&loop=([10]))?(?:&autoplay=([10]))?(?:&muted=([10]))?)?/; 
+    const peerTubeMatch = url.match(peerTubeRegExp);
 
     const qqRegExp = /\/\/v\.qq\.com.*?vid=(.+)/;
     const qqMatch = url.match(qqRegExp);
@@ -138,7 +141,24 @@ export default class VideoDialog {
         .attr('height', '498')
         .attr('width', '510')
         .attr('src', '//player.youku.com/embed/' + youkuMatch[1]);
-    } else if ((qqMatch && qqMatch[1].length) || (qqMatch2 && qqMatch2[2].length)) {
+    } else if (peerTubeMatch && peerTubeMatch[0].length){
+      var begin = 0;
+      if (peerTubeMatch[2] !== 'undefined') begin = peerTubeMatch[2];
+      var end =0;
+      if (peerTubeMatch[3] !== 'undefined') end = peerTubeMatch[3];
+      var loop = 0;
+      if (peerTubeMatch[4] !== 'undefined') loop = peerTubeMatch[4];
+      var autoplay = 0;
+      if (peerTubeMatch[5] !== 'undefined') autoplay = peerTubeMatch[5];
+      var muted = 0;
+      if (peerTubeMatch[6] !== 'undefined') muted = peerTubeMatch[6];
+      $video = $('<iframe allowfullscreen sandbox="allow-same-origin allow-scripts allow-popups">')
+      .attr('frameborder', 0)
+      .attr('src', '//'+ peerTubeMatch[1] +'/videos/embed/' + peerTubeMatch[2]+"?loop="+loop
+      +"&autoplay="+autoplay+"&muted="+muted +(begin > 0 ? '&start=' + begin : '')+(end > 0 ? '&end=' + start : ''))
+      .attr('width', '560')
+      .attr('height', '315');
+    }else if ((qqMatch && qqMatch[1].length) || (qqMatch2 && qqMatch2[2].length)) {
       const vid = ((qqMatch && qqMatch[1].length) ? qqMatch[1] : qqMatch2[2]);
       $video = $('<iframe webkitallowfullscreen mozallowfullscreen allowfullscreen>')
         .attr('frameborder', 0)

--- a/src/js/base/settings.js
+++ b/src/js/base/settings.js
@@ -246,6 +246,7 @@ $.summernote = $.extend($.summernote, {
       'player.vimeo.com',
       'www.dailymotion.com',
       'player.youku.com',
+      'jumpingbean.tv',
       'v.qq.com',
     ],
 

--- a/src/js/base/summernote-en-US.js
+++ b/src/js/base/summernote-en-US.js
@@ -47,7 +47,7 @@ $.extend($.summernote.lang, {
       videoLink: 'Video Link',
       insert: 'Insert Video',
       url: 'Video URL',
-      providers: '(YouTube, Google Drive, Vimeo, Vine, Instagram, DailyMotion or Youku)',
+      providers: '(YouTube, Google Drive, Vimeo, Vine, Instagram, DailyMotion, Youku, Peertube)',
     },
     link: {
       link: 'Link',


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

- This changes is to add support for PeerTube hosted videos

#### Where should the reviewer start?

- start on the src/js/base/module/VideoDialog.js

#### How should this be manually tested?

- Run "npm run dev"
- On the test pack click the video icon on the menu bar
- Add a PeerTube url like https://jumpingbean.tv/videos/watch/0d96a0dd-b447-4752-b57e-c5b5a58ea76e

#### Any background context you want to provide?

- PeerTube is distributed, self hosted video service and would be great to support in Summernote.
- Only issue I have is how to add a whitelist entry for the PeerTube instance as each instance will have a different url. I have white listed the url for jumpingbean.tv in settings.js for now. I understand this will need to be changed to allow dynamic adding of whitelisted urls but bot sure how to do this.

#### What are the relevant tickets?

No related ticket

#### Screenshot (if for frontend)


### Checklist

- [x] Added relevant tests or not required - not sure how to do this for video urls
- [x] Didn't break anything - not to my knowledge
