### PR TITLE
fix: escape text link content to prevent html injection

### DIFF
--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -222,7 +222,7 @@ export default class Editor {
       let anchors = [];
       if (isTextChanged) {
         rng = rng.deleteContents();
-        const anchor = rng.insertNode($('<A>' + linkText + '</A>')[0]);
+        const anchor = rng.insertNode($('<A></A>').text(linkText)[0]);
         anchors.push(anchor);
       } else {
         anchors = this.style.styleNodes(rng, {

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -576,6 +576,25 @@ describe('Editor', () => {
       expectContentsAwait(context, '<p><a href="/relative/url" target="_blank">summernote</a></p>', done);
     });
 
+    it('should insert safe html', (done) => {
+      var text = 'hello';
+      var pNode = $editable.find('p')[0];
+      var textNode = pNode.childNodes[0];
+      var startIndex = textNode.wholeText.indexOf(text);
+      var endIndex = startIndex + text.length;
+
+      var rng = range.create(textNode, startIndex, textNode, endIndex);
+
+      editor.createLink({
+        url: '/relative/url',
+        text: '<iframe src="hackme.com"></iframe>',
+        range: rng,
+        isNewWindow: true,
+      });
+
+      expectContentsAwait(context, '<p><a href="/relative/url" target="_blank">&lt;iframe src="hackme.com"&gt;&lt;/iframe&gt;</a></p>', done);
+    });
+
     it('should modify a link', (done) => {
       context.invoke('code', '<p><a href="http://summernote.org">hello world</a></p>');
 


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?
- fixes html injection when inserting link
### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
