### PR TITLE
Translate aria label for close button in dialogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ selenium-debug.log
 
 # build files
 dist/
+
+# agent files
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,3 @@ selenium-debug.log
 
 # build files
 dist/
-
-# agent files
-CLAUDE.md

--- a/public/lang/summernote-ar-AR.js
+++ b/public/lang/summernote-ar-AR.js
@@ -85,6 +85,9 @@
         fullscreen: 'حجم الشاشة بالكامل',
         codeview: 'شفيرة المصدر',
       },
+      modal: {
+        close: 'غلق',
+      },
       paragraph: {
         paragraph: 'فقرة',
         outdent: 'محاذاة للخارج',

--- a/public/lang/summernote-az-AZ.js
+++ b/public/lang/summernote-az-AZ.js
@@ -97,6 +97,9 @@
         fullscreen: 'Tam ekran',
         codeview: 'HTML Kodu',
       },
+      modal: {
+        close: 'Bağla',
+      },
       paragraph: {
         paragraph: 'Paraqraf',
         outdent: 'Girintini artır',

--- a/public/lang/summernote-bg-BG.js
+++ b/public/lang/summernote-bg-BG.js
@@ -85,6 +85,9 @@
         fullscreen: 'На цял екран',
         codeview: 'Преглед на код',
       },
+      modal: {
+        close: 'Затвори',
+      },
       paragraph: {
         paragraph: 'Параграф',
         outdent: 'Намаляване на отстъпа',

--- a/public/lang/summernote-bn-BD.js
+++ b/public/lang/summernote-bn-BD.js
@@ -87,6 +87,9 @@
         fullscreen: 'পূর্ণ পর্দা',
         codeview: 'কোড দৃশ্য',
       },
+      modal: {
+        close: 'বন্ধ করুন',
+      },
       paragraph: {
         paragraph: 'অনুচ্ছেদ',
         outdent: 'ঋণাত্মক প্রান্তিককরণ',

--- a/public/lang/summernote-ca-ES.js
+++ b/public/lang/summernote-ca-ES.js
@@ -85,6 +85,9 @@
         fullscreen: 'Pantalla sencera',
         codeview: 'Veure codi font',
       },
+      modal: {
+        close: 'Tancar',
+      },
       paragraph: {
         paragraph: 'Paràgraf',
         outdent: 'Menys tabulació',

--- a/public/lang/summernote-cs-CZ.js
+++ b/public/lang/summernote-cs-CZ.js
@@ -80,6 +80,9 @@
         fullscreen: 'Celá obrazovka',
         codeview: 'HTML kód',
       },
+      modal: {
+        close: 'Zavřít',
+      },
       paragraph: {
         paragraph: 'Odstavec',
         outdent: 'Předsadit',

--- a/public/lang/summernote-da-DK.js
+++ b/public/lang/summernote-da-DK.js
@@ -85,6 +85,9 @@
         fullscreen: 'Fuld skærm',
         codeview: 'HTML-Visning',
       },
+      modal: {
+        close: 'Luk',
+      },
       paragraph: {
         paragraph: 'Afsnit',
         outdent: 'Formindsk indryk',

--- a/public/lang/summernote-de-CH.js
+++ b/public/lang/summernote-de-CH.js
@@ -86,6 +86,9 @@
         fullscreen: 'Vollbild',
         codeview: 'Quellcode anzeigen',
       },
+      modal: {
+        close: 'Schliessen',
+      },
       paragraph: {
         paragraph: 'Absatz',
         outdent: 'Einzug verkleinern',

--- a/public/lang/summernote-de-DE.js
+++ b/public/lang/summernote-de-DE.js
@@ -86,6 +86,9 @@
         fullscreen: 'Vollbild',
         codeview: 'Quellcode anzeigen',
       },
+      modal: {
+        close: 'Schließen',
+      },
       paragraph: {
         paragraph: 'Absatz',
         outdent: 'Einzug verkleinern',

--- a/public/lang/summernote-el-GR.js
+++ b/public/lang/summernote-el-GR.js
@@ -87,6 +87,9 @@
         fullscreen: 'Πλήρης οθόνη',
         codeview: 'Προβολή HTML',
       },
+      modal: {
+        close: 'Κλείσιμο',
+      },
       paragraph: {
         paragraph: 'Παράγραφος',
         outdent: 'Μείωση εσοχής',

--- a/public/lang/summernote-es-ES.js
+++ b/public/lang/summernote-es-ES.js
@@ -87,6 +87,9 @@
         fullscreen: 'Pantalla completa',
         codeview: 'Ver el código fuente',
       },
