### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/js/module/Dropzone.js
+++ b/src/js/module/Dropzone.js
@@ -115,7 +115,7 @@ export default class Dropzone {
 
   destroy() {
     Object.keys(this.documentEventHandlers).forEach((key) => {
-      this.$eventListener.off(key.substr(2).toLowerCase(), this.documentEventHandlers[key]);
+      this.$eventListener.off(key.slice(2).toLowerCase(), this.documentEventHandlers[key]);
     });
     this.documentEventHandlers = {};
   }


### PR DESCRIPTION
#### What does this PR do?

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

#### Where should the reviewer start?


#### How should this be manually tested?

I have tested the return of the statement to make sure it's still the same

#### Any background context you want to provide?


#### What are the relevant tickets?


#### Screenshot (if for frontend)


### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
