### PR TITLE
Intentation of bullet point list is throwing error if <ul> and <li> are separated by line breaks

### DIFF
--- a/src/js/editing/Bullet.js
+++ b/src/js/editing/Bullet.js
@@ -263,7 +263,7 @@ export default class Bullet {
    */
   findList(node) {
     return node
-      ? lists.find(node.children, child => ['OL', 'UL'].indexOf(child.nodeName) > -1)
+      ? node.children && lists.find(node.children, child => ['OL', 'UL'].indexOf(child.nodeName) > -1)
       : null;
   }
 


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

Fix the issue with indentation of bullet point list if the HTML code contains line breaks

#### Where should the reviewer start?

- start on the src/js/editing/Bullet.js

#### How should this be manually tested?

1. Switch to Code-View

2. Insert the following HTML snippet:

```
  <ul>
   <li>a</li>
   <li>b</li>
  </ul>
```
3. Switch back to WYSIWYG editor

4. Try to add indentation to one of the bullet points

#### Any background context you want to provide?

- see issue #4515

#### What are the relevant tickets?


#### Screenshot (if for frontend)


### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
