### PR TITLE
Fix table insert method

### DIFF
--- a/src/js/module/Buttons.js
+++ b/src/js/module/Buttons.js
@@ -561,7 +561,7 @@ export default class Buttons {
           $catcher.css({
             width: this.options.insertTableMaxSize.col + 'em',
             height: this.options.insertTableMaxSize.row + 'em',
-          }).on('mousedown', this.context.createInvokeHandler('editor.insertTable'))
+          }).on('mouseup', this.context.createInvokeHandler('editor.insertTable'))
             .on('mousemove', this.tableMoveHandler.bind(this));
         },
       }).render();


### PR DESCRIPTION
#### What does this PR do / why do we need it?

- This PR fixes a UX inconsistency related to the toolbar button events.
- Previously, the "Insert Table" button triggered its action on `mousedown`, while other toolbar buttons (e.g., bold, italic, link) triggered on `mouseup`.
- To maintain consistent behavior across all toolbar buttons, this PR changes the "Insert Table" trigger event from `mousedown` to `mouseup`.

#### Any background context you want to provide?

- This inconsistency could lead to unexpected behavior or confusion for users who expect uniform interactions with toolbar buttons.

### Checklist

- [x] Added relevant tests or not required
- [x] Didn't break anything