### PR TITLE
Correctly close tags in summernote-bs5.js

### DIFF
--- a/src/styles/bs5/summernote-bs5.js
+++ b/src/styles/bs5/summernote-bs5.js
@@ -3,10 +3,10 @@ import '/js/settings';
 import renderer from '/js/renderer';
 import './summernote-bs5.scss';
 
-const editor = renderer.create('<div class="note-editor note-frame card"/>');
-const toolbar = renderer.create('<div class="note-toolbar card-header" role="toolbar"/>');
-const editingArea = renderer.create('<div class="note-editing-area"/>');
-const codable = renderer.create('<textarea class="note-codable" aria-multiline="true"/>');
+const editor = renderer.create('<div class="note-editor note-frame card"></div>');
+const toolbar = renderer.create('<div class="note-toolbar card-header" role="toolbar"></div>');
+const editingArea = renderer.create('<div class="note-editing-area"></div>');
+const codable = renderer.create('<textarea class="note-codable" aria-multiline="true"></textarea>');
 const editable = renderer.create('<div class="note-editable card-block" contentEditable="true" role="textbox" aria-multiline="true"/>');
 const statusbar = renderer.create([
   '<output class="note-status-output" role="status" aria-live="polite"></output>',
@@ -19,7 +19,7 @@ const statusbar = renderer.create([
   '</div>',
 ].join(''));
 
-const airEditor = renderer.create('<div class="note-editor note-airframe"/>');
+const airEditor = renderer.create('<div class="note-editor note-airframe"></div<');
 const airEditable = renderer.create([
   '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"></div>',
   '<output class="note-status-output" role="status" aria-live="polite"></output>',
@@ -62,7 +62,7 @@ const dropdownCheck = renderer.create('<div class="note-dropdown-menu dropdown-m
   }
 });
 
-const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false" tabindex="-1" role="dialog"/>', function($node, options) {
+const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false" tabindex="-1" role="dialog"></div>', function($node, options) {
   if (options.fade) {
     $node.addClass('fade');
   }
@@ -139,7 +139,7 @@ const ui = function(editorOptions) {
     options: editorOptions,
 
     palette: function($node, options) {
-      return renderer.create('<div class="note-color-palette"/>', function($node, options) {
+      return renderer.create('<div class="note-color-palette"></div>', function($node, options) {
         const contents = [];
         for (let row = 0, rowSize = options.colors.length; row < rowSize; row++) {
           const eventName = options.eventName;

--- a/src/styles/bs5/summernote-bs5.js
+++ b/src/styles/bs5/summernote-bs5.js
@@ -19,7 +19,7 @@ const statusbar = renderer.create([
   '</div>',
 ].join(''));
 
-const airEditor = renderer.create('<div class="note-editor note-airframe"></div<');
+const airEditor = renderer.create('<div class="note-editor note-airframe"></div>');
 const airEditable = renderer.create([
   '<div class="note-editable" contentEditable="true" role="textbox" aria-multiline="true"></div>',
   '<output class="note-status-output" role="status" aria-live="polite"></output>',


### PR DESCRIPTION
`<textarea>`, in particular, should be closed explicitly to avoid dangling-markup mitigations some browsers are considering[1]. This change shifts bs5 to match the code in bs3 and bs4, both of which close the tags correctly.

[1]: https://bugs.chromium.org/p/chromium/issues/detail?id=1473854

<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

This PR closes several tags in `//src/style/summernote-bs5.js` with closing tags, as opposed to `/>` which only works for XML/XHTML documents.

#### Where should the reviewer start?

- `//src/style/summernote-bs5.js`

#### How should this be manually tested?

- Nothing should visibly change, but the bug reported against Chromium in https://bugs.chromium.org/p/chromium/issues/detail?id=1473854 will be fixed.

### Checklist

(Apologies; I don't know or use this system at all, so I'm not sure how to test it. I'm just submitting this change to address a bug filed against Chromium. :) )

- [X] Added relevant tests or not required
- [X] Didn't break anything
