### PR TITLE
Window height stabilized.

### DIFF
--- a/src/styles/lite/scss/modal.scss
+++ b/src/styles/lite/scss/modal.scss
@@ -96,6 +96,7 @@
   // Automatically set modal's width for larger viewports
   .note-modal-content {
     width: 600px;
+    height: 300px;
     margin: 30px auto;
   }
 }


### PR DESCRIPTION
#### What does this PR do?

Popup window height appeared to be unstable in Bootstrap 5. This update aims to fix this problem and stabilize the Pop-up height.

#### Where should the reviewer start?

- start on the src/styles/lite/scss/modal.scss
```scss
@media (min-width: 768px) {
  // Automatically set modal's width for larger viewports
  .note-modal-content {
    width: 600px;
    height: 300px;
    margin: 30px auto;
  }
}
```

#### How should this be manually tested?

Testing can be performed on a page with the following entities.

- jquery-3.6.1.min.js
- summernote-0.8.18 (lite version)
- bootstrap-5.2.0

#### Any background context you want to provide?

- No

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything

Thank you very much for this beautiful plugin.