### PR TITLE
Fix/build script for node latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "dev": "eslint config && webpack serve --config=./config/webpack.development.js --progress",
     "prebuild": "node ./config/build-fonts.js",
-    "build": "webpack --node-env production --mode=production --config=./config/webpack.production.js --progress",
+    "build": "NODE_OPTIONS=--openssl-legacy-provider webpack --node-env production --mode=production --config=./config/webpack.production.js --progress",
     "lint": "eslint src plugin test config",
     "test": "karma start .karma/config.js --single-run",
     "test:grep": "karma run .karma/config.js -- --grep",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "prebuild": "node ./config/build-fonts.js",
     "build": "NODE_OPTIONS=--openssl-legacy-provider webpack --node-env production --mode=production --config=./config/webpack.production.js --progress",
     "lint": "eslint src plugin test config",
-    "test": "karma start .karma/config.js --single-run",
+    "test": "NODE_OPTIONS=--openssl-legacy-provider karma start .karma/config.js --single-run",
     "test:grep": "karma run .karma/config.js -- --grep",
     "test:watch": "karma start .karma/config.js",
     "test:travis": "karma start .karma/travis.js --single-run",


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

- Fixed failed script for build in nodejs 18 version 
- add NODE_OPTIONS=--openssl-legacy-provider

#### Where should the reviewer start?

- start on the package.json, 
-  build, test commands 

#### How should this be manually tested?



#### Any background context you want to provide?

- https://stackoverflow.com/questions/69394632/webpack-build-failing-with-err-ossl-evp-unsupported
- https://github.com/webpack/webpack/issues/14532

#### What are the relevant tickets?

#4177

#### Screenshot (if for frontend)


### Checklist

