### PR TITLE
Fix pressing enter on last LI element to create a new line.

### DIFF
--- a/src/js/core/dom.js
+++ b/src/js/core/dom.js
@@ -422,6 +422,13 @@ function insertAfter(node, preceding) {
  */
 function appendChildNodes(node, aChild) {
   $.each(aChild, function(idx, child) {
+	// special case: appending a pure UL/OL to a LI element creates inaccessible LI element 
+	// e.g. press enter in last LI which has UL/OL-subelements
+	// Therefore, if current node is LI element with no child nodes (text-node) and appending a list, add a br before
+	if (isLi(node) && node.firstChild === null && isList(child)) {
+		node.appendChild(create("br"));
+	}
+	
     node.appendChild(child);
   });
   return node;
@@ -843,8 +850,12 @@ function splitNode(point, options) {
     return point.node.splitText(point.offset);
   } else {
     const childNode = point.node.childNodes[point.offset];
+    let childNodes = listNext(childNode);
+    // remove empty nodes
+    childNodes = childNodes.filter(function (element) {return !dom_isEmpty(element);});	
+	
     const clone = insertAfter(point.node.cloneNode(false), point.node);
-    appendChildNodes(clone, listNext(childNode));
+    appendChildNodes(clone, childNodes);
 
     if (!isSkipPaddingBlankHTML) {
       paddingBlankHTML(point.node);


### PR DESCRIPTION
If the last LI element has a sub-list, creating a new LI needs an additional <br> element. Ticket-Nr: #4582 

#### What does this PR do?

- The PR fixes #4582

#### Where should the reviewer start?

- dom.js

#### How should this be manually tested?

- Create list as shown in the screen below
- Nagivate to the last line in the top hierarchy
- Press enter at the end of the line
- New line should appear and should be editable

#### Any background context you want to provide?

- When creating a new LI entry, the previous children are attached to the new line.
- If the new LI element is immediately followed by a <ul> or <ol> element, the LI-element can't be edited

#### What are the relevant tickets?
#4582 

#### Screenshot (if for frontend)
![summernote-last-line-enter-fix](https://github.com/summernote/summernote/assets/27145868/8c9c4ae5-9300-48c8-9fa5-91ec5d540a61)


### Checklist

- [ ] Added relevant tests or not required
- [x] Didn't break anything
