### PR TITLE
pasteHTML auto add unused <p><br></p> #3370

### DIFF
--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -542,7 +542,7 @@ class WrappedRange {
    * insert node at current cursor
    *
    * @param {Node} node
-   * @param {Boolean} [doNotInsertPara} - default is false, removes added <p> that's added if true
+   * @param {Boolean} doNotInsertPara - default is false, removes added <p> that's added if true
    * @return {Node}
    */
   insertNode(node, doNotInsertPara = false) {

--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -554,7 +554,7 @@ class WrappedRange {
     const info = dom.splitPoint(rng.getStartPoint(), dom.isInline(node));
     if (info.rightNode) {
       info.rightNode.parentNode.insertBefore(node, info.rightNode);
-      if (dom.isEmpty(info.rightNode) && dom.isPara(node)) {
+      if (dom.isEmpty(info.rightNode) && !dom.isInline(node)) {
         info.rightNode.parentNode.removeChild(info.rightNode);
       }
     } else {

--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -542,9 +542,10 @@ class WrappedRange {
    * insert node at current cursor
    *
    * @param {Node} node
+   * @param {Boolean} [doNotInsertPara} - default is false, removes added <p> that's added if true
    * @return {Node}
    */
-  insertNode(node) {
+  insertNode(node, doNotInsertPara = false) {
     let rng = this;
 
     if (dom.isText(node) || dom.isInline(node)) {
@@ -554,7 +555,7 @@ class WrappedRange {
     const info = dom.splitPoint(rng.getStartPoint(), dom.isInline(node));
     if (info.rightNode) {
       info.rightNode.parentNode.insertBefore(node, info.rightNode);
-      if (dom.isEmpty(info.rightNode) && !dom.isInline(node)) {
+      if (dom.isEmpty(info.rightNode) && (doNotInsertPara || dom.isPara(node))) {
         info.rightNode.parentNode.removeChild(info.rightNode);
       }
     } else {
@@ -583,7 +584,7 @@ class WrappedRange {
     }
 
     childNodes = childNodes.map(function(childNode) {
-      return rng.insertNode(childNode);
+      return rng.insertNode(childNode, !dom.isInline(childNode));
     });
 
     if (reversed) {

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -333,7 +333,7 @@ describe('Editor', () => {
   describe('insertHorizontalRule', () => {
     it('should insert horizontal rule', (done) => {
       editor.insertHorizontalRule();
-      expectContentsAwait(context, '<p>hello</p><hr>', done);
+      expectContentsAwait(context, '<p>hello</p><hr><p><br></p>', done);
     });
   });
 
@@ -345,6 +345,7 @@ describe('Editor', () => {
         '<tr><td><br></td><td><br></td></tr>',
         '<tr><td><br></td><td><br></td></tr>',
         '</tbody></table>',
+        '<p><br></p>',
       ].join('');
       editor.insertTable('2x2');
       expectContentsAwait(context, markup, done);

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -292,9 +292,14 @@ describe('Editor', () => {
       expectContentsAwait(context, '<p>hello<span> world</span></p>', done);
     });
 
-    it('should not add empty paragraph', (done) => {
+    it('should not add empty paragraph when pasting paragraphs', (done) => {
       editor.pasteHTML('<p><span>whatever</span><br></p><p><span>it has</span><br></p>');
       expectContentsAwait(context, '<p>hello</p><p><span>whatever</span><br></p><p><span>it has</span><br></p>', done);
+    });
+
+    it('should not add empty paragraph when pasting a node that is not isInline', (done) => {
+      editor.pasteHTML('<ul><li>list</li></ul><hr><p>paragraph</p><table><tr><td>table</td></tr></table><p></p><blockquote>blockquote</blockquote><data>data</data>');
+      expectContentsAwait(context, '<p>hello</p><ul><li>list</li></ul><hr><p>paragraph</p><table><tbody><tr><td>table</td></tr></tbody></table><p></p><blockquote>blockquote</blockquote><data>data</data>', done);
     });
 
     it('should not call change event more than once per paste event', () => {
@@ -328,7 +333,7 @@ describe('Editor', () => {
   describe('insertHorizontalRule', () => {
     it('should insert horizontal rule', (done) => {
       editor.insertHorizontalRule();
-      expectContentsAwait(context, '<p>hello</p><hr><p><br></p>', done);
+      expectContentsAwait(context, '<p>hello</p><hr>', done);
     });
   });
 
@@ -340,7 +345,6 @@ describe('Editor', () => {
         '<tr><td><br></td><td><br></td></tr>',
         '<tr><td><br></td><td><br></td></tr>',
         '</tbody></table>',
-        '<p><br></p>',
       ].join('');
       editor.insertTable('2x2');
       expectContentsAwait(context, markup, done);


### PR DESCRIPTION
#### What does this PR do?

- stop summernote from adding redundant `<p><br></p>` when pasteHTML

#### Where should the reviewer start?

- start on the src/summernote.js

#### How should this be manually tested?

-` editor.summernote('pasteHTML', '<ul><li>list</li></ul><hr><p>paragraph</p><table><tr><td>table</td></tr></table><p></p><blockquote>blockquote</blockquote><data>data</data>')`

- there shouldn't be extra `<p><br></p>` inserted between the nodes 

#### Any background context you want to provide?

- We were trying to sanitize the user input and noticed all the extra paragraph that gets inserted after lists and tables and what not

#### What are the relevant tickets?

#3370

#### Screenshot (if for frontend)

Before fix
<img width="337" alt="image" src="https://user-images.githubusercontent.com/1414577/176631783-a21a103e-8b36-4e95-ba5f-b38e9b66ce5c.png">


After fix
<img width="265" alt="image" src="https://user-images.githubusercontent.com/1414577/176631947-6212a478-1e83-49ec-9c9f-040ddceda0d2.png">



### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
