### PR TITLE
JQMIGRATE: jQuery.fn.mouseup() event shorthand is deprecated

### DIFF
--- a/examples/ondialog-multitab.html
+++ b/examples/ondialog-multitab.html
@@ -24,7 +24,7 @@
         $('.dropping').summernote('destroy');
       });
 
-      $('.nav.nav-tabs a').click(function (e) {
+      $('.nav.nav-tabs a').on('click', function (e) {
         e.preventDefault()
           $(this).tab('show')
       })

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "email": "<susukang98@gmail.com>"
   },
   "main": "dist/summernote.js",
-  "engines" : { 
-    "node" : ">=17.0.0" 
+  "engines": {
+    "node": ">=17.0.0"
   },
   "scripts": {
     "dev": "eslint config && webpack serve --config=./config/webpack.development.js --progress",
@@ -105,5 +105,6 @@
     "webpack-cli": "^4.5.0",
     "webpack-dev-server": "^4.3.0",
     "zip-webpack-plugin": "^4.0.1"
-  }
+  },
+  "dependencies": {}
 }

--- a/plugin/databasic/summernote-ext-databasic.js
+++ b/plugin/databasic/summernote-ext-databasic.js
@@ -237,7 +237,7 @@
 
           $saveBtn
             .text(info.node ? lang.databasic.edit : lang.databasic.insert)
