### PR TITLE
Applied the suggested bug fix and also added two extra tests

### DIFF
--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -870,9 +870,7 @@ export default class Editor {
           this.$editable.data(KEY_BOGUS, firstSpan);
         }
       } else {
-        this.setLastRange(
-          this.createRangeFromList(spans).select()
-        );
+        rng.select();
       }
     } else {
       const noteStatusOutput = $.now();

--- a/test/base/module/Buttons.spec.js
+++ b/test/base/module/Buttons.spec.js
@@ -182,13 +182,29 @@ describe('Buttons', () => {
   */
 
   describe('font family button', () => {
-    it('should change font family when it is clicked', (done) => {
-      var $li = $toolbar.find('.dropdown-fontname a[data-value="Comic Sans MS"]');
+    it('should change font family (Courier New) when it is clicked', (done) => {
+      var $li = $toolbar.find('.dropdown-fontname a[data-value="Courier New"]');
       var $span = $toolbar.find('span.note-current-fontname');
       assert.isTrue($li.length === 1);
-      assert.isTrue($span.text() !== 'Comic Sans MS');
+      assert.isTrue($span.text() !== 'Courier New');
       $li.click();
-      expect($editable.find('p').children().first()).await(done).to.be.equalsStyle('"Comic Sans MS"', 'font-family');
+      expect($editable.find('p').children().first()).await(done).to.be.equalsStyle('"Courier New"', 'font-family');
+    });
+    it('should change font family (Arial) when it is clicked', (done) => {
+      var $li = $toolbar.find('.dropdown-fontname a[data-value="Arial"]');
+      var $span = $toolbar.find('span.note-current-fontname');
+      assert.isTrue($li.length === 1);
+      assert.isTrue($span.text() !== 'Arial');
+      $li.click();
+      expect($editable.find('p').children().first()).await(done).to.be.equalsStyle('"Arial"', 'font-family');
+    });
+    it('should change font family (Helvetica) when it is clicked', (done) => {
+      var $li = $toolbar.find('.dropdown-fontname a[data-value="Helvetica"]');
+      var $span = $toolbar.find('span.note-current-fontname');
+      assert.isTrue($li.length === 1);
+      assert.isTrue($span.text() !== 'Helvetica');
+      $li.click();
+      expect($editable.find('p').children().first()).await(done).to.be.equalsStyle('"Helvetica"', 'font-family');
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

- This PR is a fix for  https://github.com/summernote/summernote/issues/4261

#### Where should the reviewer start?

- start on the src/js/module/Editor.js

#### How should this be manually tested?

- To test the issue manually user needs to create multiple lines of text with blank lines in between in any order. 
   Once created user needs to select multiple lines including blank lines and change the font family of the selected text.
   

#### Any background context you want to provide?

- I have modified the tests in **test/base/module/Buttons.spec.js** to test for **Arial, Courier New** and **Helvetica** font instead of **Comic Sans MS**, since there was no setting for Comic Sans MS in the original code the test was failing .

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/4261

#### Screenshot (if for frontend)

https://user-images.githubusercontent.com/16719734/168010289-c1f6f0fb-9434-485f-94fb-a7fa3859bbc0.mp4



### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
