### PR TITLE
Indent and outdent for lists with Tab

### DIFF
--- a/src/js/editing/Bullet.js
+++ b/src/js/editing/Bullet.js
@@ -31,13 +31,21 @@ export default class Bullet {
     $.each(clustereds, (idx, paras) => {
       const head = lists.head(paras);
       if (dom.isLi(head)) {
-        const previousList = this.findList(head.previousSibling);
-        if (previousList) {
-          paras.map((para) => previousList.appendChild(para));
-        } else {
-          this.wrapList(paras, head.parentNode.nodeName);
-          paras.map((para) => para.parentNode).map((para) => this.appendToPrevious(para));
+        // find previous li sibling (not just any sibling)
+        let prevLi = head.previousSibling;
+        while (prevLi && !dom.isLi(prevLi)) {
+          prevLi = prevLi.previousSibling;
         }
+        if (prevLi) {
+          const previousList = this.findList(prevLi);
+          if (previousList) {
+            paras.map((para) => previousList.appendChild(para));
+          } else {
+            this.wrapList(paras, head.parentNode.nodeName);
+            paras.map((para) => para.parentNode).map((para) => prevLi.appendChild(para));
+          }
+        }
+        // if no previous li exists, do nothing
       } else {
         $.each(paras, (idx, para) => {
           $(para).css('marginLeft', (idx, val) => {
@@ -62,7 +70,13 @@ export default class Bullet {
     $.each(clustereds, (idx, paras) => {
       const head = lists.head(paras);
       if (dom.isLi(head)) {
-        this.releaseList([paras]);
+        const parentList = head.parentNode;
+        const isNestedList = parentList && dom.ancestor(parentList.parentNode, dom.isLi);
+        if (isNestedList) {
+          this.releaseList([paras], false);
+        } else {
+          this.releaseList([paras]);
+        }
       } else {
         $.each(paras, (idx, para) => {
           $(para).css('marginLeft', (idx, val) => {
@@ -256,7 +270,7 @@ export default class Bullet {
    * @return {HTMLNode}
    */
   appendToPrevious(node) {
-    return node.previousSibling ? dom.appendChildNodes(node.previousSibling, [node]) : this.wrapList([node], 'LI');
+    return node.previousSibling && dom.isLi(node.previousSibling) ? dom.appendChildNodes(node.previousSibling, [node]) : this.wrapList([node], 'LI');
   }
 
   /**
@@ -268,7 +282,7 @@ export default class Bullet {
    * @return {Array[]}
    */
   findList(node) {
-    return node ? lists.find(node.children, (child) => ['OL', 'UL'].indexOf(child.nodeName) > -1) : null;
+    return node && node.children ? lists.find(node.children, (child) => ['OL', 'UL'].indexOf(child.nodeName) > -1) : null;
   }
 
   /**

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -463,6 +463,18 @@ export default class Editor {
     const eventName = keyMap[keys.join('+')];
 
     if (keyName === 'TAB' && !this.options.tabDisable) {
+      // check if in a list - always handle TAB/SHIFT+TAB in lists
+      const rng = this.getLastRange();
+      if (rng) {
+        const node = rng.sc || rng.ec;
+        const listItem = dom.ancestor(node, dom.isLi);
+        if (listItem && eventName) {
+          if (this.context.invoke(eventName) !== false) {
+            event.preventDefault();
+            return true;
+          }
+        }
+      }
       this.afterCommand();
     } else if (eventName) {
       if (this.context.invoke(eventName) !== false) {
@@ -703,6 +715,16 @@ export default class Editor {
     if (rng.isCollapsed() && rng.isOnCell()) {
       this.table.tab(rng);
     } else {
+      // check if in a list item → indent
+      const node = rng.sc || rng.ec;
+      const listItem = dom.ancestor(node, dom.isLi);
+      if (listItem) {
+        this.beforeCommand();
+        this.bullet.indent(this.editable);
+        this.afterCommand();
+        return;
+      }
+
       if (this.options.tabSize === 0) {
         return false;
       }
@@ -723,6 +745,32 @@ export default class Editor {
     if (rng.isCollapsed() && rng.isOnCell()) {
       this.table.tab(rng, true);
     } else {
+      // check if in a list item, always handle tab key in lists
+      const node = rng.sc || rng.ec;
+      const listItem = dom.ancestor(node, dom.isLi);
+      if (listItem) {
+        const text = $(listItem).text().trim();
+        const isEmpty = text.length === 0 || listItem.innerHTML.trim() === '' || listItem.innerHTML.trim() === '<br>';
+        if (isEmpty) {
+          const parentList = listItem.parentNode;
+          const isNestedList = parentList && dom.ancestor(parentList.parentNode, dom.isLi);
+          if (isNestedList) {
+            this.beforeCommand();
+            this.bullet.outdent(this.editable);
+            this.afterCommand();
+          } else {
+            this.beforeCommand();
+            this.bullet.releaseList([[listItem]], true);
+            this.afterCommand();
+          }
+        } else {
+          this.beforeCommand();
+          this.bullet.outdent(this.editable);
+          this.afterCommand();
+        }
+        return;
+      }
+
       if (this.options.tabSize === 0) {
         return false;
       }

--- a/src/styles/summernote/common.scss
+++ b/src/styles/summernote/common.scss
@@ -74,8 +74,8 @@ $img-margin-right: 10px;
       ol {
         counter-reset: ol-item;
       }
-      li{
-        margin-bottom: 0.25em;
+      li {
+        margin-top: 0.5em;
       }
 
       ol > li {
@@ -114,9 +114,9 @@ $img-margin-right: 10px;
         }
       } 
       ol ol ol ol ol ol > li {
-        padding-left: 6em;
+        padding-left: 7em;
         &::before {
-          width: 5.5em; 
+          width: 6.5em; 
         }
       } 
 

--- a/src/styles/summernote/common.scss
+++ b/src/styles/summernote/common.scss
@@ -63,6 +63,90 @@ $img-margin-right: 10px;
       img.note-float-right {
         margin-left: $img-margin-left;
       }
+
+      // === List styles ===
+      ol, ul {
+        list-style: none;
+        padding-inline-start: 20px;
+      }
+
+      // Ordered Lists: generalized via CSS counters() — works at any nesting depth
+      ol {
+        counter-reset: ol-item;
+      }
+      li{
+        margin-bottom: 0.25em;
+      }
+
+      ol > li {
+        counter-increment: ol-item;
+        position: relative;
+        padding-left: 3em;
+        line-height: 1.5;
+
+        &::before {
+          content: counters(ol-item, ".") ".";
+          position: absolute;
+          left: 0;
+          width: 2.5em;
+          text-align: right;
+          padding-right: 0.4em;
+          line-height: inherit;
+        }
+      }
+
+      ol ol ol > li {
+        padding-left: 4em;
+        &::before {
+          width: 3.5em; 
+        }
+      }  
+      ol ol ol ol > li {
+        padding-left: 5em;
+        &::before {
+          width: 4.5em; 
+        }
+      } 
+      ol ol ol ol ol > li {
+        padding-left: 6em;
+        &::before {
+          width: 5.5em; 
+        }
+      } 
+      ol ol ol ol ol ol > li {
+        padding-left: 6em;
+        &::before {
+          width: 5.5em; 
+        }
+      } 
+
+      // Unordered Lists
+      ul > li {
+        position: relative;
+        padding-left: 1.75em;
+        line-height: 1.5;
+
+        &::before {
+          position: absolute;
+          left: 0.1em;
+          line-height: inherit;
+        }
+      }
+
+      ul > li::before          { content: "•"; }
+      ul ul > li::before       { content: "◦"; }
+      ul ul ul > li::before    { content: "▪"; }
+
+    }
+  }
+}
+
+// Fix Firefox cursor position in empty list items
+@-moz-document url-prefix() {
+  .note-editor .note-editing-area .note-editable {
+    ul > li:has(> br:only-child),
+    ol > li:has(> br:only-child) {
+      align-items: baseline;
     }
   }
 }

--- a/src/styles/summernote/common.scss
+++ b/src/styles/summernote/common.scss
@@ -82,7 +82,7 @@ $img-margin-right: 10px;
         counter-increment: ol-item;
         position: relative;
         padding-left: 3em;
-        line-height: 1.5;
+        line-height: 1.2;
 
         &::before {
           content: counters(ol-item, ".") ".";
@@ -124,7 +124,7 @@ $img-margin-right: 10px;
       ul > li {
         position: relative;
         padding-left: 1.75em;
-        line-height: 1.5;
+        line-height: 1.2;
 
         &::before {
           position: absolute;

--- a/test/base/module/Editor.spec.js
+++ b/test/base/module/Editor.spec.js
@@ -138,16 +138,52 @@ describe('Editor', () => {
     });
 
     it('should indent and outdent list', async() => {
-      editor.insertOrderedList();
-      await expectContentsAwait(context, '<ol><li>hello</li></ol>');
+      context.invoke('code', '<ol><li>first</li><li>hello</li></ol>');
+      $editable.appendTo('body');
+      var secondLi = $editable.find('li').eq(1)[0];
+      var textNode = secondLi.firstChild;
+      editor.setLastRange(range.create(textNode, 0, textNode, 0).select());
+      await nextTick();
+
       editor.indent();
-      await expectContentsAwait(context, '<ol><li><ol><li>hello</li></ol></li></ol>');
-      editor.indent();
-      await expectContentsAwait(context, '<ol><li><ol><li><ol><li>hello</li></ol></li></ol></li></ol>');
+      await expectContentsAwait(context, '<ol><li>first<ol><li>hello</li></ol></li></ol>');
       editor.outdent();
-      await expectContentsAwait(context, '<ol><li><ol><li>hello</li></ol></li></ol>');
-      editor.outdent();
-      await expectContentsAwait(context, '<ol><li>hello</li></ol>');
+      await expectContentsAwait(context, '<ol><li>first</li><li>hello</li></ol>');
+    });
+  });
+
+  describe('tab and untab in list', () => {
+    it('should not indent the first list item when there is no previous sibling', async() => {
+      context.invoke('code', '<ul><li>first</li><li>second</li></ul>');
+      $editable.appendTo('body');
+      var firstLi = $editable.find('li').eq(0)[0];
+      var textNode = firstLi.firstChild;
+      editor.setLastRange(range.create(textNode, 0, textNode, 0).select());
+      await nextTick();
+      editor.tab();
+      await expectContentsAwait(context, '<ul><li>first</li><li>second</li></ul>');
+    });
+
+    it('should indent a list item under the previous sibling on tab', async() => {
+      context.invoke('code', '<ul><li>first</li><li>second</li></ul>');
+      $editable.appendTo('body');
+      var secondLi = $editable.find('li').eq(1)[0];
+      var textNode = secondLi.firstChild;
+      editor.setLastRange(range.create(textNode, 0, textNode, 0).select());
+      await nextTick();
+      editor.tab();
+      await expectContentsAwait(context, '<ul><li>first<ul><li>second</li></ul></li></ul>');
+    });
+
+    it('should outdent a nested list item one level on shift+tab', async() => {
+      context.invoke('code', '<ul><li>first<ul><li>nested</li></ul></li></ul>');
+      $editable.appendTo('body');
+      var nestedLi = $editable.find('li').eq(1)[0];
+      var textNode = nestedLi.firstChild;
+      editor.setLastRange(range.create(textNode, 0, textNode, 0).select());
+      await nextTick();
+      editor.untab();
+      await expectContentsAwait(context, '<ul><li>first</li><li>nested</li></ul>');
     });
   });
 


### PR DESCRIPTION
<!--
Thank you for taking your time to contribute to Summernote.
Please fill out the information below to help us review your pull request.
After you have filled out the information, please check the boxes below to confirm that you have completed the necessary steps.
-->

#### What does this PR do / why do we need it?

- fixes intending of list element withoput previous sibling.
- Implements Tab / Shift+Tab handling inside list items: Tab indents the current item under the previous sibling, Shift+Tab outdents it one level. Previously Tab would jump focus out of the editor instead.

- Fixes ordered and unordered list marker rendering: browsers render list-style-position: inside markers inline with the text, which causes wrapped lines to start below the marker instead of the first character. Replaced with position: absolute counter markers so that all lines align consistently regardless of nesting depth.

- Existing test should indent and outdent list — adjusted: now requires two items, because the first item (no previous sibling) can no longer be indented. Now it tests meaningful behavior.

3 new tests in tab and untab in list:

First item: Tab does nothing (no previous li)
Second item: Tab indents under the first
Nested item: Shift+Tab moves it one level back up

#### Which issue(s) this PR fixes?

Fixes #4761

#### Any background context you want to provide?

- 

#### Screenshot (if appropriate)
This showcases the styling issues with list-style-position: inside; before and how it looks now after the CSS fix, while keeping list-style-position: inside for technical reasons.
<img alt="ListBulletsSummernote" src="https://github.com/user-attachments/assets/10e3d70c-9621-420a-8481-bab97824521a" />

### Checklist

- [X] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced Tab and Shift+Tab keyboard shortcuts for improved list indentation and outdentation.
  * Improved nested list detection and handling for smarter list navigation.

* **Bug Fixes**
  * Fixed edge cases in list manipulation to prevent errors.

* **Style**
  * Added comprehensive visual styling for ordered and unordered lists with proper indentation and marker display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->