### PR TITLE
fix: When disabled, paste content is prohibited

### DIFF
--- a/src/js/module/Clipboard.js
+++ b/src/js/module/Clipboard.js
@@ -16,6 +16,10 @@ export default class Clipboard {
    * @param {Event} event
    */
   pasteByEvent(event) {
+
+    if (this.context.isDisabled()) {
+      return;
+    }
     const clipboardData = event.originalEvent.clipboardData;
 
     if (clipboardData && clipboardData.items && clipboardData.items.length) {


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

When the editing area is disabled, it needs to prohibit pasting content.

- awesome stuff
- really cool feature
- refactor X

#### Where should the reviewer start?

- start on the src/summernote.js

#### How should this be manually tested?

- click here and here

#### Any background context you want to provide?

- the gem needed to be updated...

#### What are the relevant tickets?


#### Screenshot (if for frontend)


### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
