### PR TITLE
Fixed click removing active state in lite style

### DIFF
--- a/src/styles/lite/js/DropdownUI.js
+++ b/src/styles/lite/js/DropdownUI.js
@@ -57,10 +57,10 @@ class DropdownUI {
   }
 }
 
-$(document).on('click', function(e) {
+$(document).on('click.note-dropdown-menu', function(e) {
   if (!$(e.target).closest('.note-btn-group').length) {
+    $('.note-btn-group.open .note-btn.active').removeClass('active');
     $('.note-btn-group.open').removeClass('open');
-    $('.note-btn-group .note-btn.active').removeClass('active');
   }
 });
 


### PR DESCRIPTION
#### What does this PR do?

- Click did remove active state off all buttons in lite style
- Now only removes active state from open dropdown button

#### What are the relevant tickets?

Fixes #4220

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
