### PR TITLE
fix newline problem with style

### DIFF
--- a/test/base/core/dom.spec.js
+++ b/test/base/core/dom.spec.js
@@ -302,8 +302,8 @@ describe('base:core.dom', () => {
         let $s = $para.find('s');
         dom.splitTree($para[0], { node: $s[0].firstChild, offset: 6 });
 
-        expect($para.html()).to.equalsIgnoreCase('<b>b</b><u>u</u><s>strike</s>');
-        expect($para.next().html()).to.equalsIgnoreCase('<s><br></s><i>i</i>');
+        expect($para.html()).to.equalsIgnoreCase('<b>b</b><u>u</u><s>strike</s><i><br></i>');
+        expect($para.next().html()).to.equalsIgnoreCase('<i>i</i>');
       });
 
       it('should be split by s tag with offset 3 (2 depth case)', () => {


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?
This PR fixes the problem of an extra blank line when the cursor wraps on the far right of the style
![2](https://user-images.githubusercontent.com/89820102/155082219-3d412f06-288d-4aee-953e-a30e9cad482b.jpg)

![1](https://user-images.githubusercontent.com/89820102/155082161-6f1db4aa-6340-4c55-b61b-8ef556e051c6.jpg)

When the text has a style (such as background color), and a line break is performed on the far right of the style, an empty line will be added

- awesome stuff
- really cool feature
- refactor X

#### Where should the reviewer start?

- start on the src/summernote.js

#### How should this be manually tested?

- click here and here

#### Any background context you want to provide?

- the gem needed to be updated...

#### What are the relevant tickets?


#### Screenshot (if for frontend)


### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
