### PR TITLE
[#4089] Show table popover with multiline content in cell

### DIFF
--- a/src/js/base/module/TablePopover.js
+++ b/src/js/base/module/TablePopover.js
@@ -60,7 +60,7 @@ export default class TablePopover {
       return false;
     }
 
-    const isCell = dom.isCell(target);
+    const isCell = dom.isCell(target) || dom.isCell(target?.parentElement);
 
     if (isCell) {
       const pos = dom.posFromPlaceholder(target);


### PR DESCRIPTION
#### What does this PR do?
Shows table popover when table cell has multiline content. <p> tag is inserted when we hit enter in table cell and table popover stops working properly since click target is `<p>` not `<td>`.  

Checked for immediate parent only and not ancestor to avoid popover when styling content

#### Where should the reviewer start?

- start on the src/summernote.js

#### How should this be manually tested?

- Create a table
- click on a cell
- type some content and hit enter
- click on cell again, table popover should show

#### Any background context you want to provide?

- the gem needed to be updated...

#### What are the relevant tickets?
#4089

#### Screenshot (if for frontend)


### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
