### PR TITLE
Update Editor.js - add copy handler

### DIFF
--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -387,7 +387,7 @@ export default class Editor {
     }).on('paste', (event) => {
       this.setLastRange();
       this.context.triggerEvent('paste', event);
-    }).on('copy', function (event) {
+    }).on('copy', (event) => {
       this.context.triggerEvent('copy', event);
     }).on('input', () => {
       // To limit composition characters (e.g. Korean)

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -387,6 +387,8 @@ export default class Editor {
     }).on('paste', (event) => {
       this.setLastRange();
       this.context.triggerEvent('paste', event);
+    }).on('copy', function (event) {
+      this.context.triggerEvent('copy', event);
     }).on('input', () => {
       // To limit composition characters (e.g. Korean)
       if (this.isLimited(0) && this.snapshot) {


### PR DESCRIPTION
This change will add a copy handler which can be used to copy raw HTML instead of HTML enriched with styles and styling tags. #4536

#### What does this PR do?

The PR will add the possibility to add a copy handler which is trigger when copying from the editor to the clipboard

#### Where should the reviewer start?

- start on the Editor.js

#### How should this be manually tested?

When instating the editor, you can add a custom copy handler:
htmlArea.summernote( {
  callbacks: {
	onCopy: function(e) {
		 //do some stuff
        }
  }
})

#### Any background context you want to provide?

Modern browsers add styles and additional elements to keep the formatting when copy&paste between different applications.
When using copy&paste within the browser, the HTML gets complex and can cause issues (e.g. bullet points won't work anymore)

#### What are the relevant tickets?
#4536 

#### Screenshot (if for frontend)


### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
