### PR TITLE
Feat: Add supports for youtube shorts and live

### DIFF
--- a/src/js/module/VideoDialog.js
+++ b/src/js/module/VideoDialog.js
@@ -48,7 +48,7 @@ export default class VideoDialog {
 
   createVideoNode(url) {
     // video url patterns(youtube, instagram, vimeo, dailymotion, youku, peertube, mp4, ogg, webm)
-    const ytRegExp = /(?:youtu\.be\/|youtube\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=))([^&\n?]+)(?:.*[?&]t=([^&\n]+))?.*/;
+    const ytRegExp = /(?:youtu\.be\/|youtube\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=|shorts\/|live\/))([^&\n?]+)(?:.*[?&]t=([^&\n]+))?.*/;
     const ytRegExpForStart = /^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$/;
     const ytMatch = url.match(ytRegExp);
 

--- a/test/base/module/VideoDialog.spec.js
+++ b/test/base/module/VideoDialog.spec.js
@@ -60,5 +60,23 @@ describe('VideoDialog', () => {
       expectUrl('https://youtu.be/wZZ7oFKsKzY?t=4h2m42s',
         '//www.youtube.com/embed/wZZ7oFKsKzY?start=14562');
     });
+
+    it('should get proper iframe src when insert various youtube urls', () => {
+      // Normal
+      expectUrl('https://www.youtube.com/watch?v=jNQXAC9IVRw',
+        '//www.youtube.com/embed/jNQXAC9IVRw');
+      // Shorten
+      expectUrl('https://youtu.be/jNQXAC9IVRw',
+        '//www.youtube.com/embed/jNQXAC9IVRw');
+      // Embed
+      expectUrl('https://www.youtube.com/embed/jNQXAC9IVRw',
+        '//www.youtube.com/embed/jNQXAC9IVRw');
+      // Shorts
+      expectUrl('https://www.youtube.com/shorts/SXHMnicI6Pg',
+        '//www.youtube.com/embed/SXHMnicI6Pg');
+      // Live
+      expectUrl('https://www.youtube.com/live/DxmRTlPv8Q4',
+        '//www.youtube.com/embed/DxmRTlPv8Q4');
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

Currently, the youtube regex doesn't support embedding shorts and live youtube content. Adjusting the regex to support both of them. Also, add more tests for youtube urls.

regex test: https://regexr.com/7r3ai

#### Where should the reviewer start?

- start on the src/js/module/VideoDialog.js

#### How should this be manually tested?

- Insert youtube short / live urls in insert video modals
- Video should be shown in the editor

#### Any background context you want to provide?

- Supporting other youtube video format (live and shorts)

#### What are the relevant tickets?

- https://github.com/summernote/summernote/issues/4398

#### Screenshot (if for frontend)


https://github.com/summernote/summernote/assets/15049282/5c29f331-1353-46d8-b4ea-4e52a0db3b06


### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
