### PR TITLE
Update Bullet.js - fix outdent issue with whitespaces

### DIFF
--- a/src/js/editing/Bullet.js
+++ b/src/js/editing/Bullet.js
@@ -171,7 +171,7 @@ export default class Bullet {
 
       if (headList.parentNode.nodeName === 'LI') {
         paras.map(para => {
-          const newList = this.findNextSiblings(para);
+          const newList = this.findNextElementSiblings(para);
 
           if (parentItem.nextElementSibling) {
             parentItem.parentNode.insertBefore(
@@ -273,18 +273,18 @@ export default class Bullet {
   }
 
   /**
-   * @method findNextSiblings
+   * @method findNextElementSiblings
    *
    * Finds all list item siblings that follow it
    *
    * @param {HTMLNode} ListItem
    * @return {HTMLNode}
    */
-  findNextSiblings(node) {
+  findNextElementSiblings(node) {
     const siblings = [];
-    while (node.nextSibling) {
-      siblings.push(node.nextSibling);
-      node = node.nextSibling;
+    while (node.nextElementSibling) {
+      siblings.push(node.nextElementSibling);
+      node = node.nextElementSibling;
     }
     return siblings;
   }


### PR DESCRIPTION
Handle whitespaces after the <LI> element correctly

#### What does this PR do?
The outdent function didn't work correctly, when the <LI> contained whitespaces at the end of the line.
A detailed description can be found at issue #4559 

#### Where should the reviewer start?

- src\js\editing\Bullet.js

#### How should this be manually tested?

- see issue for an example

#### Any background context you want to provide?



#### What are the relevant tickets?
#4559 

#### Screenshot (if for frontend)


### Checklist

- [ ] Added relevant tests or not required
- [x] Didn't break anything
