### PR TITLE
fix: Additional blank lines will be added when the Enter key is pressed

### DIFF
--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -464,7 +464,6 @@ export default class Editor {
       if (this.context.invoke(eventName) !== false) {
         event.preventDefault();
         // if keyMap action was invoked
-        this.context.invoke(eventName);
         return true;
       }
     } else if (key.isEdit(event.keyCode)) {


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

Additional blank lines will be added when the Enter key is pressed.
The event will be executed twice.
Execute once during if judgment, and if the result is true, it will be executed again
I deleted 'this context. invoke(eventName)’.
I tested it and found no problem.

- awesome stuff
- really cool feature
- refactor X

#### Where should the reviewer start?

- start on the src/summernote.js

#### How should this be manually tested?

- click here and here

#### Any background context you want to provide?

- the gem needed to be updated...

#### What are the relevant tickets?


#### Screenshot (if for frontend)


### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
