### PR TITLE
fix(Button): change mouseup to mousedown

### DIFF
--- a/src/js/module/Buttons.js
+++ b/src/js/module/Buttons.js
@@ -561,7 +561,7 @@ export default class Buttons {
           $catcher.css({
             width: this.options.insertTableMaxSize.col + 'em',
             height: this.options.insertTableMaxSize.row + 'em',
-          }).mouseup(this.context.createInvokeHandler('editor.insertTable'))
+          }).mousedown(this.context.createInvokeHandler('editor.insertTable'))
             .on('mousemove', this.tableMoveHandler.bind(this));
         },
       }).render();


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?
As mentioned earlier #4225, it happen Inserting a table places it at the top of the editor.
so i am comparing 0.8.18 at official page and 0.8.20.
i found #4048, then i revoke it. 

it's work

#### How should this be manually tested?

- click here and here

#### What are the relevant tickets?

#4225
#4048

### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
