### PR TITLE
First matched item not active when using delayed ajax call #4255

### DIFF
--- a/src/js/module/HintPopover.js
+++ b/src/js/module/HintPopover.js
@@ -146,13 +146,18 @@ export default class HintPopover {
 
   createItemTemplates(hintIdx, items) {
     const hint = this.hints[hintIdx];
-    return items.map((item /*, idx */) => {
+    return items.map((item , idx) => {
       const $item = $('<div class="note-hint-item"></div>');
       $item.append(hint.template ? hint.template(item) : item + '');
       $item.data({
         'index': hintIdx,
         'item': item,
       });
+
+      if (hintIdx === 0 && idx === 0) {
+        $item.addClass('active');
+      }
+
       return $item;
     });
   }


### PR DESCRIPTION
#### What does this PR do?

- allow the first item to be selected when items are fetched asynchronously while in createItemTemplates (reinstate previously removed code https://github.com/summernote/summernote/commit/1f4bc36c6187f8c1d3a9199febd92eb636989999 and also related #2041)

#### Where should the reviewer start?

- start on the src/summernote.js

#### How should this be manually tested?

- in the search option use an async call, the first item should be selected
e.g.
 hint: {
    match: /\B@(\w*)$/,
    search: function (keyword, callback) {
      setTimeout(function() {
        callback(['jayden', 'sam', 'alvin', 'david'])
      }, 300);
    },
    content: function (item) {
      return '@' + item;
    }    
  }


#### Any background context you want to provide?

- After upgrading to latest summernote, list fetched asynchronously no longer automatically highlight the first item

#### What are the relevant tickets?

#4255 #4148 #2041

#### Screenshot (if for frontend)

before fix:
<img width="142" alt="image" src="https://user-images.githubusercontent.com/1414577/159604808-a00fe247-5503-439b-aa55-6c79cb0a4025.png">

after fix:
<img width="117" alt="image" src="https://user-images.githubusercontent.com/1414577/159605026-f55a57ab-fbfa-47ff-9c20-9720d94b026e.png">


### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
