### PR TITLE
This PR fixes the problem when pressing return two times on the last li element

### DIFF
--- a/src/js/core/dom.js
+++ b/src/js/core/dom.js
@@ -851,8 +851,6 @@ function splitNode(point, options) {
   } else {
     const childNode = point.node.childNodes[point.offset];
     let childNodes = listNext(childNode);
-    // remove empty nodes
-    childNodes = childNodes.filter(function(element) {return !isEmpty(element);});	
 
     const clone = insertAfter(point.node.cloneNode(false), point.node);
     appendChildNodes(clone, childNodes);


### PR DESCRIPTION

#### What does this PR do?

This PR fixes the problem when pressing return two times on the last li element.
It should create a new line outside of the ul/ol after the second return.
The issue was introduced by #4584 

#### Where should the reviewer start?

start on the src/js/core/dom.js

#### How should this be manually tested?

Create a ul-list and create some li elements.
Set cursor last element, end of line.
Press return two times.
A new line outside of the ul should be created.

#### Any background context you want to provide?

The removed line cleaned up some empty elements. But cleanup is not vital for the fix in #4584 

#### What are the relevant tickets?
#4584 

#### Screenshot (if for frontend)


### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything
