### PR TITLE
Resolve #4556 - Fix: Automatically Check 'Use Default Protocol' When URL Lacks Protocol

### DIFF
--- a/src/js/module/LinkDialog.js
+++ b/src/js/module/LinkDialog.js
@@ -3,6 +3,8 @@ import env from '../core/env';
 import key from '../core/key';
 import func from '../core/func';
 
+const linkPattern = /^([A-Za-z][A-Za-z0-9+-.]*\:[\/]{2}|tel:|mailto:[A-Z0-9._%+-]+@|xmpp:[A-Z0-9._%+-]+@)?(www\.)?(.+)$/i;
+
 export default class LinkDialog {
   constructor(context) {
     this.context = context;
@@ -127,8 +129,8 @@ export default class LinkDialog {
 
         $openInNewWindow.prop('checked', isNewWindowChecked);
 
-        const useProtocolChecked = linkInfo.url
-          ? false : this.context.options.useProtocol;
+        const match = linkInfo.url.match(linkPattern);
+        const useProtocolChecked = linkInfo.url && match[1] ? false : this.context.options.useProtocol;
 
         $useProtocol.prop('checked', useProtocolChecked);
 

--- a/test/base/module/LinkDialog.spec.js
+++ b/test/base/module/LinkDialog.spec.js
@@ -74,7 +74,7 @@ describe('LinkDialog', () => {
       expect(checked).to.be.false;
     });
 
-    it('should uncheck default protocol if link (without protocol) exists', () => {
+    it('should check default protocol if link (without protocol) exists', () => {
       range.createFromNode($editable.find('a')[2]).normalize().select();
       context.invoke('editor.setLastRange');
       dialog.show();
@@ -82,7 +82,7 @@ describe('LinkDialog', () => {
       var checked = dialog.$dialog
         .find('.sn-checkbox-use-protocol input[type=checkbox]')
         .is(':checked');
-      expect(checked).to.be.false;
+      expect(checked).to.be.true;
     });
 
     it('should check default protocol if link not exists', () => {


### PR DESCRIPTION
#### What does this PR do?

- If linkInfo.url is not undefined, but there is no protocol, 'Use default protocol' checked.

#### What are the relevant tickets?

#4556 

#### Screenshot (if for frontend)

After Improvement

<img width="1142" alt="スクリーンショット 2023-11-18 17 24 16" src="https://github.com/summernote/summernote/assets/98577773/2ed12f6c-d276-48dc-b6af-d0280da4643b">

<img width="1169" alt="スクリーンショット 2023-11-18 17 24 25" src="https://github.com/summernote/summernote/assets/98577773/ec6bd54e-4efd-4d90-88c7-670ab9fec368">

<img width="1198" alt="スクリーンショット 2023-11-18 17 24 33" src="https://github.com/summernote/summernote/assets/98577773/3b15c014-284d-47cc-9c1e-57af2f594914">

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything