### PR TITLE
Improve images pasting from clipboard

### DIFF
--- a/src/js/module/Clipboard.js
+++ b/src/js/module/Clipboard.js
@@ -23,16 +23,18 @@ export default class Clipboard {
     const clipboardData = event.originalEvent.clipboardData;
 
     if (clipboardData && clipboardData.items && clipboardData.items.length) {
-      const item = clipboardData.items.length > 1 ? clipboardData.items[1] : lists.head(clipboardData.items);
-      if (item.kind === 'file' && item.type.indexOf('image/') !== -1) {
-        // paste img file
-        this.context.invoke('editor.insertImagesOrCallback', [item.getAsFile()]);
+      const clipboardFiles = clipboardData.files;
+      const clipboardText = clipboardData.getData('Text');
+
+      // paste img file
+      if (clipboardFiles.length > 0) {
+        this.context.invoke('editor.insertImagesOrCallback', clipboardFiles);
         event.preventDefault();
-      } else if (item.kind === 'string') {
-        // paste text with maxTextLength check
-        if (this.context.invoke('editor.isLimited', clipboardData.getData('Text').length)) {
-          event.preventDefault();
-        }
+      }
+
+      // paste text with maxTextLength check
+      if (clipboardText.length > 0 && this.context.invoke('editor.isLimited', clipboardText.length)) {
+        event.preventDefault();
       }
     } else if (window.clipboardData) {
       // for IE


### PR DESCRIPTION
#### What does this PR do?

Found problem with multiple images addition from clipboard. It always adds only first image. 
Changes fix it and allow multiple images addition via clipboard.

#### Where should the reviewer start?

- start on the src/js/module/Clipboard.js

#### How should this be manually tested?

1) Add several images to clipboard
2) Add them to summernote via ctrl + v
3) Check that all images were successfully added 

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
