### PR TITLE
Fix AirPopover Position to cursor on key events

### DIFF
--- a/src/js/module/AirPopover.js
+++ b/src/js/module/AirPopover.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import lists from '../core/lists';
+import func from '../core/func';
 
 const AIRMODE_POPOVER_X_OFFSET = -5;
 const AIRMODE_POPOVER_Y_OFFSET = 5;
@@ -30,8 +31,16 @@ export default class AirPopover {
       },
       'summernote.keyup summernote.mouseup summernote.scroll': (we, e) => {
         if (this.options.editing && !this.onContextmenu) {
-          this.pageX = e.pageX;
-          this.pageY = e.pageY;
+          if (e.type == 'keyup') {
+            let range = this.context.invoke('editor.getLastRange');
+            let wordRange = range.getWordRange();
+            const bnd = func.rect2bnd(lists.last(wordRange.getClientRects()));
+            this.pageX = bnd.left;
+            this.pageY = bnd.top;
+          } else {
+            this.pageX = e.pageX;
+            this.pageY = e.pageY;
+          }
           this.update();
         }
         this.onContextmenu = false;
@@ -96,7 +105,7 @@ export default class AirPopover {
     this.ui.toggleBtnActive(this.$popover.find('.btn-codeview'), isCodeview);
     if (isCodeview) {
       this.hide();
-    } 
+    }
   }
 
   hide() {


### PR DESCRIPTION
Position is taken from the current cursor range instead from pageX / pageY which is only set in mouse events (Inspired by HintPopover)

#### What are the relevant tickets?
#4339


