### PR TITLE
A custom keyMap containing 'TAB':'indent' created two lines on indentation

### DIFF
--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -467,10 +467,6 @@ export default class Editor {
     } else if (eventName) {
       if (this.context.invoke(eventName) !== false) {
         event.preventDefault();
-        // if keyMap action was invoked
-        if (keyName != 'ENTER') {  // <--- Without this check, we get double Empty Paragraph insertion.
-          this.context.invoke(eventName);
-        }
         return true;
       }
     } else if (key.isEdit(event.keyCode)) {


### PR DESCRIPTION
#### What does this PR do?
The issue is described in #4588 

#### Where should the reviewer start?

- start on src/js/module/editor.js

#### How should this be manually tested?

- create a custom keyMap with at least:
```
var customKeymap = {
	pc: {
	 'TAB':'indent',
     ...
```

- Create a bullet list and try to indent one line item. The line should be moved to the next list hierarchy.

#### Any background context you want to provide?

The event "eventName" was invoked twice in this case and causing the extra line.
Invoking in the first place should be sufficient.

#### What are the relevant tickets?
#4588 

#### Screenshot (if for frontend)
see ticket

### Checklist

- [X] Added relevant tests or not required
- [X] Didn't break anything
