### PR TITLE
Optimize tooltip initialization for improved performance

### DIFF
--- a/src/styles/bs3/summernote-bs3.js
+++ b/src/styles/bs3/summernote-bs3.js
@@ -163,10 +163,15 @@ const ui = function(editorOptions) {
         $node.html(contents.join(''));
 
         if (options.tooltip) {
-          $node.find('.note-color-btn').tooltip({
+          var tooltipOptions = {
             container: options.container || editorOptions.container,
             trigger: 'hover',
-            placement: 'bottom',
+            placement: 'bottom'
+          };
+
+          $node.tooltip({
+            selector: '.note-color-btn',
+            ...tooltipOptions
           });
         }
       })($node, options);

--- a/src/styles/bs3/summernote-bs3.js
+++ b/src/styles/bs3/summernote-bs3.js
@@ -166,12 +166,12 @@ const ui = function(editorOptions) {
           var tooltipOptions = {
             container: options.container || editorOptions.container,
             trigger: 'hover',
-            placement: 'bottom'
+            placement: 'bottom',
           };
 
           $node.tooltip({
             selector: '.note-color-btn',
-            ...tooltipOptions
+            ...tooltipOptions,
           });
         }
       })($node, options);

--- a/src/styles/bs4/summernote-bs4.js
+++ b/src/styles/bs4/summernote-bs4.js
@@ -231,12 +231,12 @@ const ui = function(editorOptions) {
           var tooltipOptions = {
             container: options.container || editorOptions.container,
             trigger: 'hover',
-            placement: 'bottom'
+            placement: 'bottom',
           };
 
           $node.tooltip({
             selector: '.note-color-btn',
-            ...tooltipOptions
+            ...tooltipOptions,
           });
         }
       })($node, options);

--- a/src/styles/bs4/summernote-bs4.js
+++ b/src/styles/bs4/summernote-bs4.js
@@ -228,10 +228,15 @@ const ui = function(editorOptions) {
         $node.html(contents.join(''));
 
         if (options.tooltip) {
-          $node.find('.note-color-btn').tooltip({
+          var tooltipOptions = {
             container: options.container || editorOptions.container,
             trigger: 'hover',
-            placement: 'bottom',
+            placement: 'bottom'
+          };
+
+          $node.tooltip({
+            selector: '.note-color-btn',
+            ...tooltipOptions
           });
         }
       })($node, options);

--- a/src/styles/bs5/summernote-bs5.js
+++ b/src/styles/bs5/summernote-bs5.js
@@ -164,10 +164,15 @@ const ui = function(editorOptions) {
         $node.html(contents.join(''));
 
         if (options.tooltip) {
-          $node.find('.note-color-btn').tooltip({
+          var tooltipOptions = {
             container: options.container || editorOptions.container,
             trigger: 'hover',
-            placement: 'bottom',
+            placement: 'bottom'
+          };
+
+          $node.tooltip({
+            selector: '.note-color-btn',
+            ...tooltipOptions
           });
         }
       })($node, options);

--- a/src/styles/bs5/summernote-bs5.js
+++ b/src/styles/bs5/summernote-bs5.js
@@ -167,12 +167,12 @@ const ui = function(editorOptions) {
           var tooltipOptions = {
             container: options.container || editorOptions.container,
             trigger: 'hover',
-            placement: 'bottom'
+            placement: 'bottom',
           };
 
           $node.tooltip({
             selector: '.note-color-btn',
-            ...tooltipOptions
+            ...tooltipOptions,
           });
         }
       })($node, options);


### PR DESCRIPTION
Ive found performance issue when you use multiple editors on the same page.
And its getting worse with each new initialization of summernote until page reload.

Found out it was tooltip find() thing.

Replaced tooltip init code with new one works much better.

![photo_2024-10-15 19 55 42](https://github.com/user-attachments/assets/b8379dda-46f1-4fee-a754-a83c441a94a8)
![photo_2024-10-15 19 55 47](https://github.com/user-attachments/assets/bfee572d-5208-43ba-86a6-0fd9cbf51c7c)

Before fix each summernote instance spend from 40ms to infinity to init tooltips.
Measurements after loading multiple summernote instances before fix, started from first init 40ms to 200ms+ at +/- fifth try
<img width="330" alt="Screenshot 2024-10-15 at 20 03 51" src="https://github.com/user-attachments/assets/65c6deb2-ecd0-482d-aadc-28323aa5cf89">

after fix its about 0-1ms after same amount of summernote instances 
<img width="308" alt="Screenshot 2024-10-15 at 20 04 19" src="https://github.com/user-attachments/assets/447a2895-dc84-4774-abcb-fec490ff2de4">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced tooltip functionality for color buttons and dropdowns in the UI.
	- Improved organization and clarity in tooltip and button creation processes across multiple versions.
- **Bug Fixes**
	- Updated dropdown toggle attributes for better compatibility with Bootstrap 5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->