### PR TITLE
Enhance lite button to default if specified container not provided

### DIFF
--- a/src/styles/lite/summernote-lite.js
+++ b/src/styles/lite/summernote-lite.js
@@ -657,7 +657,13 @@ const ui = function(editorOptions) {
     airEditor: airEditor,
     airEditable: airEditable,
     buttonGroup: buttonGroup,
-    button: button,
+    button: (options) => {
+      console.log("button", options);
+      return button({
+        ...options,
+        container: options.container || editorOptions.container,
+      });
+    },
     dropdown: dropdown,
     dropdownCheck: dropdownCheck,
     dropdownButton: dropdownButton,

--- a/src/styles/lite/summernote-lite.js
+++ b/src/styles/lite/summernote-lite.js
@@ -658,7 +658,6 @@ const ui = function(editorOptions) {
     airEditable: airEditable,
     buttonGroup: buttonGroup,
     button: (options) => {
-      console.log("button", options);
       return button({
         ...options,
         container: options.container || editorOptions.container,


### PR DESCRIPTION
<!--
Thank you for taking your time to contribute to Summernote.
Please fill out the information below to help us review your pull request.
After you have filled out the information, please check the boxes below to confirm that you have completed the necessary steps.
-->

#### What does this PR do / why do we need it?

- Modify button tooltip script error in lite ui

#### Which issue(s) this PR fixes?

Fixes #4701 

#### Any background context you want to provide?

- When creating a button in a plugin, a tooltip script error occurs because the editor's container is not set to the default value. 

#### Screenshot (if appropriate)

- N/A

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced button functionality in the editor's UI, now defaulting to a specified container if not provided.

- **Bug Fixes**
	- Improved handling of container options for better user experience in the editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->