+      modal: {
+        close: 'Cerrar',
+      },
       paragraph: {
         paragraph: 'Párrafo',
         outdent: 'Reducir la sangría',

--- a/public/lang/summernote-es-EU.js
+++ b/public/lang/summernote-es-EU.js
@@ -85,6 +85,9 @@
         fullscreen: 'Pantaila osoa',
         codeview: 'Kodea ikusi',
       },
+      modal: {
+        close: 'Itxi',
+      },
       paragraph: {
         paragraph: 'Paragrafoa',
         outdent: 'Koska txikiagoa',

--- a/public/lang/summernote-fa-IR.js
+++ b/public/lang/summernote-fa-IR.js
@@ -85,6 +85,9 @@
         fullscreen: 'نمایش تمام صفحه',
         codeview: 'مشاهده ی کد',
       },
+      modal: {
+        close: 'بستن',
+      },
       paragraph: {
         paragraph: 'پاراگراف',
         outdent: 'کاهش تو رفتگی',

--- a/public/lang/summernote-fi-FI.js
+++ b/public/lang/summernote-fi-FI.js
@@ -84,6 +84,9 @@
         fullscreen: 'Koko näyttö',
         codeview: 'HTML-näkymä',
       },
+      modal: {
+        close: 'Sulje',
+      },
       paragraph: {
         paragraph: 'Kappale',
         outdent: 'Pienennä sisennystä',

--- a/public/lang/summernote-fr-FR.js
+++ b/public/lang/summernote-fr-FR.js
@@ -85,6 +85,9 @@
         fullscreen: 'Plein écran',
         codeview: 'Afficher le code HTML',
       },
+      modal: {
+        close: 'Fermer',
+      },
       paragraph: {
         paragraph: 'Paragraphe',
         outdent: 'Diminuer le retrait',

--- a/public/lang/summernote-gl-ES.js
+++ b/public/lang/summernote-gl-ES.js
@@ -85,6 +85,9 @@
         fullscreen: 'Pantalla completa',
         codeview: 'Ver código fonte',
       },
+      modal: {
+        close: 'Pechar',
+      },
       paragraph: {
         paragraph: 'Parágrafo',
         outdent: 'Menos tabulación',

--- a/public/lang/summernote-he-IL.js
+++ b/public/lang/summernote-he-IL.js
@@ -85,6 +85,9 @@
         fullscreen: 'מסך מלא',
         codeview: 'תצוגת קוד',
       },
+      modal: {
+        close: 'סגור',
+      },
       paragraph: {
         paragraph: 'פסקה',
         outdent: 'הקטן כניסה',

--- a/public/lang/summernote-hr-HR.js
+++ b/public/lang/summernote-hr-HR.js
@@ -85,6 +85,9 @@
         fullscreen: 'Preko cijelog ekrana',
         codeview: 'Izvorni kôd',
       },
+      modal: {
+        close: 'Zatvori',
+      },
       paragraph: {
         paragraph: 'Paragraf',
         outdent: 'Smanji uvlačenje',

--- a/public/lang/summernote-hu-HU.js
+++ b/public/lang/summernote-hu-HU.js
@@ -85,6 +85,9 @@
         fullscreen: 'Teljes képernyő',
         codeview: 'Kód nézet',
       },
+      modal: {
+        close: 'Bezárás',
+      },
       paragraph: {
         paragraph: 'Bekezdés',
         outdent: 'Behúzás csökkentése',

--- a/public/lang/summernote-id-ID.js
+++ b/public/lang/summernote-id-ID.js
@@ -85,6 +85,9 @@
         fullscreen: 'Layar penuh',
         codeview: 'Kode HTML',
       },
+      modal: {
+        close: 'Tutup',
+      },
       paragraph: {
         paragraph: 'Paragraf',
         outdent: 'Outdent',

--- a/public/lang/summernote-it-IT.js
+++ b/public/lang/summernote-it-IT.js
@@ -85,6 +85,9 @@
         fullscreen: 'Modalità a tutto schermo',
         codeview: 'Visualizza codice',
       },
