### PR TITLE
Replace several jQuery calls with native equivalents for compatibility with jQuery 4.0.0

### DIFF
--- a/public/plugin/databasic/summernote-ext-databasic.js
+++ b/public/plugin/databasic/summernote-ext-databasic.js
@@ -213,13 +213,13 @@
 
           self.updateNode(info);
         })
-        .fail(function() {
+        .catch(function() {
           context.invoke('editor.restoreRange');
         });
     };
 
     self.openDialog = function(info) {
-      return $.Deferred(function(deferred) {
+      return new Promise(function(resolve, reject) {
         var $inpTest = self.$dialog.find('.ext-databasic-test');
         var $saveBtn = self.$dialog.find('.ext-databasic-save');
         var onKeyup = function(event) {
@@ -240,7 +240,7 @@
             .on('click', function(event) {
               event.preventDefault();
 
-              deferred.resolve({ test: $inpTest.val() });
+              resolve({ test: $inpTest.val() });
             });
 
           // init save button
@@ -251,9 +251,7 @@
           $inpTest.off('input keyup');
           $saveBtn.off('click');
 
-          if (deferred.state() === 'pending') {
-            deferred.reject();
-          }
+          reject();
         });
 
         ui.showDialog(self.$dialog);

--- a/public/plugin/specialchars/summernote-ext-specialchars.js
+++ b/public/plugin/specialchars/summernote-ext-specialchars.js
@@ -137,7 +137,7 @@
             // insert video node
             context.invoke('editor.insertNode', $node);
           }
-        }).fail(function() {
+        }).catch(function() {
           context.invoke('editor.restoreRange');
         });
       };
@@ -149,7 +149,7 @@
        * @return {Promise}
        */
       this.showSpecialCharDialog = function(text) {
-        return $.Deferred(function(deferred) {
+        return new Promise(function(resolve, reject) {
           var $specialCharDialog = self.$dialog;
           var $specialCharNode = $specialCharDialog.find('.note-specialchar-node');
           var $selectedNode = null;
@@ -239,7 +239,7 @@
               return;
             }
 
-            deferred.resolve(decodeURIComponent($selectedNode.find('button').attr('data-value')));
+            resolve(decodeURIComponent($selectedNode.find('button').attr('data-value')));
             $specialCharDialog.modal('hide');
           }
 
@@ -286,7 +286,7 @@
 
             $specialCharNode.on('click', function(event) {
               event.preventDefault();
-              deferred.resolve(decodeURIComponent($(event.currentTarget).find('button').attr('data-value')));
+              resolve(decodeURIComponent($(event.currentTarget).find('button').attr('data-value')));
               ui.hideDialog(self.$dialog);
             });
           });
@@ -298,9 +298,7 @@
 
             $(document).off('keydown', keyDownEventHandler);
 
-            if (deferred.state() === 'pending') {
-              deferred.reject();
-            }
+            reject();
           });
 
           ui.showDialog(self.$dialog);

--- a/src/js/Context.js
+++ b/src/js/Context.js
@@ -58,7 +58,7 @@ export default class Context {
 
   _initialize() {
     // set own id
-    this.options.id = func.uniqueId($.now());
+    this.options.id = func.uniqueId(Date.now());
     // set default container for tooltips, popovers, and dialogs
     this.options.container = this.options.container || this.layoutInfo.editor;
 

--- a/src/js/core/async.js
+++ b/src/js/core/async.js
@@ -9,17 +9,17 @@ import $ from 'jquery';
  * @return {Promise} - then: dataUrl
  */
 export function readFileAsDataURL(file) {
-  return $.Deferred((deferred) => {
+  return new Promise((resolve, reject) => {
     $.extend(new FileReader(), {
       onload: (event) => {
         const dataURL = event.target.result;
-        deferred.resolve(dataURL);
+        resolve(dataURL);
       },
       onerror: (err) => {
-        deferred.reject(err);
+        reject(err);
       },
     }).readAsDataURL(file);
-  }).promise();
+  });
 }
 
 /**
@@ -31,17 +31,17 @@ export function readFileAsDataURL(file) {
  * @return {Promise} - then: $image
  */
 export function createImage(url) {
-  return $.Deferred((deferred) => {
+  return new Promise((resolve, reject) => {
     const $img = $('<img>');
 
     $img.one('load', () => {
       $img.off('error abort');
-      deferred.resolve($img);
+      resolve($img);
     }).one('error abort', () => {
       $img.off('load').detach();
-      deferred.reject($img);
+      reject($img);
     }).css({
       display: 'none',
     }).appendTo(document.body).attr('src', url);
-  }).promise();
+  });
 }

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -782,7 +782,7 @@ export default class Editor {
       this.getLastRange().insertNode($image[0]);
       this.setLastRange(range.createFromNodeAfter($image[0]).select());
       this.afterCommand();
-    }).fail((e) => {
+    }).catch((e) => {
       this.context.triggerEvent('image.upload.error', e);
     });
   }
