### PR TITLE
Limit node version > =17.0.0 because node_ Options=--openssl legacy p…

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "email": "<susukang98@gmail.com>"
   },
   "main": "dist/summernote.js",
+  "engines" : { 
+    "node" : ">=17.0.0" 
+  },
   "scripts": {
     "dev": "eslint config && webpack serve --config=./config/webpack.development.js --progress",
     "prebuild": "node ./config/build-fonts.js",


### PR DESCRIPTION
…rovider does not support versions below 17.0.0

<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?
Limit node version > =17.0.0 because node_ Options=--openssl legacy provider does not support versions below 17.0.0
- awesome stuff
- really cool feature
- refactor X

#### Where should the reviewer start?

- start on the src/summernote.js

#### How should this be manually tested?

- click here and here

#### Any background context you want to provide?

- the gem needed to be updated...

#### What are the relevant tickets?


#### Screenshot (if for frontend)


### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