+      modal: {
+        close: 'Chiudi',
+      },
       paragraph: {
         paragraph: 'Paragrafo',
         outdent: 'Diminuisce il livello di rientro',

--- a/public/lang/summernote-ja-JP.js
+++ b/public/lang/summernote-ja-JP.js
@@ -85,6 +85,9 @@
         fullscreen: 'フルスクリーン',
         codeview: 'コード表示',
       },
+      modal: {
+        close: '閉じる',
+      },
       paragraph: {
         paragraph: '文章',
         outdent: '字上げ',

--- a/public/lang/summernote-ko-KR.js
+++ b/public/lang/summernote-ko-KR.js
@@ -86,6 +86,9 @@
         fullscreen: '전체 화면',
         codeview: '코드 보기',
       },
+      modal: {
+        close: '닫기',
+      },
       paragraph: {
         paragraph: '문단 정렬',
         outdent: '내어쓰기',

--- a/public/lang/summernote-lt-LT.js
+++ b/public/lang/summernote-lt-LT.js
@@ -85,6 +85,9 @@
         fullscreen: 'Viso ekrano režimas',
         codeview: 'HTML kodo peržiūra',
       },
+      modal: {
+        close: 'Uždaryti',
+      },
       paragraph: {
         paragraph: 'Pastraipa',
         outdent: 'Sumažinti įtrauką',

--- a/public/lang/summernote-lt-LV.js
+++ b/public/lang/summernote-lt-LV.js
@@ -85,6 +85,9 @@
         fullscreen: 'Pa visu ekrānu',
         codeview: 'HTML kods',
       },
+      modal: {
+        close: 'Aizvērt',
+      },
       paragraph: {
         paragraph: 'Paragrāfs',
         outdent: 'Samazināt atkāpi',

--- a/public/lang/summernote-mn-MN.js
+++ b/public/lang/summernote-mn-MN.js
@@ -87,6 +87,9 @@
         fullscreen: 'Дэлгэцийг дүүргэх',
         codeview: 'HTML-Code харуулах',
       },
+      modal: {
+        close: 'Хаалт',
+      },
       paragraph: {
         paragraph: 'Хэсэг',
         outdent: 'Догол мөр хасах',

--- a/public/lang/summernote-nb-NO.js
+++ b/public/lang/summernote-nb-NO.js
@@ -85,6 +85,9 @@
         fullscreen: 'Fullskjerm',
         codeview: 'HTML-visning',
       },
+      modal: {
+        close: 'Lukk',
+      },
       paragraph: {
         paragraph: 'Avsnitt',
         outdent: 'Tilbakerykk',

--- a/public/lang/summernote-nl-NL.js
+++ b/public/lang/summernote-nl-NL.js
@@ -85,6 +85,9 @@
         fullscreen: 'Volledig scherm',
         codeview: 'Bekijk Code',
       },
+      modal: {
+        close: 'sluiten',
+      },
       paragraph: {
         paragraph: 'Paragraaf',
         outdent: 'Inspringen verkleinen',

--- a/public/lang/summernote-pl-PL.js
+++ b/public/lang/summernote-pl-PL.js
@@ -85,6 +85,9 @@
         fullscreen: 'Pełny ekran',
         codeview: 'Źródło',
       },
+      modal: {
+        close: 'Zamknij',
+      },
       paragraph: {
         paragraph: 'Akapit',
         outdent: 'Zmniejsz wcięcie',

--- a/public/lang/summernote-pt-BR.js
+++ b/public/lang/summernote-pt-BR.js
@@ -86,6 +86,9 @@
         fullscreen: 'Tela cheia',
         codeview: 'Ver código-fonte',
       },
+      modal: {
+        close: 'Fechar',
+      },
       paragraph: {
         paragraph: 'Parágrafo',
         outdent: 'Menor tabulação',

--- a/public/lang/summernote-pt-PT.js
+++ b/public/lang/summernote-pt-PT.js
@@ -85,6 +85,9 @@
         fullscreen: 'Janela Completa',
         codeview: 'Ver código-fonte',
       },
+      modal: {
+        close: 'Fechar',
+      },
       paragraph: {
         paragraph: 'Parágrafo',
         outdent: 'Menor tabulação',

--- a/public/lang/summernote-ro-RO.js
+++ b/public/lang/summernote-ro-RO.js
@@ -85,6 +85,9 @@
         fullscreen: 'Măreşte',
         codeview: 'Sursă',
       },
