### PR TITLE
Support jQuery 3.5+

### DIFF
--- a/plugin/databasic/summernote-ext-databasic.js
+++ b/plugin/databasic/summernote-ext-databasic.js
@@ -20,7 +20,7 @@
     var options = context.options;
     var lang = options.langInfo;
 
-    self.icon = '<i class="fa fa-object-group"/>';
+    self.icon = '<i class="fa fa-object-group"></i>';
 
     // add context menu button for dialog
     context.memo('button.databasic', function() {

--- a/plugin/specialchars/summernote-ext-specialchars.js
+++ b/plugin/specialchars/summernote-ext-specialchars.js
@@ -65,7 +65,7 @@
 
       context.memo('button.specialchars', function() {
         return ui.button({
-          contents: '<i class="fa fa-font fa-flip-vertical">',
+          contents: '<i class="fa fa-font fa-flip-vertical"></i>',
           tooltip: lang.specialChar.specialChar,
           click: function() {
             self.show();
@@ -81,10 +81,10 @@
        * @return {jQuery}
        */
       this.makeSpecialCharSetTable = function() {
-        var $table = $('<table/>');
+        var $table = $('<table></table>');
         $.each(specialCharDataSet, function(idx, text) {
-          var $td = $('<td/>').addClass('note-specialchar-node');
-          var $tr = (idx % COLUMN_LENGTH === 0) ? $('<tr/>') : $table.find('tr').last();
+          var $td = $('<td></td>').addClass('note-specialchar-node');
+          var $tr = (idx % COLUMN_LENGTH === 0) ? $('<tr></tr>') : $table.find('tr').last();
 
           var $button = ui.button({
             callback: function($node) {

--- a/src/js/base/module/AutoLink.js
+++ b/src/js/base/module/AutoLink.js
@@ -42,7 +42,7 @@ export default class AutoLink {
       const urlText = this.options.showDomainOnlyForAutolink ?
         keyword.replace(/^(?:https?:\/\/)?(?:tel?:?)?(?:mailto?:?)?(?:xmpp?:?)?(?:www\.)?/i, '').split('/')[0]
         : keyword;
-      const node = $('<a />').html(urlText).attr('href', link)[0];
+      const node = $('<a></a>').html(urlText).attr('href', link)[0];
       if (this.context.options.linkTargetBlank) {
         $(node).attr('target', '_blank');
       }

--- a/src/js/base/module/HelpDialog.js
+++ b/src/js/base/module/HelpDialog.js
@@ -49,7 +49,7 @@ export default class HelpDialog {
       $row.append($('<label><kbd>' + key + '</kdb></label>').css({
         'width': 180,
         'margin-right': 10,
-      })).append($('<span/>').html(this.context.memo('help.' + command) || command));
+      })).append($('<span></span>').html(this.context.memo('help.' + command) || command));
       return $row.html();
     }).join('');
   }

--- a/src/js/base/module/HintPopover.js
+++ b/src/js/base/module/HintPopover.js
@@ -147,7 +147,7 @@ export default class HintPopover {
   createItemTemplates(hintIdx, items) {
     const hint = this.hints[hintIdx];
     return items.map((item /*, idx */) => {
-      const $item = $('<div class="note-hint-item"/>');
+      const $item = $('<div class="note-hint-item"></div>');
       $item.append(hint.template ? hint.template(item) : item + '');
       $item.data({
         'index': hintIdx,

--- a/src/js/base/module/LinkDialog.js
+++ b/src/js/base/module/LinkDialog.js
@@ -28,13 +28,13 @@ export default class LinkDialog {
         `<input id="note-dialog-link-url-${this.options.id}" class="note-link-url form-control note-form-control note-input" type="text" value="http://"/>`,
       '</div>',
       !this.options.disableLinkTarget
-        ? $('<div/>').append(this.ui.checkbox({
+        ? $('<div></div>').append(this.ui.checkbox({
           className: 'sn-checkbox-open-in-new-window',
           text: this.lang.link.openInNewWindow,
           checked: true,
         }).render()).html()
         : '',
-      $('<div/>').append(this.ui.checkbox({
+      $('<div></div>').append(this.ui.checkbox({
         className: 'sn-checkbox-use-protocol',
         text: this.lang.link.useProtocol,
         checked: true,

--- a/src/js/base/module/Placeholder.js
+++ b/src/js/base/module/Placeholder.js
@@ -26,7 +26,7 @@ export default class Placeholder {
   }
 
   initialize() {
-    this.$placeholder = $('<div class="note-placeholder">');
+    this.$placeholder = $('<div class="note-placeholder"></div>');
     this.$placeholder.on('click', () => {
       this.context.invoke('focus');
     }).html(this.options.placeholder).prependTo(this.$editingArea);

--- a/src/js/bs3/ui.js
+++ b/src/js/bs3/ui.js
@@ -1,11 +1,11 @@
 import $ from 'jquery';
 import renderer from '../base/renderer';
 
-const editor = renderer.create('<div class="note-editor note-frame panel panel-default"/>');
-const toolbar = renderer.create('<div class="panel-heading note-toolbar" role="toolbar"/>');
-const editingArea = renderer.create('<div class="note-editing-area"/>');
-const codable = renderer.create('<textarea class="note-codable" aria-multiline="true"/>');
-const editable = renderer.create('<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>');
+const editor = renderer.create('<div class="note-editor note-frame panel panel-default"></div>');
+const toolbar = renderer.create('<div class="panel-heading note-toolbar" role="toolbar"></div>');
+const editingArea = renderer.create('<div class="note-editing-area"></div>');
+const codable = renderer.create('<textarea class="note-codable" aria-multiline="true"></textarea>');
+const editable = renderer.create('<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"></div>');
 const statusbar = renderer.create([
   '<output class="note-status-output" role="status" aria-live="polite"></output>',
   '<div class="note-statusbar" role="status">',
@@ -17,15 +17,15 @@ const statusbar = renderer.create([
   '</div>',
 ].join(''));
 
-const airEditor = renderer.create('<div class="note-editor note-airframe"/>');
+const airEditor = renderer.create('<div class="note-editor note-airframe"></div>');
 const airEditable = renderer.create([
   '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"></div>',
   '<output class="note-status-output" role="status" aria-live="polite"></output>',
 ].join(''));
 
-const buttonGroup = renderer.create('<div class="note-btn-group btn-group">');
+const buttonGroup = renderer.create('<div class="note-btn-group btn-group"></div>');
 
-const dropdown = renderer.create('<ul class="note-dropdown-menu dropdown-menu">', function($node, options) {
+const dropdown = renderer.create('<ul class="note-dropdown-menu dropdown-menu"></ul>', function($node, options) {
   const markup = Array.isArray(options.items) ? options.items.map(function(item) {
     const value = (typeof item === 'string') ? item : (item.value || '');
     const content = options.template ? options.template(item) : item;
@@ -47,7 +47,7 @@ const dropdownButtonContents = function(contents, options) {
   return contents + ' ' + icon(options.icons.caret, 'span');
 };
 
-const dropdownCheck = renderer.create('<ul class="note-dropdown-menu dropdown-menu note-check">', function($node, options) {
+const dropdownCheck = renderer.create('<ul class="note-dropdown-menu dropdown-menu note-check"></ul>', function($node, options) {
   const markup = Array.isArray(options.items) ? options.items.map(function(item) {
     const value = (typeof item === 'string') ? item : (item.value || '');
     const content = options.template ? options.template(item) : item;
@@ -60,7 +60,7 @@ const dropdownCheck = renderer.create('<ul class="note-dropdown-menu dropdown-me
   }
 });
 
-const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false" tabindex="-1" role="dialog"/>', function($node, options) {
+const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false" tabindex="-1" role="dialog"></div>', function($node, options) {
   if (options.fade) {
     $node.addClass('fade');
   }
@@ -136,7 +136,7 @@ const ui = function(editorOptions) {
     options: editorOptions,
 
     palette: function($node, options) {
-      return renderer.create('<div class="note-color-palette"/>', function($node, options) {
+      return renderer.create('<div class="note-color-palette"></div>', function($node, options) {
         const contents = [];
         for (let row = 0, rowSize = options.colors.length; row < rowSize; row++) {
           const eventName = options.eventName;
@@ -171,7 +171,7 @@ const ui = function(editorOptions) {
     },
 
     button: function($node, options) {
-      return renderer.create('<button type="button" class="note-btn btn btn-default btn-sm" tabindex="-1">', function($node, options) {
+      return renderer.create('<button type="button" class="note-btn btn btn-default btn-sm" tabindex="-1"></button>', function($node, options) {
         if (options && options.tooltip) {
           $node.attr({
             title: options.tooltip,

--- a/src/js/bs4/ui.js
+++ b/src/js/bs4/ui.js
@@ -1,11 +1,11 @@
 import $ from 'jquery';
 import renderer from '../base/renderer';
 
-const editor = renderer.create('<div class="note-editor note-frame card"/>');
-const toolbar = renderer.create('<div class="note-toolbar card-header" role="toolbar"/>');
-const editingArea = renderer.create('<div class="note-editing-area"/>');
-const codable = renderer.create('<textarea class="note-codable" aria-multiline="true"/>');
-const editable = renderer.create('<div class="note-editable card-block" contentEditable="true" role="textbox" aria-multiline="true"/>');
+const editor = renderer.create('<div class="note-editor note-frame card"></div>');
+const toolbar = renderer.create('<div class="note-toolbar card-header" role="toolbar"></div>');
+const editingArea = renderer.create('<div class="note-editing-area"></div>');
+const codable = renderer.create('<textarea class="note-codable" aria-multiline="true"></textarea>');
+const editable = renderer.create('<div class="note-editable card-block" contentEditable="true" role="textbox" aria-multiline="true"></div>');
 const statusbar = renderer.create([
   '<output class="note-status-output" role="status" aria-live="polite"></output>',
   '<div class="note-statusbar" role="status">',
@@ -17,15 +17,15 @@ const statusbar = renderer.create([
   '</div>',
 ].join(''));
 
-const airEditor = renderer.create('<div class="note-editor note-airframe"/>');
+const airEditor = renderer.create('<div class="note-editor note-airframe"></div>');
 const airEditable = renderer.create([
   '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"></div>',
   '<output class="note-status-output" role="status" aria-live="polite"></output>',
 ].join(''));
 
-const buttonGroup = renderer.create('<div class="note-btn-group btn-group">');
+const buttonGroup = renderer.create('<div class="note-btn-group btn-group"></div>');
 
-const dropdown = renderer.create('<div class="note-dropdown-menu dropdown-menu" role="list">', function($node, options) {
+const dropdown = renderer.create('<div class="note-dropdown-menu dropdown-menu" role="list"></div>', function($node, options) {
   const markup = Array.isArray(options.items) ? options.items.map(function(item) {
     const value = (typeof item === 'string') ? item : (item.value || '');
     const content = options.template ? options.template(item) : item;
@@ -47,7 +47,7 @@ const dropdownButtonContents = function(contents) {
   return contents;
 };
 
-const dropdownCheck = renderer.create('<div class="note-dropdown-menu dropdown-menu note-check" role="list">', function($node, options) {
+const dropdownCheck = renderer.create('<div class="note-dropdown-menu dropdown-menu note-check" role="list"></div>', function($node, options) {
   const markup = Array.isArray(options.items) ? options.items.map(function(item) {
     const value = (typeof item === 'string') ? item : (item.value || '');
     const content = options.template ? options.template(item) : item;
@@ -60,7 +60,7 @@ const dropdownCheck = renderer.create('<div class="note-dropdown-menu dropdown-m
   }
 });
 
-const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false" tabindex="-1" role="dialog"/>', function($node, options) {
+const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false" tabindex="-1" role="dialog"></div>', function($node, options) {
   if (options.fade) {
     $node.addClass('fade');
   }
@@ -137,7 +137,7 @@ const ui = function(editorOptions) {
     options: editorOptions,
 
     palette: function($node, options) {
-      return renderer.create('<div class="note-color-palette"/>', function($node, options) {
+      return renderer.create('<div class="note-color-palette"></div>', function($node, options) {
         const contents = [];
         for (let row = 0, rowSize = options.colors.length; row < rowSize; row++) {
           const eventName = options.eventName;
@@ -172,7 +172,7 @@ const ui = function(editorOptions) {
     },
 
     button: function($node, options) {
-      return renderer.create('<button type="button" class="note-btn btn btn-light btn-sm" tabindex="-1">', function($node, options) {
+      return renderer.create('<button type="button" class="note-btn btn btn-light btn-sm" tabindex="-1"></button>', function($node, options) {
         if (options && options.tooltip) {
           $node.attr({
             title: options.tooltip,

--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -4,11 +4,11 @@ import TooltipUI from './ui/TooltipUI';
 import DropdownUI from './ui/DropdownUI';
 import ModalUI from './ui/ModalUI';
 
-const editor = renderer.create('<div class="note-editor note-frame"/>');
-const toolbar = renderer.create('<div class="note-toolbar" role="toolbar"/>');
-const editingArea = renderer.create('<div class="note-editing-area"/>');
-const codable = renderer.create('<textarea class="note-codable" aria-multiline="true"/>');
-const editable = renderer.create('<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"/>');
+const editor = renderer.create('<div class="note-editor note-frame"></div>');
+const toolbar = renderer.create('<div class="note-toolbar" role="toolbar"></div>');
+const editingArea = renderer.create('<div class="note-editing-area"></div>');
+const codable = renderer.create('<textarea class="note-codable" aria-multiline="true"></textarea>');
+const editable = renderer.create('<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"></div>');
 const statusbar = renderer.create([
   '<output class="note-status-output" role="status" aria-live="polite"></output>',
   '<div class="note-statusbar" role="status">',
@@ -20,14 +20,14 @@ const statusbar = renderer.create([
   '</div>',
 ].join(''));
 
-const airEditor = renderer.create('<div class="note-editor note-airframe"/>');
+const airEditor = renderer.create('<div class="note-editor note-airframe"></div>');
 const airEditable = renderer.create([
   '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"></div>',
   '<output class="note-status-output" role="status" aria-live="polite"></output>',
 ].join(''));
 
-const buttonGroup = renderer.create('<div class="note-btn-group">');
-const button = renderer.create('<button type="button" class="note-btn" tabindex="-1">', function($node, options) {
+const buttonGroup = renderer.create('<div class="note-btn-group"></div>');
+const button = renderer.create('<button type="button" class="note-btn" tabindex="-1"></button>', function($node, options) {
   // set button type
   if (options && options.tooltip) {
     $node.attr({
@@ -55,7 +55,7 @@ const button = renderer.create('<button type="button" class="note-btn" tabindex=
   }
 });
 
-const dropdown = renderer.create('<div class="note-dropdown-menu" role="list">', function($node, options) {
+const dropdown = renderer.create('<div class="note-dropdown-menu" role="list"></div>', function($node, options) {
   const markup = Array.isArray(options.items) ? options.items.map(function(item) {
     const value = (typeof item === 'string') ? item : (item.value || '');
     const content = options.template ? options.template(item) : item;
@@ -85,7 +85,7 @@ const dropdown = renderer.create('<div class="note-dropdown-menu" role="list">',
   }
 });
 
-const dropdownCheck = renderer.create('<div class="note-dropdown-menu note-check" role="list">', function($node, options) {
+const dropdownCheck = renderer.create('<div class="note-dropdown-menu note-check" role="list"></div>', function($node, options) {
   const markup = Array.isArray(options.items) ? options.items.map(function(item) {
     const value = (typeof item === 'string') ? item : (item.value || '');
     const content = options.template ? options.template(item) : item;
@@ -258,7 +258,7 @@ const tableDropdownButton = function(opt) {
   }).render();
 };
 
-const palette = renderer.create('<div class="note-color-palette"/>', function($node, options) {
+const palette = renderer.create('<div class="note-color-palette"></div>', function($node, options) {
   const contents = [];
   for (let row = 0, rowSize = options.colors.length; row < rowSize; row++) {
     const eventName = options.eventName;
@@ -403,7 +403,7 @@ const colorDropdownButton = function(opt, type) {
   }).render();
 };
 
-const dialog = renderer.create('<div class="note-modal" aria-hidden="false" tabindex="-1" role="dialog"/>', function($node, options) {
+const dialog = renderer.create('<div class="note-modal" aria-hidden="false" tabindex="-1" role="dialog"></div>', function($node, options) {
   if (options.fade) {
     $node.addClass('fade');
   }
@@ -521,7 +521,7 @@ const icon = function(iconClassName, tagName) {
     return iconClassName;
   }
   tagName = tagName || 'i';
-  return '<' + tagName + ' class="' + iconClassName + '"/>';
+  return '<' + tagName + ' class="' + iconClassName + '"></' + tagName + '>';
 };
 
 const ui = function(editorOptions) {

--- a/src/js/lite/ui/ModalUI.js
+++ b/src/js/lite/ui/ModalUI.js
@@ -3,7 +3,7 @@ import $ from 'jquery';
 class ModalUI {
   constructor($node /*, options */) {
     this.$modal = $node;
-    this.$backdrop = $('<div class="note-modal-backdrop"/>');
+    this.$backdrop = $('<div class="note-modal-backdrop"></div>');
   }
 
   show() {

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -436,7 +436,7 @@ describe('Editor', () => {
     });
 
     it('should apply custom className in formatBlock', (done) => {
-      var $target = $('<h4 class="customH4Class" />');
+      var $target = $('<h4 class="customH4Class"></h4>');
       $editable.appendTo('body');
       range.createFromNode($editable.find('p')[0]).normalize().select();
       editor.formatBlock('h4', $target);
@@ -456,11 +456,11 @@ describe('Editor', () => {
     });
 
     it('should replace existing class in formatBlock if target has class', (done) => {
-      const $target1 = $('<p class="old" />');
+      const $target1 = $('<p class="old"></p>');
       $editable.appendTo('body');
       range.createFromNode($editable.find('p')[0]).normalize().select();
       editor.formatBlock('p', $target1);
-      const $target2 = $('<p class="new" />');
+      const $target2 = $('<p class="new"></p>');
       editor.formatBlock('p', $target2);
 
       // start <p class="old">hello</p> => <p class="new">hello</p>

--- a/test/chaidom.js
+++ b/test/chaidom.js
@@ -24,7 +24,7 @@ export default function(chai) {
 
   chai.dom.equalsStyle = ($node, expected, style) => {
     const nodeStyle = window.getComputedStyle($node[0]).getPropertyValue(style);
-    const testerStyle = $('<div />').css(style, expected).css(style);
+    const testerStyle = $('<div></div>').css(style, expected).css(style);
     return nodeStyle === testerStyle;
   };
 


### PR DESCRIPTION
#### What does this PR do?

jQuery 3.5 [introduced a breaking change](https://jquery.com/upgrade-guide/3.5/), which basically means that jQuery previously would expand a self-closing tag into opening and closing tags, but now it does not. For example:

```
// jQuery < 3.5
$('<textarea />'); // Expands to <textarea></textarea>

// jQuery >= 3.5
$('<textarea />'); // Remains <textarea />
                   // which is interpreted by browsers as an opening tag with no closing tag
```

Normally this does not cause issues, but Chrome is particularly sensitive to an unclosed `<textarea>` tag. This caused the issue in #3820 

This PR replaces the self-closing syntax with explicitly-closed syntax for any non-void HTML elements. It also fixes #3820 once and for all.

#### Where should the reviewer start?

Make sure I covered all self-closing situations in the codebase.

#### How should this be manually tested?

- Run existing summernote version with jQuery >= 3.5
- Try to submit a form with a summernote field in Chrome
- Observe error in Chrome console: `Form submission failed, as the <TEXTAREA> element named '' was implicitly closed by reaching the end of the file. Please add an explicit end tag ('</TEXTAREA>')`

- Build this PR and run same procedure above
- Observe that form submits successfully

#### Any background context you want to provide?

- https://jquery.com/upgrade-guide/3.5/

#### What are the relevant tickets?

- #3820

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
