### PR TITLE
Removes "unmet peer dependency " warning when running "yarn install"

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "webpack-bundle-analyzer": "^4.4.0",
     "webpack-cli": "^4.5.0",
     "webpack-dev-server": "^4.3.0",
+	"webpack-sources": "^3.2.3",
     "zip-webpack-plugin": "^4.0.1"
   },
   "dependencies": {}


### PR DESCRIPTION
#### What does this PR do?

When running "yarn install" the following warning was printed:
warning " > zip-webpack-plugin@4.0.1" has unmet peer dependency "webpack-sources@*".
This PR removes this warning.

#### Where should the reviewer start?

package.json

#### How should this be manually tested?

run "yarn install" at console

#### Any background context you want to provide?

An unmet dependency was added to package.json

#### What are the relevant tickets?


#### Screenshot (if for frontend)


### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