+      modal: {
+        close: 'Închide',
+      },
       paragraph: {
         paragraph: 'Paragraf',
         outdent: 'Creşte identarea',

--- a/public/lang/summernote-ru-RU.js
+++ b/public/lang/summernote-ru-RU.js
@@ -85,6 +85,9 @@
         fullscreen: 'На весь экран',
         codeview: 'Исходный код',
       },
+      modal: {
+        close: 'Закрыть',
+      },
       paragraph: {
         paragraph: 'Параграф',
         outdent: 'Уменьшить отступ',

--- a/public/lang/summernote-sk-SK.js
+++ b/public/lang/summernote-sk-SK.js
@@ -85,6 +85,9 @@
         fullscreen: 'Celá obrazovka',
         codeview: 'HTML kód',
       },
+      modal: {
+        close: 'Zavrieť',
+      },
       paragraph: {
         paragraph: 'Odsek',
         outdent: 'Zväčšiť odsadenie',

--- a/public/lang/summernote-sl-SI.js
+++ b/public/lang/summernote-sl-SI.js
@@ -85,6 +85,9 @@
         fullscreen: 'Celozaslonski način',
         codeview: 'Pregled HTML kode',
       },
+      modal: {
+        close: 'Zapri',
+      },
       paragraph: {
         paragraph: 'Slogi odstavka',
         outdent: 'Zmanjšaj odmik',

--- a/public/lang/summernote-sr-RS-Latin.js
+++ b/public/lang/summernote-sr-RS-Latin.js
@@ -85,6 +85,9 @@
         fullscreen: 'Preko celog ekrana',
         codeview: 'Izvorni kod',
       },
+      modal: {
+        close: 'Zatvori',
+      },
       paragraph: {
         paragraph: 'Paragraf',
         outdent: 'Smanji uvlačenje',

--- a/public/lang/summernote-sr-RS.js
+++ b/public/lang/summernote-sr-RS.js
@@ -85,6 +85,9 @@
         fullscreen: 'Преко целог екрана',
         codeview: 'Изворни код',
       },
+      modal: {
+        close: 'Затвори',
+      },
       paragraph: {
         paragraph: 'Параграф',
         outdent: 'Смањи увлачење',

--- a/public/lang/summernote-sv-SE.js
+++ b/public/lang/summernote-sv-SE.js
@@ -85,6 +85,9 @@
         fullscreen: 'Fullskärm',
         codeview: 'HTML-visning',
       },
+      modal: {
+        close: 'Stäng',
+      },
       paragraph: {
         paragraph: 'Justera text',
         outdent: 'Minska indrag',

--- a/public/lang/summernote-ta-IN.js
+++ b/public/lang/summernote-ta-IN.js
@@ -85,6 +85,9 @@
         fullscreen: 'முழுத்திரை',
         codeview: 'நிரலாக்க காட்சி',
       },
+      modal: {
+        close: 'மூடு',
+      },
       paragraph: {
         paragraph: 'பத்தி',
         outdent: 'வெளித்தள்ளு',

--- a/public/lang/summernote-th-TH.js
+++ b/public/lang/summernote-th-TH.js
@@ -85,6 +85,9 @@
         fullscreen: 'ขยายเต็มหน้าจอ',
         codeview: 'ซอร์สโค้ด',
       },
+      modal: {
+        close: 'ปิด',
+      },
       paragraph: {
         paragraph: 'ย่อหน้า',
         outdent: 'เยื้องซ้าย',

--- a/public/lang/summernote-tr-TR.js
+++ b/public/lang/summernote-tr-TR.js
@@ -85,6 +85,9 @@
         fullscreen: 'Tam ekran',
         codeview: 'HTML Kodu',
       },
+      modal: {
+        close: 'Kapat',
+      },
       paragraph: {
         paragraph: 'Paragraf',
         outdent: 'Girintiyi artır',

--- a/public/lang/summernote-uk-UA.js
+++ b/public/lang/summernote-uk-UA.js
@@ -85,6 +85,9 @@
         fullscreen: 'На весь екран',
         codeview: 'Початковий код',
       },
+      modal: {
+        close: 'Закрити',
+      },
       paragraph: {
         paragraph: 'Параграф',
         outdent: 'Зменшити відступ',

--- a/public/lang/summernote-uz-UZ.js
+++ b/public/lang/summernote-uz-UZ.js
@@ -75,6 +75,9 @@
         fullscreen: 'Бутун экран бўйича',
         codeview: 'Бошланғич код',
       },