-            .click(function(event) {
+            .on('click', function(event) {
               event.preventDefault();
 
               deferred.resolve({ test: $inpTest.val() });

--- a/src/js/core/dom.js
+++ b/src/js/core/dom.js
@@ -891,24 +891,24 @@ function splitTree(root, point, options) {
     let domList = ancestors.slice(0, ancestors.length - 1);
     let ifHasNextSibling = domList.find(item => item.nextSibling);
     if (ifHasNextSibling && point.offset != 0 && isRightEdgePoint(point)) {
-        let nestSibling = ifHasNextSibling.nextSibling;
-        let textNode;
-        if (nestSibling.nodeType == 1) {
-            textNode = nestSibling.childNodes[0];
-            ancestors = listAncestor(textNode, func.eq(root));
-            point = {
-                node: textNode,
-                offset: 0,
-            };
-        }
-        else if (nestSibling.nodeType == 3 && !nestSibling.data.match(/[\n\r]/g)) {
-            textNode = nestSibling;
-            ancestors = listAncestor(textNode, func.eq(root));
-            point = {
-                node: textNode,
-                offset: 0,
-            };
-        }
+      let nestSibling = ifHasNextSibling.nextSibling;
+      let textNode;
+      if (nestSibling.nodeType == 1) {
+        textNode = nestSibling.childNodes[0];
+        ancestors = listAncestor(textNode, func.eq(root));
+        point = {
+          node: textNode,
+          offset: 0,
+        };
+      }
+      else if (nestSibling.nodeType == 3 && !nestSibling.data.match(/[\n\r]/g)) {
+        textNode = nestSibling;
+        ancestors = listAncestor(textNode, func.eq(root));
+        point = {
+          node: textNode,
+          offset: 0,
+        };
+      }
     }
   }
   return ancestors.reduce(function(node, parent) {

--- a/src/js/editing/Bullet.js
+++ b/src/js/editing/Bullet.js
@@ -107,7 +107,7 @@ export default class Bullet {
       const diffLists = rng.nodes(dom.isList, {
         includeAncestor: true,
       }).filter((listNode) => {
-        return !$.nodeName(listNode, listName);
+        return (listNode.nodeName !== listName);
       });
 
       if (diffLists.length) {

--- a/src/js/module/Buttons.js
+++ b/src/js/module/Buttons.js
@@ -183,7 +183,7 @@ export default class Buttons {
                   .attr('aria-label', color)
                   .attr('data-value', color)
                   .attr('data-original-title', color);
-                $chip.click();
+                $chip.trigger('click');
               });
             });
           },
@@ -209,7 +209,7 @@ export default class Buttons {
                 .attr('data-value', color)
                 .attr('data-original-title', color);
               $palette.prepend($chip);
-              $picker.click();
+              $picker.trigger('click');
             } else {
               if (lists.contains(['backColor', 'foreColor'], eventName)) {
                 const key = eventName === 'backColor' ? 'background-color' : 'color';
@@ -561,7 +561,7 @@ export default class Buttons {
           $catcher.css({
             width: this.options.insertTableMaxSize.col + 'em',
             height: this.options.insertTableMaxSize.row + 'em',
-          }).mousedown(this.context.createInvokeHandler('editor.insertTable'))
+          }).on('mousedown', this.context.createInvokeHandler('editor.insertTable'))
             .on('mousemove', this.tableMoveHandler.bind(this));
         },
       }).render();

--- a/src/js/module/Clipboard.js
+++ b/src/js/module/Clipboard.js
@@ -1,5 +1,3 @@
-import lists from '../core/lists';
-
 export default class Clipboard {
   constructor(context) {
     this.context = context;

--- a/src/js/module/Codeview.js
+++ b/src/js/module/Codeview.js
@@ -106,7 +106,7 @@ export default class CodeView {
     this.context.invoke('airPopover.updateCodeview', true);
 
     this.$editor.addClass('codeview');
-    this.$codable.focus();
+    this.$codable.trigger('focus');
 
     // activate CodeMirror as codable
     if (CodeMirror) {
@@ -164,7 +164,7 @@ export default class CodeView {
       this.context.triggerEvent('change', this.$editable.html(), this.$editable);
     }
 
-    this.$editable.focus();
+    this.$editable.trigger('focus');
 
     this.context.invoke('toolbar.updateCodeview', false);
     this.context.invoke('airPopover.updateCodeview', false);

--- a/src/js/module/Dropzone.js
+++ b/src/js/module/Dropzone.js
@@ -91,7 +91,7 @@ export default class Dropzone {
       event.preventDefault();
 
       if (dataTransfer && dataTransfer.files && dataTransfer.files.length) {
-        this.$editable.focus();
+        this.$editable.trigger('focus');
         this.context.invoke('editor.insertImagesOrCallback', dataTransfer.files);
       } else {
         $.each(dataTransfer.types, (idx, type) => {

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -747,21 +747,21 @@ export default class Editor {
    * removed (function added by 1der1)
   */
   removed(rng, node, tagName) { // LB
-		rng = range.create();
-		if (rng.isCollapsed() && rng.isOnCell()) {
-			node = rng.ec;
-			if( (tagName = node.tagName) &&
+    rng = range.create();
+    if (rng.isCollapsed() && rng.isOnCell()) {
+      node = rng.ec;
+      if( (tagName = node.tagName) &&
 				(node.childElementCount === 1) &&
 				(node.childNodes[0].tagName === "BR") ){
 
-				if(tagName === "P") {
-					node.remove();
-				} else if(['TH', 'TD'].indexOf(tagName) >=0) {
-					node.firstChild.remove();
-				}
-			}
-		}
-	}
+        if(tagName === "P") {
+          node.remove();
+        } else if(['TH', 'TD'].indexOf(tagName) >=0) {
+          node.firstChild.remove();
+        }
+      }
+    }
+  }
   /**
    * insert image
    *

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -1026,7 +1026,7 @@ export default class Editor {
     // [workaround] Screen will move when page is scolled in IE.
     //  - do focus when not focused
     if (!this.hasFocus()) {
-      this.$editable.focus();
+      this.$editable.trigger('focus');
     }
   }
 

--- a/src/js/module/HintPopover.js
+++ b/src/js/module/HintPopover.js
@@ -246,7 +246,7 @@ export default class HintPopover {
             }
           });
           // select first .note-hint-item
-          this.$content.find('.note-hint-item:first').addClass('active');
+          this.$content.find('.note-hint-item').first().addClass('active');
 
           // set position for popover after group is created
           if (this.direction === 'top') {

--- a/src/js/module/ImageDialog.js
+++ b/src/js/module/ImageDialog.js
@@ -109,7 +109,7 @@ export default class ImageDialog {
           $imageUrl.trigger('focus');
         }
 
-        $imageBtn.click((event) => {
+        $imageBtn.on('click', (event) => {
           event.preventDefault();
           deferred.resolve($imageUrl.val());
         });

--- a/src/js/module/VideoDialog.js
+++ b/src/js/module/VideoDialog.js
@@ -222,7 +222,7 @@ export default class VideoDialog {
           $videoUrl.trigger('focus');
         }
 
-        $videoBtn.click((event) => {
+        $videoBtn.on('click', (event) => {
           event.preventDefault();
           deferred.resolve($videoUrl.val());
         });

--- a/src/styles/lite/summernote-lite.js
+++ b/src/styles/lite/summernote-lite.js
@@ -253,8 +253,8 @@ const tableDropdownButton = function(opt) {
         width: opt.col + 'em',
         height: opt.row + 'em',
       })
-        .mouseup(opt.itemClick)
-        .mousemove(function(e) {
+        .on('mouseup', opt.itemClick)
+        .on('mousemove', function(e) {
           tableMoveHandler(e, opt.col, opt.row);
         });
     },

--- a/test/base/module/Buttons.spec.js
+++ b/test/base/module/Buttons.spec.js
@@ -58,7 +58,7 @@ describe('Buttons', () => {
 
   describe('bold button', () => {
     it('should execute bold command when it is clicked', (done) => {
-      $toolbar.find('.note-btn-bold').click();
+      $toolbar.find('.note-btn-bold').trigger('click');
       expect($editable.html()).await(done).to.equalsIgnoreCase('<p><b>hello</b></p>');
     });
   });
@@ -68,14 +68,14 @@ describe('Buttons', () => {
       var $button = $toolbar.find('.note-btn-bold');
       assert.isTrue($button.length === 1);
       assert.isFalse($button.hasClass('active'));
-      $button.click();
+      $button.trigger('click');
       expect($button.hasClass('active')).await(done).to.be.true;
     });
   });
 
   describe('italic button', () => {
     it('should execute italic command when it is clicked', (done) => {
-      $toolbar.find('.note-btn-italic').click();
+      $toolbar.find('.note-btn-italic').trigger('click');
       expect($editable.html()).await(done).to.equalsIgnoreCase('<p><i>hello</i></p>');
     });
   });
@@ -85,14 +85,14 @@ describe('Buttons', () => {
       var $button = $toolbar.find('.note-btn-italic');
       assert.isTrue($button.length === 1);
       assert.isFalse($button.hasClass('active'));
-      $button.click();
+      $button.trigger('click');
       expect($button.hasClass('active')).await(done).to.be.true;
     });
   });
 
   describe('underline button', () => {
     it('should execute underline command when it is clicked', (done) => {
-      $toolbar.find('.note-btn-underline').click();
+      $toolbar.find('.note-btn-underline').trigger('click');
       expect($editable.html()).await(done).to.equalsIgnoreCase('<p><u>hello</u></p>');
     });
   });
@@ -102,14 +102,14 @@ describe('Buttons', () => {
       var $button = $toolbar.find('.note-btn-underline');
       assert.isTrue($button.length === 1);
       assert.isFalse($button.hasClass('active'));
-      $button.click();
+      $button.trigger('click');
       expect($button.hasClass('active')).await(done).to.be.true;
     });
   });
 
   describe('superscript button', () => {
     it('should execute superscript command when it is clicked', (done) => {
-      $toolbar.find('.note-btn-superscript').click();
+      $toolbar.find('.note-btn-superscript').trigger('click');
       expect($editable.html()).await(done).to.equalsIgnoreCase('<p><sup>hello</sup></p>');
     });
   });
@@ -119,14 +119,14 @@ describe('Buttons', () => {
       var $button = $toolbar.find('.note-btn-superscript');
       assert.isTrue($button.length === 1);
       assert.isFalse($button.hasClass('active'));
-      $button.click();
+      $button.trigger('click');
       expect($button.hasClass('active')).await(done).to.be.true;
     });
   });
 
   describe('subscript button', () => {
     it('should execute subscript command when it is clicked', (done) => {
-      $toolbar.find('.note-btn-subscript').click();
+      $toolbar.find('.note-btn-subscript').trigger('click');
       expect($editable.html()).await(done).to.equalsIgnoreCase('<p><sub>hello</sub></p>');
     });
   });
@@ -136,14 +136,14 @@ describe('Buttons', () => {
       var $button = $toolbar.find('.note-btn-subscript');
       assert.isTrue($button.length === 1);
       assert.isFalse($button.hasClass('active'));
-      $button.click();
+      $button.trigger('click');
       expect($button.hasClass('active')).await(done).to.be.true;
     });
   });
 
   describe('strikethrough button', () => {
     it('should execute strikethrough command when it is clicked', (done) => {
-      $toolbar.find('.note-btn-strikethrough').click();
+      $toolbar.find('.note-btn-strikethrough').trigger('click');
       expect($editable.html()).await(done).to.equalsIgnoreCase('<p><strike>hello</strike></p>');
     });
   });
@@ -153,7 +153,7 @@ describe('Buttons', () => {
       var $button = $toolbar.find('.note-btn-strikethrough');
       assert.isTrue($button.length === 1);
       assert.isFalse($button.hasClass('active'));
-      $button.click();
+      $button.trigger('click');
       expect($button.hasClass('active')).await(done).to.be.true;
     });
   });
@@ -163,7 +163,7 @@ describe('Buttons', () => {
       var $button = $toolbar.find('i.note-icon-eraser').parent();
       assert.isTrue($button.length === 1);
       assert.isFalse($button.hasClass('active'));
-      $button.click();
+      $button.trigger('click');
       expect($button.hasClass('active')).await(done).to.be.false;
     });
   });
@@ -187,7 +187,7 @@ describe('Buttons', () => {
       var $span = $toolbar.find('span.note-current-fontname');
       assert.isTrue($li.length === 1);
       assert.isTrue($span.text() !== 'Courier New');
-      $li.click();
+      $li.trigger('click');
       expect($editable.find('p').children().first()).await(done).to.be.equalsStyle('"Courier New"', 'font-family');
     });
     it('should change font family (Arial) when it is clicked', (done) => {
@@ -195,7 +195,7 @@ describe('Buttons', () => {
       var $span = $toolbar.find('span.note-current-fontname');
       assert.isTrue($li.length === 1);
       assert.isTrue($span.text() !== 'Arial');
-      $li.click();
+      $li.trigger('click');
       expect($editable.find('p').children().first()).await(done).to.be.equalsStyle('"Arial"', 'font-family');
     });
     it('should change font family (Helvetica) when it is clicked', (done) => {
@@ -203,14 +203,14 @@ describe('Buttons', () => {
       var $span = $toolbar.find('span.note-current-fontname');
       assert.isTrue($li.length === 1);
       assert.isTrue($span.text() !== 'Helvetica');
-      $li.click();
+      $li.trigger('click');
       expect($editable.find('p').children().first()).await(done).to.be.equalsStyle('"Helvetica"', 'font-family');
     });
   });
 
   describe('recent color button in all color button', () => {
     it('should execute color command when it is clicked', (done) => {
-      $toolbar.find('.note-color-all').find('.note-current-color-button').click();
+      $toolbar.find('.note-color-all').find('.note-current-color-button').trigger('click');
       expect($editable.find('p').children().first()).await(done).to.be.equalsStyle('#FFFF00', 'background-color');
     });
   });
@@ -218,7 +218,7 @@ describe('Buttons', () => {
   describe('fore color button in all color button', () => {
     it('should execute fore color command when it is clicked', (done) => {
       var $button = $toolbar.find('.note-color-all .note-holder').find('.note-color-btn[data-event=foreColor]').eq(10);
-      $button.click();
+      $button.trigger('click');
       expect($editable.find('p').children().first()).await(done).to.be.equalsStyle($button.data('value'), 'color');
     });
   });
@@ -226,7 +226,7 @@ describe('Buttons', () => {
   describe('back color button in all color button', () => {
     it('should execute back color command when it is clicked', (done) => {
       var $button = $toolbar.find('.note-color-all .note-holder').find('.note-color-btn[data-event=backColor]').eq(10);
-      $button.click();
+      $button.trigger('click');
       expect($editable.find('p').children().first()).await(done).to.be.equalsStyle($button.data('value'), 'background-color');
     });
   });
@@ -234,7 +234,7 @@ describe('Buttons', () => {
   describe('color button in fore color button', () => {
     it('should execute fore color command when it is clicked', (done) => {
       var $button = $toolbar.find('.note-color-fore').find('.note-color-btn[data-event=foreColor]').eq(4);
-      $button.click();
+      $button.trigger('click');
       expect($editable.find('p').children().first()).await(done).to.be.equalsStyle($button.data('value'), 'color');
     });
   });
@@ -242,7 +242,7 @@ describe('Buttons', () => {
   describe('back color button in back color button', () => {
     it('should execute back color command when it is clicked', (done) => {
       var $button = $toolbar.find('.note-color-back').find('.note-color-btn[data-event=backColor]').eq(20);
-      $button.click();
+      $button.trigger('click');
       expect($editable.find('p').children().first()).await(done).to.be.equalsStyle($button.data('value'), 'background-color');
     });
   });

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -237,7 +237,7 @@ describe('Editor', () => {
         setTimeout(() => {
           editor.insertNode($('<span> world</span>')[0]);
           setTimeout(() => {
-            $('body').focus();
+            $('body').trigger('focus');
             editor.insertNode($('<span> hello</span>')[0]);
             setTimeout(() => {
               expectContentsAwait(context, '<p><span> world</span><span> hello</span>hello</p>', done);
@@ -274,7 +274,7 @@ describe('Editor', () => {
       setTimeout(() => {
         editor.insertText(' world');
         setTimeout(() => {
-          $('body').focus();
+          $('body').trigger('focus');
           setTimeout(() => {
             editor.insertText(' summernote');
             setTimeout(() => {

--- a/test/base/module/HintPopover.spec.js
+++ b/test/base/module/HintPopover.spec.js
@@ -58,7 +58,7 @@ describe('HintPopover', () => {
     });
 
     it('should not be shown without matches', () => {
-      $editable.keyup();
+      $editable.trigger('keyup');
       expect($('.note-hint-popover').css('display')).to.equals('none');
     });
 
@@ -66,7 +66,7 @@ describe('HintPopover', () => {
       var textNode = $editable.find('p')[0].firstChild;
       editor.setLastRange(range.create(textNode, 5, textNode, 5).select());
       editor.insertText(' #');
-      $editable.keyup();
+      $editable.trigger('keyup');
 
       setTimeout(() => {
         expect($('.note-hint-popover').css('display')).to.equals('block');
@@ -78,7 +78,7 @@ describe('HintPopover', () => {
       var textNode = $editable.find('p')[0].firstChild;
       editor.setLastRange(range.create(textNode, 5, textNode, 5).select());
       editor.insertText(' #al');
-      $editable.keyup();
+      $editable.trigger('keyup');
 
       setTimeout(() => {
         // alvin should be activated
@@ -93,7 +93,7 @@ describe('HintPopover', () => {
       var textNode = $editable.find('p')[0].firstChild;
       editor.setLastRange(range.create(textNode, 5, textNode, 5).select());
       editor.insertText(' #');
-      $editable.keyup();
+      $editable.trigger('keyup');
 
       var onChange = chai.spy();
       $note.on('summernote.change', onChange);
@@ -115,7 +115,7 @@ describe('HintPopover', () => {
       var textNode = $editable.find('p')[0].firstChild;
       editor.setLastRange(range.create(textNode, 5, textNode, 5).select());
       editor.insertText(' #');
-      $editable.keyup();
+      $editable.trigger('keyup');
 
       setTimeout(() => {
         var e = $.Event('keydown');
@@ -194,7 +194,7 @@ describe('HintPopover', () => {
       var textNode = $editable.find('p')[0].firstChild;
       editor.setLastRange(range.create(textNode, 5, textNode, 5).select());
       editor.insertText(' @David S');
-      $editable.keyup();
+      $editable.trigger('keyup');
 
       setTimeout(() => {
         // David Summer should be activated
@@ -209,7 +209,7 @@ describe('HintPopover', () => {
       var textNode = $editable.find('p')[0].firstChild;
       editor.setLastRange(range.create(textNode, 5, textNode, 5).select());
       editor.insertText(' @David S');
-      $editable.keyup();
+      $editable.trigger('keyup');
 
       setTimeout(() => {
         // alvin should be activated

--- a/yarn.lock
+++ b/yarn.lock
@@ -2181,9 +2181,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001252, caniuse-lite@^1.0.30001254:
-  version "1.0.30001258"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001258.tgz#b604eed80cc54a578e4bf5a02ae3ed49f869d252"
-  integrity sha512-RBByOG6xWXUp0CR2/WU2amXz3stjKpSl5J1xU49F1n2OxD//uBZO4wCKUiG+QMGf7CHGfDDcqoKriomoGVxTeA==
+  version "1.0.30001576"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001576.tgz"
+  integrity sha512-ff5BdakGe2P3SQsMsiqmt1Lc8221NR1VzHj5jXN5vBny9A6fpze94HiVV/n7XRosOlsShJcvMv5mdnpjOGCEgg==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
- also goes for mousedown, mousemove, click, focus

<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

Change jQuery deprecated event calls: 
- using .trigger('event') instead of .event() to trigger the event
- using .on('event', function) instead of .event(function)

Also jQuery.nodeName(node, nodeName) method is deprecated in 3.2.0 https://blog.jquery.com/2017/03/16/jquery-3-2-0-is-out/

#### Where should the reviewer start?

- start on the src/summernote.js

#### How should this be manually tested?

- you can insert jquery migration check js underneath the jquery 3.5.1 <script> call in summernote-bsX.html and look at console output (for nodeName deprecation output click on ordered list button twice)

```
    <!-- include jQuery -->
    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-migrate/3.4.1/jquery-migrate.js"></script>
```

#### Any background context you want to provide?

N/A

#### What are the relevant tickets?


#### Screenshot (if for frontend)
![image](https://github.com/summernote/summernote/assets/1414577/74bd0bdb-3f35-4835-8404-54a5a5cb1eac)


### Checklist

- [] Added relevant tests or not required
- [] Didn't break anything
