### PR TITLE
Fix hidden caret by avoiding bogus-char selection

### DIFF
--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -456,6 +456,31 @@ describe('Editor', () => {
     });
   });
 
+  describe('fontStyling', () => {
+    it('should remove bogus character when selection changes', async() => {
+      $editable.appendTo('body');
+      context.invoke('editor.focus');
+      await nextTick();
+
+      var textNode = $editable.find('p')[0].firstChild;
+      editor.setLastRange(range.create(textNode, 0, textNode, 0).select());
+
+      editor.fontSize(20);
+
+      var bogusSpan = $editable.data('bogus');
+      expect(bogusSpan).toBeDefined();
+
+      editor.setLastRange(range.create(textNode, 5, textNode, 5).select());
+
+      document.dispatchEvent(new Event('selectionchange'));
+      await nextTick();
+
+      expect($editable.data('bogus')).toBeUndefined();
+      expect($editable.find('span').length).toEqual(0);
+      expect($editable.html()).toEqual('<p>hello</p>');
+    });
+  });
+
   describe('createLink', () => {
     it('should create normal link', async() => {
       var text = 'hello';


### PR DESCRIPTION
<!--
Thank you for taking your time to contribute to Summernote.
Please fill out the information below to help us review your pull request.
After you have filled out the information, please check the boxes below to confirm that you have completed the necessary steps.
-->

#### What does this PR do / why do we need it?

Stop selecting the ZERO_WIDTH_NBSP/FEFF helper character when applying font-size with a collapsed range, since selecting that invisible node can make the caret appear hidden.

Also clean up the tracked KEY_BOGUS span on selection changes: once the cursor leaves the helper span, remove it (when it only contains the bogus char) and clear the KEY_BOGUS reference. Otherwise, these bogus spans can become orphaned if you change the font-size and update the selection without content changes.

#### Which issue(s) this PR fixes?

Fixes #4101, #4490, #4697

### Checklist

- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed invisible placeholder characters that could appear during editing and ensured the cursor is positioned correctly.
  * Improved handling of selection changes to clear leftover placeholder spans and ensure styling applies to the intended text.
  * Reduced stray span artifacts after styling, improving editor stability and behavior when inserting styled content.

* **Tests**
  * Added coverage for font-styling and selection-change scenarios to prevent regressions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->