### PR TITLE
Add variable to font path

### DIFF
--- a/src/styles/summernote/font.scss
+++ b/src/styles/summernote/font.scss
@@ -1,6 +1,7 @@
 // Variables
 
 $sni-css-prefix: note-icon !default;
+$sni-font-path: "./font" !default;
 
 // Path
 
@@ -9,7 +10,7 @@ $sni-css-prefix: note-icon !default;
   font-style: normal;
   font-weight: 400;
   font-display: auto;
-  src: url("./font/summernote.eot?#iefix") format("embedded-opentype"), url("./font/summernote.woff2") format("woff2"), url("./font/summernote.woff") format("woff"), url("./font/summernote.ttf") format("truetype");}
+  src: url("#{$sni-font-path}/summernote.eot?#iefix") format("embedded-opentype"), url("#{$sni-font-path}/summernote.woff2") format("woff2"), url("#{$sni-font-path}/summernote.woff") format("woff"), url("#{$sni-font-path}/summernote.ttf") format("truetype");}
 
 // Core
 


### PR DESCRIPTION
#### What does this PR do?

- Add flexibility to change font serve path

#### How should this be manually tested?

- Build and run it

#### Any background context you want to provide?
This change was motivated by new rails asset pipeline. When we put summernote font to be served from sprockets, the font path can't be reach

```ruby
Rails.application.config.assets.paths << Rails.root.join("node_modules/summernote/dist/font")
```
Files start being served from `http://localhost:3000/assets/font-name.tff`

With this change, we can set the server folder on our scss file, like this:
```scss
$sni-font-path: ".";
```

Thanks!