### PR TITLE
Fix Bootstrap 5 dropdowns

### DIFF
--- a/src/js/module/Buttons.js
+++ b/src/js/module/Buttons.js
@@ -110,7 +110,7 @@ export default class Buttons {
           contents: this.ui.dropdownButtonContents('', this.options),
           tooltip: this.lang.color.more,
           data: {
-            toggle: 'dropdown',
+            bs-toggle: 'dropdown',
           },
         }),
         this.ui.dropdown({
@@ -237,7 +237,7 @@ export default class Buttons {
           ),
           tooltip: this.lang.style.style,
           data: {
-            toggle: 'dropdown',
+            bs-toggle: 'dropdown',
           },
         }),
         this.ui.dropdown({
@@ -363,7 +363,7 @@ export default class Buttons {
           ),
           tooltip: this.lang.font.name,
           data: {
-            toggle: 'dropdown',
+            bs-toggle: 'dropdown',
           },
         }),
         this.ui.dropdownCheck({
@@ -386,7 +386,7 @@ export default class Buttons {
           contents: this.ui.dropdownButtonContents('<span class="note-current-fontsize"></span>', this.options),
           tooltip: this.lang.font.size,
           data: {
-            toggle: 'dropdown',
+            bs-toggle: 'dropdown',
           },
         }),
         this.ui.dropdownCheck({
@@ -406,7 +406,7 @@ export default class Buttons {
           contents: this.ui.dropdownButtonContents('<span class="note-current-fontsizeunit"></span>', this.options),
           tooltip: this.lang.font.sizeunit,
           data: {
-            toggle: 'dropdown',
+            bs-toggle: 'dropdown',
           },
         }),
         this.ui.dropdownCheck({
@@ -497,7 +497,7 @@ export default class Buttons {
           contents: this.ui.dropdownButtonContents(this.ui.icon(this.options.icons.alignLeft), this.options),
           tooltip: this.lang.paragraph.paragraph,
           data: {
-            toggle: 'dropdown',
+            bs-toggle: 'dropdown',
           },
         }),
         this.ui.dropdown([
@@ -520,7 +520,7 @@ export default class Buttons {
           contents: this.ui.dropdownButtonContents(this.ui.icon(this.options.icons.textHeight), this.options),
           tooltip: this.lang.font.height,
           data: {
-            toggle: 'dropdown',
+            bs-toggle: 'dropdown',
           },
         }),
         this.ui.dropdownCheck({
@@ -540,7 +540,7 @@ export default class Buttons {
           contents: this.ui.dropdownButtonContents(this.ui.icon(this.options.icons.table), this.options),
           tooltip: this.lang.table.table,
           data: {
-            toggle: 'dropdown',
+            bs-toggle: 'dropdown',
           },
         }),
         this.ui.dropdown({


### PR DESCRIPTION
Reference BS 5 dropdown doesn't works (color select, list style etc) #4170
Buttons doesn't working (dropdowns) because BS5 is expecting bs-toggle instead of toggle.  

I am not expert of npm I manually modified summernote-bs5.js for this and it worked so I guess this is a correct file.

#### What does this PR do?

- Fixes BS5 dropdown button issues

#### Where should the reviewer start?

- start on the src/js/modules/Buttons.js

#### How should this be manually tested?

- I only edited a compiled file and thinking this is a correct file which should be updated.

#### What are the relevant tickets?

BS 5 dropdown doesn't works (color select, list style etc) #4170


#### Screenshot (if for frontend)

![image](https://user-images.githubusercontent.com/805066/138056722-e13d0d3f-b926-41dd-9860-f09cb5aa5745.png)


### Checklist

- [ ] Added relevant tests or not required [Need to be tested]
- [ ] Didn't break anything    [Need to be tested]
