### PR TITLE
Jquery .change() is deprecated

### DIFF
--- a/src/js/module/Buttons.js
+++ b/src/js/module/Buttons.js
@@ -176,7 +176,7 @@ export default class Buttons {
               }).render());
             });
             $dropdown.find('input[type=color]').each((idx, item) => {
-              $(item).change(function() {
+              $(item).on("change", function() {
                 const $chip = $dropdown.find('#' + $(this).data('event')).find('.note-color-btn').first();
                 const color = this.value.toUpperCase();
                 $chip.css('background-color', color)


### PR DESCRIPTION
Jquery .change() is deprecated. 
We have to use .on("change", function()....

<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

- awesome stuff
- really cool feature
- refactor X

#### Where should the reviewer start?

- start on the src/summernote.js

#### How should this be manually tested?

- click here and here

#### Any background context you want to provide?

- the gem needed to be updated...

#### What are the relevant tickets?


#### Screenshot (if for frontend)


### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
