### PR TITLE
Fix for boostrap 5-style data- attributes.

### DIFF
--- a/src/styles/bs5/summernote-bs5.js
+++ b/src/styles/bs5/summernote-bs5.js
@@ -156,7 +156,7 @@ const ui = function(editorOptions) {
               'data-value="', color, '" ',
               'title="', colorName, '" ',
               'aria-label="', colorName, '" ',
-              'data-toggle="button" tabindex="-1"></button>',
+              'data-bs-toggle="button" tabindex="-1"></button>',
             ].join(''));
           }
           contents.push('<div class="note-color-row">' + buttons.join('') + '</div>');
@@ -176,7 +176,7 @@ const ui = function(editorOptions) {
     button: function($node, options) {
       return renderer.create('<button type="button" class="note-btn btn btn-outline-secondary btn-sm" tabindex="-1">', function($node, options) {
         if (options && options.data && options.data.toggle === 'dropdown') {
-          $node.removeAttr('data-toggle');
+          $node.removeAttr('data-bs-toggle');
           $node.attr('data-bs-toggle', 'dropdown');
           if (options && options.tooltip) {
             $node.attr({

--- a/src/styles/bs5/summernote-bs5.js
+++ b/src/styles/bs5/summernote-bs5.js
@@ -175,7 +175,7 @@ const ui = function(editorOptions) {
 
     button: function($node, options) {
       return renderer.create('<button type="button" class="note-btn btn btn-outline-secondary btn-sm" tabindex="-1">', function($node, options) {
-        if (options && options.data && options.data.toggle === 'dropdown') {
+        if (options && options.data && options.data."bs-toggle" === 'dropdown') {
           $node.removeAttr('data-bs-toggle');
           $node.attr('data-bs-toggle', 'dropdown');
           if (options && options.tooltip) {


### PR DESCRIPTION
Changed "data-toggle" to "data-bs-toggle"

<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

Currently, with bootstrap 5, the dropdown toggles do nothing when you click this. This PR fixes that.

#### Where should the reviewer start?

- The only file modified is src/styles/bs5/summernote-bs5.js

#### How should this be manually tested?

- Install Bootstrap 5
- Install summernote
- Init summernote on an element in your dom
- Click a button that contains a dropdown menu like font-size, style selection, font face, etc