### PR TITLE
Remove redundant parameter from string trim call

### DIFF
--- a/src/js/core/range.js
+++ b/src/js/core/range.js
@@ -569,7 +569,7 @@ class WrappedRange {
    * insert html at current cursor
    */
   pasteHTML(markup) {
-    markup = ((markup || '') + '').trim(markup);
+    markup = ((markup || '') + '').trim();
 
     const contentsContainer = $('<div></div>').html(markup)[0];
     let childNodes = lists.from(contentsContainer.childNodes);


### PR DESCRIPTION
#### What does this PR do / why do we need it?

- Removes a redundant parameter from string trim call in `pasteHTML` function

#### Which issue(s) this PR fixes?

N/A

#### Any background context you want to provide?

- In ASP.NET Web Forms, `String.prototype.trim` is replaced with a version that throws an error if there are any parameters, and therefore `pasteHTML` does not work with ASP.NET Web Forms. Removing the redundant parameter helps clean up the source and allows `pasteHTML` to work with ASP.NET Web Forms.

#### Screenshot (if appropriate)

- N/A

### Checklist

- [X] Added relevant tests or not required
- [X] Didn't break anything
