### PR TITLE
dimension-picker insertTable on mouseup

### DIFF
--- a/src/js/base/module/Buttons.js
+++ b/src/js/base/module/Buttons.js
@@ -561,7 +561,7 @@ export default class Buttons {
           $catcher.css({
             width: this.options.insertTableMaxSize.col + 'em',
             height: this.options.insertTableMaxSize.row + 'em',
-          }).mousedown(this.context.createInvokeHandler('editor.insertTable'))
+          }).mouseup(this.context.createInvokeHandler('editor.insertTable'))
             .on('mousemove', this.tableMoveHandler.bind(this));
         },
       }).render();

--- a/src/js/lite/ui.js
+++ b/src/js/lite/ui.js
@@ -250,7 +250,7 @@ const tableDropdownButton = function(opt) {
         width: opt.col + 'em',
         height: opt.row + 'em',
       })
-        .mousedown(opt.itemClick)
+        .mouseup(opt.itemClick)
         .mousemove(function(e) {
           tableMoveHandler(e, opt.col, opt.row);
         });


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

The "note-dimension-picker" for selecting the number of cells for a table to have was triggered on mousedown, which caused the behavior to be a little inconsistent with similar UI in other wysywigs. We have users that mousedown, drag around to pick table dimensions they want, then mouseup(let go of the mouse button) when they are where they want. Sampled other UI, and see this is how many of them work. Therefore think it's a convention that users are familiar with. 

#### Where should the reviewer start?

Using the editor

#### How should this be manually tested?

Make sure you can click, and drag around the table dimension selector, and that when mouseup happens, the generated table is of dimensions corresponding to where the cursor was last.




### Checklist

- [check ] Added relevant tests or not required
- [ check] Didn't break anything
