### PR TITLE
fixed classname of popover content area in bs5

### DIFF
--- a/src/styles/bs5/summernote-bs5.js
+++ b/src/styles/bs5/summernote-bs5.js
@@ -86,7 +86,7 @@ const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false
 const popover = renderer.create([
   '<div class="note-popover popover show">',
     '<div class="popover-arrow"></div>',
-    '<div class="popover-body note-children-container"></div>',
+    '<div class="popover-content note-children-container"></div>',
   '</div>',
 ].join(''), function($node, options) {
   const direction = typeof options.direction !== 'undefined' ? options.direction : 'bottom';


### PR DESCRIPTION
fixed classname of popover content area in bs5

from 'popover-body' to 'popover-content', matching class names of other styles.
this fixes issue #4215 (not #4149)

<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

- This fixes issue described in #4215 
- I found that the class name for popover in bs5 styles is set to 'popover-body', rather than 'popover-content', which made initialize() function in HintPopover.js not working properly.

#### Where should the reviewer start?

- try using bs5 styles and hint, and check if this.$content is properly set in initialize() function of HintPopover.js

#### What are the relevant tickets?

#4215

### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
