### PR TITLE
Allow resize the statusbar on touch devices

### DIFF
--- a/src/js/module/Statusbar.js
+++ b/src/js/module/Statusbar.js
@@ -24,7 +24,7 @@ export default class Statusbar {
       const editableCodeTop = this.$codable.offset().top - this.$document.scrollTop();
 
       const onStatusbarMove = (event) => {
-        let originalEvent = (event.type == 'mousemove') ? event : event.originalEvent.changedTouches[0];
+        let originalEvent = (event.type == 'mousemove') ? event : event.originalEvent.touches[0];
         let height = originalEvent.clientY - (editableTop + EDITABLE_PADDING);
         let heightCode = originalEvent.clientY - (editableCodeTop + EDITABLE_PADDING);
 

--- a/src/js/module/Statusbar.js
+++ b/src/js/module/Statusbar.js
@@ -24,7 +24,7 @@ export default class Statusbar {
       const editableCodeTop = this.$codable.offset().top - this.$document.scrollTop();
 
       const onStatusbarMove = (event) => {
-        let originalEvent = (event.type == 'mousedown') ? event : event.originalEvent.changedTouches[0];
+        let originalEvent = (event.type == 'mousemove') ? event : event.originalEvent.changedTouches[0];
         let height = originalEvent.clientY - (editableTop + EDITABLE_PADDING);
         let heightCode = originalEvent.clientY - (editableCodeTop + EDITABLE_PADDING);
 

--- a/src/js/module/Statusbar.js
+++ b/src/js/module/Statusbar.js
@@ -16,16 +16,17 @@ export default class Statusbar {
       return;
     }
 
-    this.$statusbar.on('mousedown', (event) => {
+    this.$statusbar.on('mousedown touchstart', (event) => {
       event.preventDefault();
       event.stopPropagation();
 
       const editableTop = this.$editable.offset().top - this.$document.scrollTop();
       const editableCodeTop = this.$codable.offset().top - this.$document.scrollTop();
 
-      const onMouseMove = (event) => {
-        let height = event.clientY - (editableTop + EDITABLE_PADDING);
-        let heightCode = event.clientY - (editableCodeTop + EDITABLE_PADDING);
+      const onStatusbarMove = (event) => {
+        let originalEvent = (event.type == 'mousedown') ? event : event.originalEvent.changedTouches[0];
+        let height = originalEvent.clientY - (editableTop + EDITABLE_PADDING);
+        let heightCode = originalEvent.clientY - (editableCodeTop + EDITABLE_PADDING);
 
         height = (this.options.minheight > 0) ? Math.max(height, this.options.minheight) : height;
         height = (this.options.maxHeight > 0) ? Math.min(height, this.options.maxHeight) : height;
@@ -37,8 +38,8 @@ export default class Statusbar {
         this.$codable.height(heightCode);
       };
 
-      this.$document.on('mousemove', onMouseMove).one('mouseup', () => {
-        this.$document.off('mousemove', onMouseMove);
+      this.$document.on('mousemove touchmove', onStatusbarMove).one('mouseup touchend', () => {
+        this.$document.off('mousemove touchmove', onStatusbarMove);
       });
     });
   }


### PR DESCRIPTION
This closes #4372 while implementing in a minimal and not invasive way the support for resize the editor from the statusbar in touch devices as well of how is done from devices with have mouses. For optimal use of this ability, probably in the future it will be necessary to rethink the appropriate height of the statusbar for touch devices.