### PR TITLE
Fix failed to execute 'setEnd' on 'Range'

### DIFF
--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -140,7 +140,7 @@ class WrappedRange {
     if (env.isW3CRangeSupport) {
       const w3cRange = document.createRange();
       w3cRange.setStart(this.sc, this.so);
-      w3cRange.setEnd(this.ec, this.eo);
+      w3cRange.setEnd(this.ec, this.ec.data ? Math.min(this.eo, this.ec.data.length) : this.eo);
 
       return w3cRange;
     } else {


### PR DESCRIPTION
<!--
Thank you for taking your time to contribute to Summernote.
Please fill out the information below to help us review your pull request.
After you have filled out the information, please check the boxes below to confirm that you have completed the necessary steps.
-->

Here's an old bug that is making a comeback.

#### What does this PR do / why do we need it?

- This PR addresses the bug #3112, which still exist in summernote **v0.9.0**. 
(I opened a new issue to address this subject : #4719)
- The change I suggest is based onto the initial fix (#3113) but takes into consideration @jokamax remark (#3366) to not break anything.
- The issue this PR fixes has been detected only with Chrome and Edge. Everything seems fine with Firefox.

#### Which issue(s) this PR fixes?

Fixes #4719 

### Checklist

- [x] Added relevant tests or not required (didn't add any, but checked that the current tests are still ok)
- [x] Didn't break anything
