### PR TITLE
Fix null error when styling all text selected with ctrl+a

### DIFF
--- a/src/js/core/dom.js
+++ b/src/js/core/dom.js
@@ -768,7 +768,7 @@ function isSpacePoint(point) {
 function walkPoint(startPoint, endPoint, handler, isSkipInnerOffset) {
   let point = startPoint;
 
-  while (point) {
+  while (point && point.node) {
     handler(point);
 
     if (isSamePoint(point, endPoint)) {


### PR DESCRIPTION
Applying a new style (e.g. font or size) to all the paragraphs only works when selecting the whole text with the cursor (thanks to #4472), but fails when selecting it with CTRL+A. This pull request fixes this.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the robustness of point traversal by adding validation to prevent errors related to undefined or null references.
	- Enhanced reliability of the function by ensuring both the point variable and its node property are properly validated before processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->