@@ -799,7 +799,7 @@ export default class Editor {
       } else {
         readFileAsDataURL(file).then((dataURL) => {
           return this.insertImage(dataURL, filename);
-        }).fail(() => {
+        }).catch(() => {
           this.context.triggerEvent('image.upload.error');
         });
       }

--- a/src/js/module/Editor.js
+++ b/src/js/module/Editor.js
@@ -886,7 +886,7 @@ export default class Editor {
         rng.select();
       }
     } else {
-      const noteStatusOutput = $.now();
+      const noteStatusOutput = Date.now();
       this.$editor.find('.note-status-output').html('<div id="note-status-output-' + noteStatusOutput + '" class="alert alert-info">' + this.lang.output.noSelection + '</div>');
       setTimeout(function() { $('#note-status-output-' + noteStatusOutput).remove(); }, 5000);
     }

--- a/src/js/module/HelpDialog.js
+++ b/src/js/module/HelpDialog.js
@@ -60,13 +60,13 @@ export default class HelpDialog {
    * @return {Promise}
    */
   showHelpDialog() {
-    return $.Deferred((deferred) => {
+    return new Promise((resolve) => {
       this.ui.onDialogShown(this.$dialog, () => {
         this.context.triggerEvent('dialog.shown');
-        deferred.resolve();
+        resolve();
       });
       this.ui.showDialog(this.$dialog);
-    }).promise();
+    });
   }
 
   show() {

--- a/src/js/module/ImageDialog.js
+++ b/src/js/module/ImageDialog.js
@@ -76,7 +76,7 @@ export default class ImageDialog {
       } else { // array of files
         this.context.invoke('editor.insertImagesOrCallback', data);
       }
-    }).fail(() => {
+    }).catch(() => {
       this.context.invoke('editor.restoreRange');
     });
   }
