### PR TITLE
Correct the URL for including Bootstrap's JavaScript bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Include the following code in the `<head>` tag of your HTML:
 <!-- include libraries(jQuery, bootstrap) -->
 <script type="text/javascript" src="//code.jquery.com/jquery-3.6.0.min.js"></script>
 <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" />
-<script type="text/javascript" src="cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
+<script type="text/javascript" src="//cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>
 
 <!-- include summernote css/js-->
 <link href="summernote-bs5.css" rel="stylesheet">


### PR DESCRIPTION
Minor fix that caused me issue/ The missing // was needed:

<script type="text/javascript" src="//cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"></script>

<!--
Thank you for taking your time to contribute to Summernote.
Please fill out the information below to help us review your pull request.
After you have filled out the information, please check the boxes below to confirm that you have completed the necessary steps.
-->

#### What does this PR do / why do we need it?

- Describe the feature or bug fix.
- It is helpful to describe why this PR is needed.

#### Which issue(s) this PR fixes?

Fixes #<issue_number>

#### Any background context you want to provide?

- N/A

#### Screenshot (if appropriate)

- N/A

### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the URL for including Bootstrap's JavaScript bundle in the README, ensuring proper loading over both HTTP and HTTPS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->