### PR TITLE
JQMIGRATE: jQuery.trim is deprecated; use String.prototype.trim

### DIFF
--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -569,7 +569,7 @@ class WrappedRange {
    * insert html at current cursor
    */
   pasteHTML(markup) {
-    markup = $.trim(markup);
+    markup = ((markup || '') + '').trim(markup);
 
     const contentsContainer = $('<div></div>').html(markup)[0];
     let childNodes = lists.from(contentsContainer.childNodes);


### PR DESCRIPTION
<!--
Thank you for taking the time to help us improve Summernote.
Please be sure that you are not submitting changes made to the files in the `dist/` folder, and only to the files contained in the `src/` folder.
-->
#### What does this PR do?

use String.prototype.trim()

#### Where should the reviewer start?

- start on the src/summernote.js

#### How should this be manually tested?

you can insert jquery migration check js underneath the jquery 3.5.1 <script> call in summernote-bsX.html and look at console output (for nodeName deprecation output click on ordered list button twice)
    <!-- include jQuery -->
    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.js"></script>
    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-migrate/3.4.1/jquery-migrate.js"></script>

open the console and execute the pasteHTML e.g.

`$('.wysiwig').summernote('pasteHTML', 'testing paste');`

It shouldn't chuck a warning.

#### Any background context you want to provide?

- the gem needed to be updated...

#### What are the relevant tickets?


#### Screenshot (if for frontend)
![image](https://github.com/summernote/summernote/assets/1414577/ff5f4ad7-1cae-442d-b7d8-8c2e758faf4b)


### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything
