### PR TITLE
Pop-up heights have been adjusted to match the content.

### DIFF
--- a/src/styles/lite/scss/modal.scss
+++ b/src/styles/lite/scss/modal.scss
@@ -96,8 +96,8 @@
   // Automatically set modal's width for larger viewports
   .note-modal-content {
     width: 600px;
-    height: 300px;
     margin: 30px auto;
+    padding-bottom: 30px;
   }
 }
 

--- a/src/styles/lite/scss/modal.scss
+++ b/src/styles/lite/scss/modal.scss
@@ -96,6 +96,7 @@
   // Automatically set modal's width for larger viewports
   .note-modal-content {
     width: 600px;
+    height: 300px;
     margin: 30px auto;
   }
 }


### PR DESCRIPTION
#### What does this PR do?



#### Where should the reviewer start?

- start on the src/styles/lite/scss/modal.scss

```scss
// Scale up the modal
@media (min-width: 768px) {
  // Automatically set modal's width for larger viewports
  .note-modal-content {
    width: 600px;
    margin: 30px auto;
    padding-bottom: 30px;
  }
}
```

#### How should this be manually tested?

- jquery-3.6.1.min.js
- bootstrap-5.2.0
- summernote-0.8.18 (lite)

#### Any background context you want to provide?

- the gem needed to be updated...

#### What are the relevant tickets?


#### Screenshot (if for frontend)


### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
