### PR TITLE
Add fixedFontSizeUnit and fontSizeStep settings

### DIFF
--- a/examples/fixed-font-size.html
+++ b/examples/fixed-font-size.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>Summernote - Fixed Font Size Unit</title>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.js"></script>
+
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.css" />
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.16.0/umd/popper.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.js"></script>
+
+  <script type="module" src="/src/styles/bs4/summernote-bs4.js"></script>
+
+  <script type="text/javascript">
+    $(document).ready(function () {
+      $('.summernote').summernote({
+        height: 550,
+        tabsize: 2,
+        fixedFontSizeUnit: 'pt',
+        fontSizeStep: 0.5,
+        spellCheck: false,
+        toolbar: [
+          ['style', ['style']],
+          ['font', ['bold', 'underline', 'clear']],
+          ['fontname', ['fontname', 'fontsize']],
+          ['color', ['color']],
+          ['para', ['ul', 'ol', 'paragraph']],
+          ['table', ['table']],
+          ['insert', ['link', 'picture', 'video']],
+          ['view', ['fullscreen', 'codeview', 'help']],
+        ],
+      });
+    });
+  </script>
+</head>
+<body>
+  <div class="container py-4">
+    <h1>Summernote with Fixed Font Size Unit</h1>
+    <p>
+      <span class="badge badge-primary">jQuery v3.5.1</span>
+      <span class="badge badge-info">Bootstrap v4.4.1</span>
+    </p>
+    <div class="summernote">
+      <p>This editor is configured with <code>fixedFontSizeUnit: 'pt'</code> and <code>fontSizeStep: 0.5</code>.</p>
+
+      <hr>
+      <h4>Foreign Unit Conversion</h4>
+      <p style="font-size: 16px">16px (Exact conversion: 12pt)</p>
+      <p style="font-size: 21px">21px (15.75pt &rarr; Snaps to 16pt)</p>
+      <p style="font-size: 10mm">10mm (~28.35pt &rarr; Snaps to 28.5pt)</p>
+      <p style="font-size: 0.25cm">0.25cm (~7.09pt &rarr; Snaps to 7.0pt)</p>
+      <p style="font-size: 0.5in">0.5in (36pt)</p>
+      <p style="font-size: 1pc">1pc (12pt)</p>
+      <p style="font-size: 1em">1em (Relative unit, usually computes to 16px &rarr; 12pt)</p>
+
+      <hr>
+      <h4>Step Rounding Tests</h4>
+      <p style="font-size: 10.1pt">10.1pt &rarr; 10.0pt</p>
+      <p style="font-size: 10.24pt">10.24pt &rarr; 10.0pt</p>
+      <p style="font-size: 10.26pt">10.26pt &rarr; 10.5pt</p>
+      <p style="font-size: 10.74pt">10.74pt &rarr; 10.5pt</p>
+      <p style="font-size: 10.76pt">10.76pt &rarr; 11.0pt</p>
+    </div>
+
+    <div class="card mt-3">
+      <div class="card-header">Source Code</div>
+      <div class="card-body">
+        <pre><code id="source-code"></code></pre>
+      </div>
+    </div>
+  </div>
+  <script>
+    $('#source-code').text($('script[type="text/javascript"]').html().trim());
+  </script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -62,6 +62,10 @@
                 href: 'external-codemirror.html'
             },
             {
+                title: 'Fixed Font Size',
+                href: 'fixed-font-size.html'
+            },
+            {
                 title: 'Hint Emoji',
                 href: 'hint-emoji.html'
             },

--- a/src/js/module/Buttons.js
+++ b/src/js/module/Buttons.js
@@ -380,11 +380,16 @@ export default class Buttons {
     });
 
     this.context.memo('button.fontsize', () => {
+      const currentStyle = this.context.invoke('editor.currentStyle');
+      let tooltip = this.lang.font.size;
+      if (currentStyle['font-size-unit-fixed']) {
+        tooltip += ' (' + currentStyle['font-size-unit'] + ')';
+      }
       return this.ui.buttonGroup([
         this.button({
           className: 'dropdown-toggle',
           contents: this.ui.dropdownButtonContents('<span class="note-current-fontsize"></span>', this.options),
-          tooltip: this.lang.font.size,
+          tooltip: tooltip,
           data: {
             toggle: 'dropdown',
           },
@@ -400,6 +405,9 @@ export default class Buttons {
     });
 
     this.context.memo('button.fontsizeunit', () => {
+      if (this.context.invoke('editor.currentStyle')['font-size-unit-fixed']) {
+        return null;
+      }
       return this.ui.buttonGroup([
         this.button({
           className: 'dropdown-toggle',

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -163,6 +163,10 @@ $.summernote = $.extend($.summernote, {
 
     fontSizeUnits: ['px', 'pt'],
 
+    fixedFontSizeUnit: null,
+
+    fontSizeStep: null,
+
     // pallete colors(n x n)
     colors: [
       ['#000000', '#424242', '#636363', '#9C9C94', '#CEC6CE', '#EFEFEF', '#F7F7F7', '#FFFFFF'],


### PR DESCRIPTION
<!--
Thank you for taking your time to contribute to Summernote.
Please fill out the information below to help us review your pull request.
After you have filled out the information, please check the boxes below to confirm that you have completed the necessary steps.
-->

#### What does this PR do / why do we need it?

This PR fixes long-standing inconsistencies in Summernote’s font-size reporting and selection behavior, particularly regarding units and fractional sizes.

It adds two new settings:

- `fixedFontSizeUnit` - When set, Summernote reports and applies font sizes in that unit and hides the unit dropdown. All absolute units are supported: `px`, `pt`, `pc`, `in`, `cm`, `mm`, `q`

- `fontSizeStep` - Snaps font sizes to a configurable step for both toolbar display and values applied to the DOM, preventing cases where the toolbar shows one value but the DOM stores another.
   - e.g., `0.5` for half-unit increments

#### Which issue(s) this PR fixes?

#2874 , #3975, #4254, #4749

#### Any background context you want to provide?

This PR builds upon work from PR #3510, which added the Font Size Unit dropdown. That change allowed  selecting and displaying non-`px` units. But it had the limitation that selecting a node without an explicit inline `font-size` style always resulted in displaying the browser's computed `px` value. In the present PR, we introduce the ability to lock the editor to a particular unit. This change is backward compatible; if `fixedFontSizeUnit` is not specified, units are handled as they were before.

### Checklist

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Set a fixed font size unit (points, centimeters, inches) for all font size selections instead of pixels
  * Configure font size step to control precision of font size increments
  * Added example demonstrating fixed font size unit configuration

* **Tests**
  * Added test coverage for font size unit conversion and step snapping behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->