### PR TITLE
Bug fix traversing using walkPoint() and nextPointWithEmptyNode()

### DIFF
--- a/src/js/core/dom.js
+++ b/src/js/core/dom.js
@@ -603,6 +603,7 @@ function nextPoint(point, isSkipInnerOffset) {
 }
 
 /**
+ * Find next boundaryPoint for preorder / depth first traversal of the DOM
  * returns next boundaryPoint with empty node
  *
  * @param {BoundaryPoint} point
@@ -612,21 +613,6 @@ function nextPoint(point, isSkipInnerOffset) {
 function nextPointWithEmptyNode(point, isSkipInnerOffset) {
   let node, offset = 0;
 
-  // if node is empty string node, return current node's sibling.
-  if (isEmpty(point.node)) {
-    if(point.node === null){
-      return null;
-    }
-
-    node = point.node.nextSibling;
-    offset = 0;
-
-    return {
-      node: node,
-      offset: offset,
-    };
-  }
-
   if (nodeLength(point.node) === point.offset) {
     if (isEditable(point.node)) {
       return null;
@@ -635,31 +621,17 @@ function nextPointWithEmptyNode(point, isSkipInnerOffset) {
     node = point.node.parentNode;
     offset = position(point.node) + 1;
 
-    // if next node is editable ,  return current node's sibling node.
+    // if parent node is editable,  return current node's sibling node.
     if (isEditable(node)) {
       node = point.node.nextSibling;
       offset = 0;
     }
-
   } else if (hasChildren(point.node)) {
     node = point.node.childNodes[point.offset];
     offset = 0;
-    if (isEmpty(node)) {
-      if (!isEmpty(point.node.nextSibling)) {
-        return {
-          node: point.node.nextSibling,
-          offset: offset,
-        };
-      }
-      return null;
-    }
   } else {
     node = point.node;
     offset = isSkipInnerOffset ? nodeLength(point.node) : point.offset + 1;
-
-    if (isEmpty(node)) {
-      return null;
-    }
   }
 
   return {
@@ -779,7 +751,7 @@ function isSpacePoint(point) {
 }
 
 /**
- * @method walkPoint
+ * @method walkPoint - preorder / depth first traversal of the DOM
  *
  * @param {BoundaryPoint} startPoint
  * @param {BoundaryPoint} endPoint


### PR DESCRIPTION
Previously algorithm would eject early if it the next node was the last child and was an empty child node, and the next sibling was empty as well. Modelled the method on nextPoint, which had similar fixes to pasteHTML()

Changes only made in dom.js

The previous version failed when it encountered this HTML:
```
<p> First paragraph </p><p> <br> </p><p><a href="https://www.google.com" target="_blank"> LINK </a> <br> </p><p><br></p><p> <u> UNREACHABLE </u> </p>
```

Ticket #4471 describes this