@@ -88,7 +88,7 @@ export default class ImageDialog {
    * @return {Promise}
    */
   showImageDialog() {
-    return $.Deferred((deferred) => {
+    return new Promise((resolve, reject) => {
       const $imageInput = this.$dialog.find('.note-image-input');
       const $imageUrl = this.$dialog.find('.note-image-url');
       const $imageBtn = this.$dialog.find('.note-image-btn');
@@ -98,7 +98,7 @@ export default class ImageDialog {
 
         // Cloning imageInput to clear element.
         $imageInput.replaceWith($imageInput.clone().on('change', (event) => {
-          deferred.resolve(event.target.files || event.target.value);
+          resolve(event.target.files || event.target.value);
         }).val(''));
 
         $imageUrl.on('input paste propertychange', () => {
@@ -111,7 +111,7 @@ export default class ImageDialog {
 
         $imageBtn.on('click', (event) => {
           event.preventDefault();
-          deferred.resolve($imageUrl.val());
+          resolve($imageUrl.val());
         });
 
         this.bindEnterKey($imageUrl, $imageBtn);
@@ -122,9 +122,7 @@ export default class ImageDialog {
         $imageUrl.off();
         $imageBtn.off();
 
-        if (deferred.state() === 'pending') {
-          deferred.reject();
-        }
+        reject();
       });
 
       this.ui.showDialog(this.$dialog);

--- a/src/js/module/LinkDialog.js
+++ b/src/js/module/LinkDialog.js
@@ -101,7 +101,7 @@ export default class LinkDialog {
    * @return {Promise}
    */
   showLinkDialog(linkInfo) {
-    return $.Deferred((deferred) => {
+    return new Promise((resolve, reject) => {
       const $linkText = this.$dialog.find('.note-link-text');
       const $linkUrl = this.$dialog.find('.note-link-url');
       const $linkBtn = this.$dialog.find('.note-link-btn');
@@ -153,7 +153,7 @@ export default class LinkDialog {
         $linkBtn.one('click', (event) => {
           event.preventDefault();
 
-          deferred.resolve({
+          resolve({
             range: linkInfo.range,
             url: $linkUrl.val(),
             text: $linkText.val(),
@@ -169,13 +169,11 @@ export default class LinkDialog {
         $linkUrl.off();
         $linkBtn.off();
 
-        if (deferred.state() === 'pending') {
-          deferred.reject();
-        }
+        reject();
       });
 
       this.ui.showDialog(this.$dialog);
-    }).promise();
+    });
   }
 
   /**
@@ -188,7 +186,7 @@ export default class LinkDialog {
     this.showLinkDialog(linkInfo).then((linkInfo) => {
       this.context.invoke('editor.restoreRange');
       this.context.invoke('editor.createLink', linkInfo);
-    }).fail(() => {
+    }).catch(() => {
       this.context.invoke('editor.restoreRange');
     });
   }

--- a/src/js/module/VideoDialog.js
+++ b/src/js/module/VideoDialog.js
@@ -203,7 +203,7 @@ export default class VideoDialog {
         // insert video node
         this.context.invoke('editor.insertNode', $node);
       }
-    }).fail(() => {
+    }).catch(() => {
       this.context.invoke('editor.restoreRange');
     });
   }
@@ -215,7 +215,7 @@ export default class VideoDialog {
    * @return {Promise}
    */
   showVideoDialog(/* text */) {
-    return $.Deferred((deferred) => {
+    return new Promise((resolve, reject) => {
       const $videoUrl = this.$dialog.find('.note-video-url');
       const $videoBtn = this.$dialog.find('.note-video-btn');
 
@@ -232,7 +232,7 @@ export default class VideoDialog {
 
         $videoBtn.on('click', (event) => {
           event.preventDefault();
-          deferred.resolve($videoUrl.val());
+          resolve($videoUrl.val());
         });
 
         this.bindEnterKey($videoUrl, $videoBtn);
@@ -242,9 +242,7 @@ export default class VideoDialog {
         $videoUrl.off();
         $videoBtn.off();
 
-        if (deferred.state() === 'pending') {
-          deferred.reject();
-        }
+        reject();
       });
 
       this.ui.showDialog(this.$dialog);


### PR DESCRIPTION
#### What does this PR do / why do we need it?

- Replace deprecated `$.now()` with `Date.now()` (jQuery 4.0.0)
- Replace `$.Deferred` with native `Promise` (jQuery 4.0.0 Slim)

#### Any background context you want to provide?

- This PR follows the advice from the [jQuery Core 4.0 Upgrade Guide](https://jquery.com/upgrade-guide/4.0/)
- It fixes one type of error that prevents Summernote from working with any version of jQuery 4.0.0
- It fixes one type of error that prevents Summernote from working with jQuery 4.0.0 Slim

### Checklist

- [X] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [X] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated dialog, image, video, link, and special-character workflows to use modern Promise handling.
  * Improved consistency of success, cancellation, and error handling across editor interactions.
  * Updated file and image loading operations for more consistent asynchronous behavior.

* **Bug Fixes**
  * Improved restoration of the editor selection when dialogs or uploads fail.
  * Ensured dialogs properly settle when dismissed.
  * Updated generated identifiers to use reliable browser timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->