### PR TITLE
Update Bullet.js fixes #4527

### DIFF
--- a/src/js/editing/Bullet.js
+++ b/src/js/editing/Bullet.js
@@ -31,7 +31,7 @@ export default class Bullet {
     $.each(clustereds, (idx, paras) => {
       const head = lists.head(paras);
       if (dom.isLi(head)) {
-        const previousList = this.findList(head.previousSibling);
+        const previousList = this.findList(head.previousElementSibling);
         if (previousList) {
           paras
             .map(para => previousList.appendChild(para));
@@ -127,8 +127,8 @@ export default class Bullet {
     const head = lists.head(paras);
     const last = lists.last(paras);
 
-    const prevList = dom.isList(head.previousSibling) && head.previousSibling;
-    const nextList = dom.isList(last.nextSibling) && last.nextSibling;
+    const prevList = dom.isList(head.previousElementSibling) && head.previousElementSibling;
+    const nextList = dom.isList(last.nextElementSibling) && last.nextElementSibling;
 
     const listNode = prevList || dom.insertAfter(dom.create(listName || 'UL'), last);
 
@@ -248,8 +248,8 @@ export default class Bullet {
    * @return {HTMLNode}
    */
   appendToPrevious(node) {
-    return node.previousSibling
-      ? dom.appendChildNodes(node.previousSibling, [node])
+    return node.previousElementSibling
+      ? dom.appendChildNodes(node.previousElementSibling, [node])
       : this.wrapList([node], 'LI');
   }
 


### PR DESCRIPTION
Use *ElementSibling methods to skip the whitespaces like line breaks

<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

This PR modified the handling of bullet-point lists. It skips whitespace when iterating through the DOM to prevent problems with pretty-printed HTML code. Indentation is not failing any more if code contains line breaks

#### Where should the reviewer start?

- start on the /src/js/editing/Bullet.js

#### How should this be manually tested?

- Follow the instructions in issue #4527 

#### Any background context you want to provide?

---

#### What are the relevant tickets?
#4527 

#### Screenshot (if for frontend)


### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
