### PR TITLE
Fix typo in Polish translation: "Ostani" → "Ostatni"

### DIFF
--- a/public/lang/summernote-pl-PL.js
+++ b/public/lang/summernote-pl-PL.js
@@ -95,7 +95,7 @@
         justify: 'Wyrównaj do lewej i prawej',
       },
       color: {
-        recent: 'Ostani kolor',
+        recent: 'Ostatni kolor',
         more: 'Więcej kolorów',
         background: 'Tło',
         foreground: 'Czcionka',


### PR DESCRIPTION
<!--
Thank you for taking your time to contribute to Summernote.
Please fill out the information below to help us review your pull request.
After you have filled out the information, please check the boxes below to confirm that you have completed the necessary steps.
-->

#### What does this PR do / why do we need it?

- Describe the feature or bug fix.
- It is helpful to describe why this PR is needed.

#### Which issue(s) this PR fixes?

Fixes #<issue_number>

#### Any background context you want to provide?

- N/A

#### Screenshot (if appropriate)

- N/A

### Checklist

- [ ] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a typo in the Polish language translation to ensure accurate text display for Polish-language users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->