### PR TITLE
Jquery $.type() is deprecated

### DIFF
--- a/src/js/summernote.js
+++ b/src/js/summernote.js
@@ -11,7 +11,7 @@ $.fn.extend({
    * @return {this}
    */
   summernote: function() {
-    const type = $.type(lists.head(arguments));
+    const type = typeof(lists.head(arguments));
     const isExternalAPICalled = type === 'string';
     const hasInitOptions = type === 'object';
 


### PR DESCRIPTION
I think we can use native function typeof() instead of $.type().

<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

- awesome stuff
- really cool feature
- refactor X

#### Where should the reviewer start?

- start on the src/summernote.js

#### How should this be manually tested?

- click here and here

#### Any background context you want to provide?

- the gem needed to be updated...

#### What are the relevant tickets?


#### Screenshot (if for frontend)


### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
