### PR TITLE
fixes jQuery lower/uppercase issue #3537 and reverts commit b5da43e824ed3aeb7f3d36fcd1038ca28774db48

### DIFF
--- a/config/webpack.production.js
+++ b/config/webpack.production.js
@@ -65,7 +65,7 @@ module.exports = {
 
   externals: {
     jquery: {
-      root: 'jquery',
+      root: 'jQuery',
       commonjs: 'jquery',
       commonjs2: 'jquery',
       amd: 'jquery',


### PR DESCRIPTION
#### What does this PR do?

jQuery is used in lower- and uppercase, depending on how it is packaged and used.
Including jQuery on a website registers the object "jQuery" and the Q must be uppercase.

#### Where should the reviewer start?

config/webpack.production.js

#### How should this be manually tested?

Build the project and create a summernote editor within a HTML page.

#### Any background context you want to provide?

fixes issue #3537

#### What are the relevant tickets?

fixes #3537

#### Screenshot (if for frontend)


### Checklist

- [X] Added relevant tests or not required
- [X] Didn't break anything
