### PR TITLE
Fix: escaping inserted link text

### DIFF
--- a/src/js/module/LinkDialog.js
+++ b/src/js/module/LinkDialog.js
@@ -116,7 +116,11 @@ export default class LinkDialog {
         $linkText.on('input paste propertychange', () => {
           // If linktext was modified by input events,
           // cloning text from linkUrl will be stopped.
-          linkInfo.text = $linkText.val();
+          let text = $linkText.val();
+          let div = document.createElement('div');
+          div.innerText = text;
+          text = div.innerHTML;
+          linkInfo.text = text;
           this.toggleLinkBtn($linkBtn, $linkText, $linkUrl);
         }).val(linkInfo.text);
 


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

- fixes problem of inserting html and scripts (xss) in link text 

#### Where should the reviewer start?

- start on the src/js/module/LinkDialog.js

#### How should this be manually tested?

Insert link and put this text `<b>this is bold</b>`, in url put anything eg. github.com
You should see inserted text, without this fix will be bolded text.

#### Any background context you want to provide?

- it is easy to insert script tags

#### What are the relevant tickets?

https://github.com/summernote/summernote/issues/2271

### Checklist

- [x] Didn't break anything
