### PR TITLE
bugfix/removeMedia-setLangRange after remove image

### DIFF
--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -301,6 +301,8 @@ export default class Editor {
       } else {
         $target = $(this.restoreTarget()).detach();
       }
+      
+      this.setLastRange(range.createFromSelection($target).select());
       this.context.triggerEvent('media.delete', $target, this.$editable);
     });
 


### PR DESCRIPTION
- update current position after clicking remove image button

<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

- awesome stuff
- really cool feature
- refactor X

#### Where should the reviewer start?

- start on the src/summernote.js

#### How should this be manually tested?

- click here and here

#### Any background context you want to provide?

- the gem needed to be updated...

#### What are the relevant tickets?


#### Screenshot (if for frontend)


### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
