### PR TITLE
added noreferrer and noopener link options

### DIFF
--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -192,10 +192,13 @@ export default class Editor {
      * @param {Object} linkInfo
      */
     this.createLink = this.wrapCommand((linkInfo) => {
+      let rel = [];
       let linkUrl = linkInfo.url;
       const linkText = linkInfo.text;
       const isNewWindow = linkInfo.isNewWindow;
       const checkProtocol = linkInfo.checkProtocol;
+      const addNoReferrer = this.options.linkAddNoReferrer;
+      const addNoOpener = this.options.linkAddNoOpener;
       let rng = linkInfo.range || this.getLastRange();
       const additionalTextLength = linkText.length - rng.toString().length;
       if (additionalTextLength > 0 && this.isLimited(additionalTextLength)) {
@@ -233,6 +236,15 @@ export default class Editor {
         $(anchor).attr('href', linkUrl);
         if (isNewWindow) {
           $(anchor).attr('target', '_blank');
+          if (addNoReferrer) {
+            rel.push('noreferrer');
+          }
+          if (addNoOpener) {
+            rel.push('noopener');
+          }
+          if (rel.length) {
+            $(anchor).attr('rel', rel.join(' '));
+          }
         } else {
           $(anchor).removeAttr('target');
         }

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -111,6 +111,10 @@ $.summernote = $.extend($.summernote, {
       ],
     },
 
+    // link options
+    linkAddNoReferrer: false,
+    addLinkNoOpener: false,
+
     // air mode: inline editor
     airMode: false,
     overrideContextMenu: false, // TBD


### PR DESCRIPTION
#### What does this PR do?

- add options to generate links with attribute `rel` to prevent external links to send `referrer or opener`:
  ```html
  <a href="https://www.example.com" target="_blank" rel="noopener noreferrer">Example Site</a>
  ```

#### Where should the reviewer start?

- start on the src/js/module/Editor.js

#### How should this be manually tested?

- configure summernote like this:
  ```js
  jQuery('#mydiv').summernote({linkAddNoReferrer: true, linkAddNoOpener: true});
  ```
- add a link with target `_blank`
- check if the rel attribute is there like in the example above

- [x] Added relevant tests or not required
- [x] Didn't break anything
