### PR TITLE
Add configurable font path for better asset pipeline integration

### DIFF
--- a/src/styles/summernote/font.scss
+++ b/src/styles/summernote/font.scss
@@ -1,6 +1,7 @@
 // Variables
 
 $sni-css-prefix: note-icon !default;
+$sni-font-path: "./font" !default;
 
 // Path
 
@@ -9,7 +10,11 @@ $sni-css-prefix: note-icon !default;
   font-style: normal;
   font-weight: 400;
   font-display: auto;
-  src: url("./font/summernote.eot?#iefix") format("embedded-opentype"), url("./font/summernote.woff2") format("woff2"), url("./font/summernote.woff") format("woff"), url("./font/summernote.ttf") format("truetype");}
+  src: url("#{$sni-font-path}/summernote.eot?#iefix") format("embedded-opentype"),
+       url("#{$sni-font-path}/summernote.woff2") format("woff2"),
+       url("#{$sni-font-path}/summernote.woff") format("woff"),
+       url("#{$sni-font-path}/summernote.ttf") format("truetype");
+}
 
 // Core
 
@@ -53,6 +58,7 @@ $sni-css-prefix: note-icon !default;
   &.#{$sni-css-prefix}-pull-left {
     margin-right: 0.3em;
   }
+
   &.#{$sni-css-prefix}-pull-right {
     margin-left: 0.3em;
   }
@@ -67,8 +73,7 @@ $sni-css-prefix: note-icon !default;
 
   @if "\\#{'x'}" == "\\x" {
     @return str-slice("\x", 1, 1) + $character-code;
-  }
-  @else {
+  } @else {
     @return #{"\"\\"}#{$character-code + "\""};
   }
 }
@@ -299,4 +304,3 @@ $sni-css-prefix: note-icon !default;
 .note-icon-video::before {
   content: "\ea38";
 }
-


### PR DESCRIPTION
#### What does this PR do?

- Add flexibility to change font serve path

#### How should this be manually tested?

- Build and run it

#### Any background context you want to provide?
This change was motivated by new rails asset pipeline. When we put summernote font to be served from sprockets, the font path can't be reach

```ruby
Rails.application.config.assets.paths << Rails.root.join("node_modules/summernote/dist/font")
```
Files start being served from `http://localhost:3000/assets/font-name.tff`

With this change, we can set the server folder on our scss file, like this:
```scss
$sni-font-path: ".";
```

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a new variable for dynamic font path management, enhancing maintainability.
	- Improved formatting of the CSS function without altering its logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->