+      modal: {
+        close: 'Ёпиқ',
+      },
       paragraph: {
         paragraph: 'Параграф',
         outdent: 'Орқага қайтишни камайтириш',

--- a/public/lang/summernote-vi-VN.js
+++ b/public/lang/summernote-vi-VN.js
@@ -85,6 +85,9 @@
         fullscreen: 'Toàn Màn hình',
         codeview: 'Xem Code',
       },
+      modal: {
+        close: 'Đóng',
+      },
       paragraph: {
         paragraph: 'Canh lề',
         outdent: 'Dịch sang trái',

--- a/public/lang/summernote-zh-CN.js
+++ b/public/lang/summernote-zh-CN.js
@@ -85,6 +85,9 @@
         fullscreen: '全屏',
         codeview: '源代码',
       },
+      modal: {
+        close: '关闭',
+      },
       paragraph: {
         paragraph: '段落',
         outdent: '减少缩进',

--- a/public/lang/summernote-zh-TW.js
+++ b/public/lang/summernote-zh-TW.js
@@ -85,6 +85,9 @@
         fullscreen: '全螢幕',
         codeview: '原始碼',
       },
+      modal: {
+        close: '關閉',
+      },
       paragraph: {
         paragraph: '段落',
         outdent: '取消縮排',

--- a/src/js/module/HelpDialog.js
+++ b/src/js/module/HelpDialog.js
@@ -27,6 +27,7 @@ export default class HelpDialog {
       fade: this.options.dialogsFade,
       body: this.createShortcutList(),
       footer: body,
+      lang: this.lang,
       callback: ($node) => {
         $node.find('.modal-body,.note-modal-body').css({
           'max-height': 300,

--- a/src/js/module/ImageDialog.js
+++ b/src/js/module/ImageDialog.js
@@ -35,7 +35,7 @@ export default class ImageDialog {
       '</div>',
     ].join('');
     const buttonClass = 'btn btn-primary note-btn note-btn-primary note-image-btn';
-    const footer = `<button type="button" href="#" class="${buttonClass}" disabled>${this.lang.image.insert}</button>`;
+    const footer = `<button type="button" class="${buttonClass}" disabled>${this.lang.image.insert}</button>`;
 
     this.$dialog = this.ui.dialog({
       title: this.lang.image.insert,

--- a/src/js/module/ImageDialog.js
+++ b/src/js/module/ImageDialog.js
@@ -35,7 +35,7 @@ export default class ImageDialog {
       '</div>',
     ].join('');
     const buttonClass = 'btn btn-primary note-btn note-btn-primary note-image-btn';
-    const footer = `<input type="button" href="#" class="${buttonClass}" value="${this.lang.image.insert}" disabled>`;
+    const footer = `<button type="button" href="#" class="${buttonClass}" disabled>${this.lang.image.insert}</button>`;
 
     this.$dialog = this.ui.dialog({
       title: this.lang.image.insert,

--- a/src/js/module/ImageDialog.js
+++ b/src/js/module/ImageDialog.js
@@ -42,6 +42,7 @@ export default class ImageDialog {
       fade: this.options.dialogsFade,
       body: body,
       footer: footer,
+      lang: this.lang,
     }).render().appendTo($container);
   }
 

--- a/src/js/module/LinkDialog.js
+++ b/src/js/module/LinkDialog.js
@@ -41,7 +41,7 @@ export default class LinkDialog {
     ].join('');
 
     const buttonClass = 'btn btn-primary note-btn note-btn-primary note-link-btn';
-    const footer = `<button type="button" href="#" class="${buttonClass}" disabled>${this.lang.link.insert}</button>`;
+    const footer = `<button type="button" class="${buttonClass}" disabled>${this.lang.link.insert}</button>`;
 
     this.$dialog = this.ui.dialog({
       className: 'link-dialog',

--- a/src/js/module/LinkDialog.js
+++ b/src/js/module/LinkDialog.js
@@ -41,7 +41,7 @@ export default class LinkDialog {
     ].join('');
 
     const buttonClass = 'btn btn-primary note-btn note-btn-primary note-link-btn';
-    const footer = `<input type="button" href="#" class="${buttonClass}" value="${this.lang.link.insert}" disabled>`;
+    const footer = `<button type="button" href="#" class="${buttonClass}" disabled>${this.lang.link.insert}</button>`;
 
     this.$dialog = this.ui.dialog({
       className: 'link-dialog',

--- a/src/js/module/LinkDialog.js
+++ b/src/js/module/LinkDialog.js
@@ -49,6 +49,7 @@ export default class LinkDialog {
       fade: this.options.dialogsFade,
       body: body,
       footer: footer,
+      lang: this.lang,
     }).render().appendTo($container);
   }
 

--- a/src/js/module/VideoDialog.js
+++ b/src/js/module/VideoDialog.js
@@ -22,7 +22,7 @@ export default class VideoDialog {
       '</div>',
     ].join('');
     const buttonClass = 'btn btn-primary note-btn note-btn-primary note-video-btn';
-    const footer = `<input type="button" href="#" class="${buttonClass}" value="${this.lang.video.insert}" disabled>`;
+    const footer = `<button type="button" href="#" class="${buttonClass}" disabled>${this.lang.video.insert}</button>`;
 
     this.$dialog = this.ui.dialog({
       title: this.lang.video.insert,

--- a/src/js/module/VideoDialog.js
+++ b/src/js/module/VideoDialog.js
@@ -29,6 +29,7 @@ export default class VideoDialog {
       fade: this.options.dialogsFade,
       body: body,
       footer: footer,
+      lang: this.lang,
     }).render().appendTo($container);
   }
 

--- a/src/js/module/VideoDialog.js
+++ b/src/js/module/VideoDialog.js
@@ -22,7 +22,7 @@ export default class VideoDialog {
       '</div>',
     ].join('');
     const buttonClass = 'btn btn-primary note-btn note-btn-primary note-video-btn';
-    const footer = `<button type="button" href="#" class="${buttonClass}" disabled>${this.lang.video.insert}</button>`;
+    const footer = `<button type="button" class="${buttonClass}" disabled>${this.lang.video.insert}</button>`;
 
     this.$dialog = this.ui.dialog({
       title: this.lang.video.insert,

--- a/src/styles/bs3/summernote-bs3.js
+++ b/src/styles/bs3/summernote-bs3.js
@@ -70,12 +70,12 @@ const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false
   $node.attr({
     'aria-label': options.title,
   });
-  const closeLabel = options.lang && options.lang.shortcut && options.lang.shortcut.close || 'Close';
+  const closeLabel = options.lang?.shortcut?.close ?? 'Close';
   $node.html([
     '<div class="modal-dialog">',
       '<div class="modal-content">',
         (options.title ? '<div class="modal-header">' +
-          '<button type="button" class="close" data-dismiss="modal" aria-label="' + closeLabel + '" aria-hidden="true">&times;</button>' +
+          '<button type="button" class="close" data-dismiss="modal" aria-label="' + closeLabel + '"><span aria-hidden="true">&times;</span></button>' +
           '<h4 class="modal-title">' + options.title + '</h4>' +
         '</div>' : ''),
         '<div class="modal-body">' + options.body + '</div>',

--- a/src/styles/bs3/summernote-bs3.js
+++ b/src/styles/bs3/summernote-bs3.js
@@ -70,11 +70,12 @@ const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false
   $node.attr({
     'aria-label': options.title,
   });
+  const closeLabel = options.lang && options.lang.shortcut && options.lang.shortcut.close || 'Close';
   $node.html([
     '<div class="modal-dialog">',
       '<div class="modal-content">',
         (options.title ? '<div class="modal-header">' +
-          '<button type="button" class="close" data-dismiss="modal" aria-label="Close" aria-hidden="true">&times;</button>' +
+          '<button type="button" class="close" data-dismiss="modal" aria-label="' + closeLabel + '" aria-hidden="true">&times;</button>' +
           '<h4 class="modal-title">' + options.title + '</h4>' +
         '</div>' : ''),
         '<div class="modal-body">' + options.body + '</div>',

--- a/src/styles/bs3/summernote-bs3.js
+++ b/src/styles/bs3/summernote-bs3.js
@@ -70,7 +70,7 @@ const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false
   $node.attr({
     'aria-label': options.title,
   });
-  const closeLabel = options.lang?.shortcut?.close ?? 'Close';
+  const closeLabel = options.lang?.modal?.close ?? 'Close';
   $node.html([
     '<div class="modal-dialog">',
       '<div class="modal-content">',

--- a/src/styles/bs4/summernote-bs4.js
+++ b/src/styles/bs4/summernote-bs4.js
@@ -110,7 +110,7 @@ const dialog = renderer.create(
     $node.attr({
       'aria-label': options.title,
     });
-    const closeLabel = options.lang?.shortcut?.close ?? 'Close';
+    const closeLabel = options.lang?.modal?.close ?? 'Close';
     $node.html(
       [
         '<div class="modal-dialog">',

--- a/src/styles/bs4/summernote-bs4.js
+++ b/src/styles/bs4/summernote-bs4.js
@@ -110,7 +110,7 @@ const dialog = renderer.create(
     $node.attr({
       'aria-label': options.title,
     });
-    const closeLabel = options.lang && options.lang.shortcut && options.lang.shortcut.close || 'Close';
+    const closeLabel = options.lang?.shortcut?.close ?? 'Close';
     $node.html(
       [
         '<div class="modal-dialog">',
@@ -120,7 +120,7 @@ const dialog = renderer.create(
             '<h4 class="modal-title">' +
             options.title +
             '</h4>' +
-            '<button type="button" class="close" data-dismiss="modal" aria-label="' + closeLabel + '" aria-hidden="true">&times;</button>' +
+            '<button type="button" class="close" data-dismiss="modal" aria-label="' + closeLabel + '"><span aria-hidden="true">&times;</span></button>' +
             '</div>'
           : '',
         '<div class="modal-body">' + options.body + '</div>',

--- a/src/styles/bs4/summernote-bs4.js
+++ b/src/styles/bs4/summernote-bs4.js
@@ -110,6 +110,7 @@ const dialog = renderer.create(
     $node.attr({
       'aria-label': options.title,
     });
+    const closeLabel = options.lang && options.lang.shortcut && options.lang.shortcut.close || 'Close';
     $node.html(
       [
         '<div class="modal-dialog">',
@@ -119,7 +120,7 @@ const dialog = renderer.create(
             '<h4 class="modal-title">' +
             options.title +
             '</h4>' +
-            '<button type="button" class="close" data-dismiss="modal" aria-label="Close" aria-hidden="true">&times;</button>' +
+            '<button type="button" class="close" data-dismiss="modal" aria-label="' + closeLabel + '" aria-hidden="true">&times;</button>' +
             '</div>'
           : '',
         '<div class="modal-body">' + options.body + '</div>',

--- a/src/styles/bs5/summernote-bs5.js
+++ b/src/styles/bs5/summernote-bs5.js
@@ -70,12 +70,13 @@ const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false
   $node.attr({
     'aria-label': options.title,
   });
+  const closeLabel = options.lang && options.lang.shortcut && options.lang.shortcut.close || 'Close';
   $node.html([
     '<div class="modal-dialog">',
       '<div class="modal-content">',
         (options.title ? '<div class="modal-header">' +
           '<h4 class="modal-title">' + options.title + '</h4>' +
-          '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close" aria-hidden="true"></button>' +
+          '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="' + closeLabel + '" aria-hidden="true"></button>' +
         '</div>' : ''),
         '<div class="modal-body">' + options.body + '</div>',
         (options.footer ? '<div class="modal-footer">' + options.footer + '</div>' : ''),

--- a/src/styles/bs5/summernote-bs5.js
+++ b/src/styles/bs5/summernote-bs5.js
@@ -70,13 +70,13 @@ const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false
   $node.attr({
     'aria-label': options.title,
   });
-  const closeLabel = options.lang && options.lang.shortcut && options.lang.shortcut.close || 'Close';
+  const closeLabel = options.lang?.shortcut?.close ?? 'Close';
   $node.html([
     '<div class="modal-dialog">',
       '<div class="modal-content">',
         (options.title ? '<div class="modal-header">' +
           '<h4 class="modal-title">' + options.title + '</h4>' +
-          '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="' + closeLabel + '" aria-hidden="true"></button>' +
+          '<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="' + closeLabel + '"></button>' +
         '</div>' : ''),
         '<div class="modal-body">' + options.body + '</div>',
         (options.footer ? '<div class="modal-footer">' + options.footer + '</div>' : ''),

--- a/src/styles/bs5/summernote-bs5.js
+++ b/src/styles/bs5/summernote-bs5.js
@@ -70,7 +70,7 @@ const dialog = renderer.create('<div class="modal note-modal" aria-hidden="false
   $node.attr({
     'aria-label': options.title,
   });
-  const closeLabel = options.lang?.shortcut?.close ?? 'Close';
+  const closeLabel = options.lang?.modal?.close ?? 'Close';
   $node.html([
     '<div class="modal-dialog">',
       '<div class="modal-content">',

--- a/src/styles/lite/summernote-lite.js
+++ b/src/styles/lite/summernote-lite.js
@@ -478,7 +478,7 @@ const dialog = renderer.create(
     $node.attr({
       'aria-label': options.title,
     });
-    const closeLabel = options.lang?.shortcut?.close ?? 'Close';
+    const closeLabel = options.lang?.modal?.close ?? 'Close';
     $node.html(
       [
         '<div class="note-modal-content">',

--- a/src/styles/lite/summernote-lite.js
+++ b/src/styles/lite/summernote-lite.js
@@ -478,12 +478,12 @@ const dialog = renderer.create(
     $node.attr({
       'aria-label': options.title,
     });
-    const closeLabel = options.lang && options.lang.shortcut && options.lang.shortcut.close || 'Close';
+    const closeLabel = options.lang?.shortcut?.close ?? 'Close';
     $node.html(
       [
         '<div class="note-modal-content">',
         options.title
-          ? '<div class="note-modal-header"><button type="button" class="close" aria-label="' + closeLabel + '" aria-hidden="true"><i class="note-icon-close"></i></button><h4 class="note-modal-title">' +
+          ? '<div class="note-modal-header"><button type="button" class="close" aria-label="' + closeLabel + '"><i class="note-icon-close" aria-hidden="true"></i></button><h4 class="note-modal-title">' +
             options.title +
             '</h4></div>'
           : '',

--- a/src/styles/lite/summernote-lite.js
+++ b/src/styles/lite/summernote-lite.js
@@ -478,11 +478,12 @@ const dialog = renderer.create(
     $node.attr({
       'aria-label': options.title,
     });
+    const closeLabel = options.lang && options.lang.shortcut && options.lang.shortcut.close || 'Close';
     $node.html(
       [
         '<div class="note-modal-content">',
         options.title
-          ? '<div class="note-modal-header"><button type="button" class="close" aria-label="Close" aria-hidden="true"><i class="note-icon-close"></i></button><h4 class="note-modal-title">' +
+          ? '<div class="note-modal-header"><button type="button" class="close" aria-label="' + closeLabel + '" aria-hidden="true"><i class="note-icon-close"></i></button><h4 class="note-modal-title">' +
             options.title +
             '</h4></div>'
           : '',
@@ -521,6 +522,7 @@ const videoDialog = function(opt) {
     fade: opt.fade,
     body: body,
     footer: footer,
+    lang: opt.lang,
   }).render();
 };
 
@@ -558,6 +560,7 @@ const imageDialog = function(opt) {
     fade: opt.fade,
     body: body,
     footer: footer,
+    lang: opt.lang,
   }).render();
 };
 
@@ -604,6 +607,7 @@ const linkDialog = function(opt) {
     fade: opt.fade,
     body: body,
     footer: footer,
+    lang: opt.lang,
   }).render();
 };
 


### PR DESCRIPTION
<!--
Thank you for taking your time to contribute to Summernote.
Please fill out the information below to help us review your pull request.
After you have filled out the information, please check the boxes below to confirm that you have completed the necessary steps.
-->

#### What does this PR do / why do we need it?

- language is added to dialogs options, in order to translate aria-label for close Buttons. Improves accessibility
- Dialog buttons are changed from input[type="button"] to button[type="button"] for improved accessibility

#### Which issue(s) this PR fixes?

I've been integrating Summernote into production applications for some time and during that work I identified and fixed several issues. I'd like to contribute those fixes back to the project rather than keeping them as local patches.
This first PR addresses two small accessibility issues I encountered: hardcoded aria-label on dialog close buttons (not part of the i18n system) and the use of input[type="button"] instead of the semantically correct button[type="button"] in dialogs.

#### Any background context you want to provide?

Greetings, I'm a senior web developer with 18+ years of experience, currently integrating Summernote into enterprise applications and adding new features through extensions, serving multiple german universities.

#### Screenshot (if appropriate)

- N/A

### Checklist

- [X] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [X] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Accessibility Improvements**
  * Modal close controls now use dynamic, localized labels and improved markup for screen-reader clarity.

* **Localization**
  * Dialogs (help, image, link, video) now receive and apply the current language for consistent translations.
  * Added modal close translations across many locale packs to surface a localized close label.

* **Style**
  * Footer controls updated to use semantic button elements for better browser and assistive-technology compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->